### PR TITLE
Native app UI: equal 4:3 panes, full-width waterfall, status log, framing dialog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,9 +325,28 @@ jobs:
         # `D:\a\_temp`, and bash eats the backslashes as escapes, so the
         # tool was handed `D:a_temp` and correctly refused to write
         # there. The shots are also worth keeping -- step 2 uploads them.
+        #
+        # `--panes` shoots both window layouts and prints the minimum
+        # size each imposes. It is here rather than opt-in because the
+        # thing these shots exist to catch is a *layout* regression, and
+        # until this flag existed the only layout under the camera was
+        # the settings dialog -- the two arrangements of the main window
+        # were not photographed on any platform, which is exactly where
+        # a font-driven regression comes from. It also puts the pane
+        # minimums in the log on all five platforms, so a widget that
+        # starts demanding width or height is visible in the diff of two
+        # runs rather than only to whoever thinks to measure.
+        #
+        # Unlike `--transmit` and `--receive` it needs no network:
+        # `AppState`'s constructor wires logging and the rig, and the
+        # checkpoint fetch is in `load_model_async`, which only
+        # `MainWindow` calls. Verified with an empty `SSTVAE_MODEL_CACHE`
+        # in a stripped environment -- the cache was still empty
+        # afterwards. Keep it that way; a link check must not depend on
+        # the Hub being up.
         run: |
           mkdir -p gui-shots
-          ./native/build/sstvae-gui-shot --out gui-shots
+          ./native/build/sstvae-gui-shot --out gui-shots --panes
         shell: bash
       # The C++ side checked against the committed corpus.
       - name: C++ tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,104 @@ structure and the wiring *between* the panels — half duplex, polling
 paused while keyed, last-received picture offered as a transmit inset —
 are visible and reviewable before the panels themselves exist.
 
+**The receive and transmit panels are side by side in a splitter, not
+in tabs** (2026-08-01). The reference put them in a `QTabWidget` and the
+port inherited it, which meant composing a picture was done blind — no
+waterfall, no decode progress, no incoming preview, on a mode where you
+prepare the next transmission while listening to the current one. Three
+consequences worth knowing: the **waterfall became a horizontal strip**
+above the picture rather than a column beside it (it was already
+frequency-on-x / time-down-y, so this is a layout change and not a
+widget one — but history depth follows height, so a strip holds less of
+it, which is why the splitter is there); the **half-duplex pause has to
+look deliberate** now that the pane stays on screen through an over,
+since a stopped waterfall is otherwise the same picture as a wedged
+capture; and a **last-reception card** keeps mode, callsign, SNR, frame
+count and filename, because the engine wipes all of it from its shared
+state two seconds after a reception and the old "Complete — SNR x" line
+erased itself while the operator was still looking at the picture.
+
+**Tabs survive as the small-screen layout** (`ui.layout`, View >
+Layout, 2026-08-02), because the splitter's floor is a property of the
+*arrangement* and only the arrangement can move it: measured on the
+real panels with `sstvae-gui-shot --panes`, **1043 px side by side
+against 545 px tabbed**. The scroll-area idea that was filed against
+this treats the symptom. Three things are settled and worth not
+re-deciding. **"auto" is resolved once, at startup, against the
+screen** — a live breakpoint reads like the obvious implementation and
+cannot work, since while side by side is in force the splitter's own
+minimum is exactly what stops the window reaching the width that would
+trigger a switch away from it, so the downward transition is
+unreachable. **Choosing a layout by hand ends "auto"** even when it
+picks what auto would have: the next screen may be a different one.
+And **the receive status line is mirrored into the status bar while
+tabbed**, since tabs give back the one thing side by side buys — seeing
+the band while composing.
+
+`gui/pane_container.cpp` owns the switch, and the order in `set_mode`
+is load-bearing: build the new container *first* (which reparents both
+panels out of the old one), then delete the old one. The obvious
+alternative — detach with `setParent(nullptr)`, delete, re-add — marks
+both panels explicitly hidden, and a widget hidden that way stays
+hidden when it is added to a visible layout. Two related traps, both
+caught by `test_pane_container.cpp` on its first run rather than by
+reading: **every `addWidget`/`addTab` hides what it reparents**, and
+the thing that normally un-hides it is the parent going from hidden to
+visible — which never happens on a switch, so the new container needs
+an explicit `show()` or the window renders empty with nothing having
+failed. And a `QTabWidget` hides its background page with `hide()`,
+which is an *explicit* hide that showing an ancestor does not clear —
+so rebuilding the splitter has to show both panes by hand.
+
+**`gui/picture_box.cpp` is the receive preview, and `setFixedHeight` is
+never how you pin an aspect ratio.** A fixed height is a hard
+*minimum*, so a wide pane raises a floor under the whole window that
+narrowing it never lowers — a ratchet. It was invisible while the
+splitter kept each pane narrow and immediately fatal once a tab gives
+one pane the whole width: **a 1400 px window demanded a 1405 px minimum
+height**, taller than the laptop panels the tabbed layout exists to
+fit. The aspect is now enforced by *geometry* — the label is positioned
+by hand, not in a layout, so it imposes nothing upward — with 4:3 as
+what the box asks for (`sizeHint`) and caps itself at, never as a
+minimum. Given the height the picture is 4:3 and full width, as before;
+denied it the picture stays 4:3 and *narrows*, which the old code could
+not do at all because it simply forced the window taller instead.
+**`OverlayEditor` had the identical construct and it was worse**: the
+transmit panel's minimum height ran 611 px at 545 wide, 925 at 1348 and
+**1274 at 1900**, so tabs would have traded 498 px of width for
+hundreds of pixels of height on exactly the screens `auto` selects them
+for. Same fix, and it costs nothing there either, because
+`canvas_rect()` already letterboxes in both directions. Both copies are
+mutation-tested (`test_picture_box.cpp`, `test_overlay_editor.cpp`) and
+both assert on a *container's* minimum rather than the widget's own
+size hint — the hint is a constant, so asserting on it is a tautology,
+and the effective minimum is what propagates into the window.
+`sstvae-gui-shot --panes` reports **both axes** for the same reason: a
+width-only number measures the axis this layout improves and stays
+silent on the one it can wreck. The
+cap is necessarily one pass behind the width (Qt clamps incoming
+geometry against the previous maximum), which `updateGeometry` closes —
+and `test_picture_box.cpp` drives two passes deliberately rather than
+asserting that a two-pass settle is a one-pass settle. Spare height in
+the receive pane now goes to the **picture** rather than the waterfall
+strip; the old stretch factors were the other way round *because* the
+picture was pinned and could not use it.
+
+**The status log is a dock, and error reporting has three tiers**
+(2026-08-01). `core/log/` is a Qt-free bounded `StatusLog` plus a
+rotating `FileWriter`; `gui/log_pane.cpp` is the view, backfilled from
+`snapshot()` so entries logged before it existed still appear. The
+tiers exist because everything used to share one overwriting label:
+**errors** are sticky (`ErrorBanner`, dismissed by hand) *and* logged,
+**state** gets its own indicator (PTT lamp, rig chip with error age,
+latched CLIP marker), and **progress** keeps the labels that may
+overwrite each other freely. The rule that produced this: `"PTT OFF
+FAILED — unkey it manually"` was provably destroyed by the `"Sent"`
+that followed it a moment later, on the same label. Errors must never
+be written to those one-line labels — beyond losing them, a long
+message inflates the layout's minimum width, which is measurable: a
+700 px screenshot request came back 1204 px wide.
+
 **The widgets live in `sstvae_gui`, a library, with `sstvae-gui` as
 just `main.cpp`** — so a test can drive a widget. Most of what makes a
 GUI good needs eyes, but the parts that do not have been wrong before:

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(sstvae_core STATIC
   core/images/images.cpp
   core/modem/modem.cpp
   core/latents/latents.cpp
+  core/log/log.cpp
   core/util/event.cpp
   core/rx/ringbuffer.cpp
   core/rig/controller.cpp
@@ -328,12 +329,18 @@ if(_want_gui)
   # layering rules forbid.
   add_library(sstvae_gui STATIC
     gui/main_window.cpp
+    gui/flow_layout.cpp
+    gui/pane_container.cpp
+    gui/picture_box.cpp
     gui/waterfall.cpp
     gui/rx_panel.cpp
     gui/rig_config.cpp
     gui/settings_dialog.cpp
     gui/overlay_editor.cpp
     gui/tx_panel.cpp
+    gui/banner.cpp
+    gui/crop_dialog.cpp
+    gui/log_pane.cpp
     gui/app_state.cpp)
   set_target_properties(sstvae_gui PROPERTIES AUTOMOC ON)
   target_include_directories(sstvae_gui PUBLIC core gui)

--- a/native/apps/sstvae_gui_shot.cpp
+++ b/native/apps/sstvae_gui_shot.cpp
@@ -21,12 +21,23 @@
 #include <QApplication>
 #include <QPixmap>
 #include <QStringList>
+#include <QLayout>
+#include <QLabel>
+#include <QProgressBar>
 #include <QTabWidget>
 
+#include <cmath>
 #include <cstdio>
 #include <string>
 
 #include "app_state.hpp"
+#include "banner.hpp"
+#include "crop_dialog.hpp"
+#include "log/log.hpp"
+#include "log_pane.hpp"
+#include "main_window.hpp"
+#include "pane_container.hpp"
+#include "rx_panel.hpp"
 #include "settings/settings.hpp"
 #include "settings_dialog.hpp"
 #include "tx_panel.hpp"
@@ -41,6 +52,12 @@ void usage() {
                  "  --size WxH   window size (default: the window's own)\n"
                  "  --tab N      only this settings tab; default is all\n"
                  "  --transmit   also shoot the transmit panel\n"
+                 "  --receive    also shoot the receive panel\n"
+                 "  --crop       also shoot the framing dialog\n"
+                 "  --window     also shoot the whole main window\n"
+                 "  --log        also shoot the log pane and error banner\n"
+                 "  --panes      also shoot both pane layouts, and report the\n"
+                 "               minimum width each one imposes on the window\n"
                  "\n"
                  "Writes settings-<n>-<name>.png, one per tab.\n");
 }
@@ -71,6 +88,11 @@ int main(int argc, char** argv) {
     int height = 0;
     int only_tab = -1;
     bool transmit = false;
+    bool receive = false;
+    bool crop = false;
+    bool window = false;
+    bool log_widgets = false;
+    bool panes = false;
 
     const QStringList args = QCoreApplication::arguments();
     for (int i = 1; i < args.size(); ++i) {
@@ -89,6 +111,16 @@ int main(int argc, char** argv) {
             only_tab = args[++i].toInt();
         } else if (arg == QLatin1String("--transmit")) {
             transmit = true;
+        } else if (arg == QLatin1String("--receive")) {
+            receive = true;
+        } else if (arg == QLatin1String("--crop")) {
+            crop = true;
+        } else if (arg == QLatin1String("--window")) {
+            window = true;
+        } else if (arg == QLatin1String("--log")) {
+            log_widgets = true;
+        } else if (arg == QLatin1String("--panes")) {
+            panes = true;
         } else {
             usage();
             return 2;
@@ -115,11 +147,257 @@ int main(int argc, char** argv) {
         sstvae::gui::AppState state;
         sstvae::gui::TransmitPanel panel(&state);
         panel.resize(width > 0 ? width : 1000, height > 0 ? height : 700);
+        // The banner *inside the panel's layout*, with the longest
+        // message the app can produce -- a wrapped QLabel that clips
+        // in a layout looks fine shot standalone, so the layout is
+        // what has to be under the camera.
+        QMetaObject::invokeMethod(
+            &panel, "on_error", Qt::DirectConnection,
+            Q_ARG(QString,
+                  QStringLiteral("PTT OFF FAILED: read timeout -- the rig "
+                                 "may still be transmitting. Unkey it "
+                                 "manually.")));
         panel.show();
         app.processEvents();
         const QString path = QStringLiteral("%1/transmit.png").arg(out);
         panel.grab().save(path);
-        std::printf("%s\n", path.toLocal8Bit().constData());
+        // The minimum is reported because it is a real constraint on
+        // the window: the two panes sit in a splitter, whose minimum is
+        // the *sum* of its children's, so a pane that quietly demands
+        // 700 px sets the floor for the whole application.
+        std::printf("%s (min %dx%d)\n", path.toLocal8Bit().constData(),
+                    panel.minimumSizeHint().width(),
+                    panel.minimumSizeHint().height());
+    }
+
+    // The receive pane at the width the dual-pane split gives it --
+    // the shape the waterfall strip and the picture have to share.
+    // `MainWindow` itself is still not a target here (it starts a model
+    // load and opens the rig), so the *arrangement* of the two panes is
+    // reviewed by reading; each pane's own layout is reviewed here.
+    if (receive) {
+        sstvae::gui::AppState state;
+        sstvae::gui::ReceivePanel panel(&state);
+        // Populated, not pristine: an empty pane hides exactly what has
+        // to be looked at -- the card at its full length, the banner
+        // inside the layout, and the longest status line the panel can
+        // produce, each of which sets a width floor. The transmit shot
+        // below injects its worst message for the same reason.
+        panel.fill_for_screenshot();
+        panel.resize(width > 0 ? width : 540, height > 0 ? height : 700);
+        panel.show();
+        app.processEvents();
+        const QString path = QStringLiteral("%1/receive.png").arg(out);
+        panel.grab().save(path);
+        std::printf("%s (min %dx%d)\n", path.toLocal8Bit().constData(),
+                    panel.minimumSizeHint().width(),
+                    panel.minimumSizeHint().height());
+    }
+
+    // Both pane arrangements, with the *real* panels in them.
+    //
+    // This is the one target that reports a number worth acting on
+    // rather than a picture worth looking at. The tabbed layout exists
+    // because a `QSplitter`'s minimum width is the sum of its
+    // children's where a `QTabWidget`'s is the max, and that claim is
+    // only interesting at the sizes the actual panels demand --
+    // `test_pane_container.cpp` proves the structure holds with toy
+    // panes, but only these two say whether the saving is enough to
+    // reach a real laptop panel. Re-run it whenever either panel grows
+    // a control.
+    if (panes) {
+        sstvae::gui::AppState state;
+        auto* rx = new sstvae::gui::ReceivePanel(&state);
+        auto* tx = new sstvae::gui::TransmitPanel(&state);
+        rx->fill_for_screenshot();
+        sstvae::gui::PaneContainer container(rx, QStringLiteral("Receive"), tx,
+                                             QStringLiteral("Transmit"));
+        container.set_control_strips(rx->control_strip(), tx->control_strip());
+        container.resize(width > 0 ? width : 1360, height > 0 ? height : 760);
+        container.show();
+        app.processEvents();
+
+        // The strips are what make the pictures equal, so their heights
+        // belong next to the pictures': when the two differ, this says
+        // by how much and which way, instead of leaving it to be
+        // inferred from the picture sizes.
+        std::printf("strips:   receive %d  transmit %d%s\n",
+                    rx->control_strip()->height(), tx->control_strip()->height(),
+                    rx->control_strip()->height() == tx->control_strip()->height()
+                        ? "  (equal)" : "  <-- NOT EQUAL");
+        std::printf("pictures: receive %dx%d  transmit %dx%d\n",
+                    rx->picture_area()->width(), rx->picture_area()->height(),
+                    tx->picture_area()->width(), tx->picture_area()->height());
+        const QString split_path = QStringLiteral("%1/panes-split.png").arg(out);
+        container.grab().save(split_path);
+        const QSize split_min = container.minimumSizeHint();
+        std::printf("%s (min %dx%d)\n", split_path.toLocal8Bit().constData(),
+                    split_min.width(), split_min.height());
+
+        container.set_mode(sstvae::gui::PaneLayout::Tabs);
+        app.processEvents();
+        const QString tabs_path = QStringLiteral("%1/panes-tabs.png").arg(out);
+        container.grab().save(tabs_path);
+        const QSize tabs_min = container.minimumSizeHint();
+        // **Both axes.** Reporting only the width measures the axis this
+        // layout improves and stays silent on the one it can wreck: a
+        // pane that pins its height to its width (see `picture_box.hpp`)
+        // does its worst damage exactly when a tab hands it the whole
+        // window, which is the case a width-only number cannot see.
+        std::printf("%s (min %dx%d; %d px narrower, %d px %s)\n",
+                    tabs_path.toLocal8Bit().constData(), tabs_min.width(),
+                    tabs_min.height(), split_min.width() - tabs_min.width(),
+                    std::abs(split_min.height() - tabs_min.height()),
+                    tabs_min.height() > split_min.height() ? "TALLER" : "shorter");
+
+        // **The third number, and the one that actually broke a
+        // window.** A minimum size *hint* never consults
+        // `heightForWidth`; what Qt applies when it lays a widget out
+        // is `minimumHeightForWidth(width)`. A widget asking to be 4:3
+        // through that shows up here and nowhere else -- and a
+        // QSplitter hides it while a QTabWidget passes it to the
+        // window, which is how the tabbed layout grew past the bottom
+        // of the screen.
+        //
+        // **This is not expected to read zero**, and an earlier version
+        // of this comment said it was, which would have had the next
+        // person chasing a ratchet that is not there. Wrapped labels
+        // legitimately have a height that depends on width, and
+        // `QWidgetItem` reports a *preferred* heightForWidth where no
+        // minimum is defined. What matters is that the number does not
+        // grow with width -- that is the ratchet -- and that the round
+        // trip below leaves the window the size it was.
+        for (const auto mode : {sstvae::gui::PaneLayout::Split,
+                                sstvae::gui::PaneLayout::Tabs}) {
+            container.set_mode(mode);
+            for (int k = 0; k < 3; ++k) {
+                container.setGeometry(0, 0, container.width(), container.height());
+                app.processEvents();
+            }
+            const int hfw = container.layout()->hasHeightForWidth()
+                                ? container.layout()->minimumHeightForWidth(container.width())
+                                : 0;
+            std::printf("%s: minimumHeightForWidth(%d) = %d%s\n",
+                        mode == sstvae::gui::PaneLayout::Split ? "split" : "tabs ",
+                        container.width(), hfw,
+                        hfw > container.height() ? "   <-- forces the window taller" : "");
+        }
+    }
+
+    // The whole window. Opt-in and last, because unlike everything
+    // else here it constructs a MainWindow, which starts a model load
+    // and opens the rig -- so it wants a warm model cache and rig
+    // control off, and a failure puts a modal on screen that a
+    // screenshot run cannot dismiss. Worth having anyway: the thing
+    // being decided *is* the window, and whether it fits a given screen
+    // height cannot be answered by shooting the panes separately.
+    if (window) {
+        sstvae::gui::MainWindow win;
+        win.resize(width > 0 ? width : 1360, height > 0 ? height : 900);
+        win.show();
+        for (int i = 0; i < 40; ++i) app.processEvents();
+        const QString path = QStringLiteral("%1/window.png").arg(out);
+        win.grab().save(path);
+        std::printf("%s (min %dx%d)\n", path.toLocal8Bit().constData(),
+                    win.minimumSizeHint().width(), win.minimumSizeHint().height());
+        // **The regression this window actually had**: switching layout
+        // grew it past the bottom of the screen and switching back did
+        // not shrink it again, because Qt lowers a minimum without
+        // resizing. Toggle twice and the size must come back unchanged.
+        {
+            auto* rxp = win.findChild<sstvae::gui::ReceivePanel*>();
+            auto* txp = win.findChild<sstvae::gui::TransmitPanel*>();
+            if (rxp != nullptr && txp != nullptr) {
+                const QSize a = rxp->picture_area()->size();
+                const QSize b = txp->picture_area()->size();
+                std::printf("  pictures: receive %dx%d  transmit %dx%d%s\n",
+                            a.width(), a.height(), b.width(), b.height(),
+                            a == b ? "  (equal)" : "  <-- NOT EQUAL");
+            }
+        }
+        auto* panes = win.findChild<sstvae::gui::PaneContainer*>();
+        if (panes != nullptr) {
+            const QSize before = win.size();
+            for (const auto m : {sstvae::gui::PaneLayout::Tabs,
+                                 sstvae::gui::PaneLayout::Split}) {
+                panes->set_mode(m);
+                for (int i = 0; i < 20; ++i) app.processEvents();
+                std::printf("  after %-5s window %dx%d\n",
+                            m == sstvae::gui::PaneLayout::Tabs ? "tabs" : "split",
+                            win.width(), win.height());
+            }
+            std::printf("  %s\n", win.size() == before
+                                       ? "round trip: size unchanged"
+                                       : "ROUND TRIP CHANGED THE WINDOW SIZE");
+        }
+    }
+
+    // The framing dialog, on a 16:9 source -- the case it exists for,
+    // where a quarter of the width is being given up and the dimmed
+    // region is what the operator is deciding about.
+    if (crop) {
+        constexpr int SW = 1600;
+        constexpr int SH = 900;
+        sstvae::images::Picture source(SW, SH);
+        for (int y = 0; y < SH; ++y) {
+            for (int x = 0; x < SW; ++x) {
+                const std::size_t i = (static_cast<std::size_t>(y) * SW + x) * 3;
+                // A coarse checker plus a gradient: structured enough
+                // that the crop window's edges are obvious, and not so
+                // busy that the dimming is hard to read.
+                const bool check = ((x / 100) + (y / 100)) % 2 == 0;
+                source.rgb[i] = static_cast<unsigned char>(check ? 210 : 60);
+                source.rgb[i + 1] = static_cast<unsigned char>(x * 255 / SW);
+                source.rgb[i + 2] = static_cast<unsigned char>(y * 255 / SH);
+            }
+        }
+        sstvae::gui::CropDialog dialog(source, sstvae::images::Framing{});
+        dialog.resize(width > 0 ? width : 640, height > 0 ? height : 560);
+        dialog.show();
+        app.processEvents();
+        const QString path = QStringLiteral("%1/crop.png").arg(out);
+        dialog.grab().save(path);
+        std::printf("%s (min %dx%d)\n", path.toLocal8Bit().constData(),
+                    dialog.minimumSizeHint().width(),
+                    dialog.minimumSizeHint().height());
+    }
+
+    // The observability widgets, with representative content: the pane
+    // filled from a preloaded log, and the banner showing the message
+    // whose survivability is the whole reason it exists.
+    if (log_widgets) {
+        sstvae::log::StatusLog log;
+        log.append("app", sstvae::log::Severity::Warning,
+                   "config: receive.decode_every: not a number; using default");
+        log.append("rig", sstvae::log::Severity::Info,
+                   "Rig: 14.2300 MHz (Elecraft K4)");
+        log.append("rx", sstvae::log::Severity::Info,
+                   "sync acquired: mode B de KD8XYZ");
+        log.append("rx", sstvae::log::Severity::Info,
+                   "reception complete: mode B de KD8XYZ, 32/32 frames,  SNR "
+                   "8.3dB -- saved /home/op/Pictures/rx/KD8XYZ-B-14230.png");
+        log.append("tx", sstvae::log::Severity::Info, "keying rig");
+        log.append("tx", sstvae::log::Severity::Error,
+                   "PTT OFF FAILED: read timeout -- the rig may still be "
+                   "transmitting. Unkey it manually.");
+        sstvae::gui::LogPane pane(&log);
+        pane.resize(width > 0 ? width : 1000, 180);
+        pane.show();
+        app.processEvents();
+        const QString pane_path = QStringLiteral("%1/log-pane.png").arg(out);
+        pane.grab().save(pane_path);
+        std::printf("%s\n", pane_path.toLocal8Bit().constData());
+
+        sstvae::gui::ErrorBanner banner;
+        banner.show_error(QStringLiteral(
+            "PTT OFF FAILED: read timeout -- the rig may still be "
+            "transmitting. Unkey it manually."));
+        banner.resize(width > 0 ? width : 1000, banner.sizeHint().height());
+        banner.show();
+        app.processEvents();
+        const QString banner_path = QStringLiteral("%1/banner.png").arg(out);
+        banner.grab().save(banner_path);
+        std::printf("%s\n", banner_path.toLocal8Bit().constData());
     }
 
     for (int i = 0; i < tabs->count(); ++i) {

--- a/native/core/audio/qt/qtaudio.cpp
+++ b/native/core/audio/qt/qtaudio.cpp
@@ -246,13 +246,22 @@ struct InputStream::Impl {
 };
 
 InputStream::InputStream(const std::string& device_name, rx::RingBuffer& ring,
-                         int samplerate, Report on_error)
+                         int samplerate, Report on_opened, Report on_error)
     : impl_(std::make_unique<Impl>()) {
+    // Falling back to the default device is information: the configured
+    // one is simply not present today.
     const QAudioDevice device =
         pick(QMediaDevices::audioInputs(), device_name,
-             QMediaDevices::defaultAudioInput(), "in", on_error);
+             QMediaDevices::defaultAudioInput(), "in", on_opened);
     impl_->device_name = to_std(device.description());
 
+    // The worker's channel is the *error* one. `fail()` and
+    // `check_error()` are genuine capture failures -- a device going
+    // away, a QAudio error code -- and they were sharing the callback
+    // that carries the opened-at notice. Handing that one channel a
+    // single severity was wrong in both directions: as an error it
+    // shouted about a working resampler, and as information it would
+    // have swallowed a device disappearing mid-reception.
     impl_->worker = std::make_unique<CaptureWorker>(device, ring, samplerate, on_error);
     impl_->worker->moveToThread(&impl_->thread);
     QObject::connect(&impl_->thread, &QThread::started, impl_->worker.get(),
@@ -278,9 +287,9 @@ InputStream::InputStream(const std::string& device_name, rx::RingBuffer& ring,
         throw std::runtime_error(why);
     }
 
-    if (on_error) {
+    if (on_opened) {
         const int rate = impl_->worker->rate();
-        on_error("[audio in] " + impl_->device_name + " at " + std::to_string(rate) +
+        on_opened("[audio in] " + impl_->device_name + " at " + std::to_string(rate) +
                  " Hz" + (rate == samplerate
                               ? ""
                               : ", resampled to " + std::to_string(samplerate) + " Hz"));

--- a/native/core/audio/qt/qtaudio.hpp
+++ b/native/core/audio/qt/qtaudio.hpp
@@ -79,8 +79,26 @@ class InputStream {
 public:
     // `device_name` empty means the system default. Throws if capture
     // cannot be started.
+    // **Two callbacks, because there are two kinds of message.**
+    //
+    // `on_opened` reports what was actually obtained: the device and the
+    // rate it opened at, and whether our resampler is in the path. That
+    // is information. Almost nothing is natively 8 kHz, so "resampled
+    // to 8000 Hz" is the normal case, and reporting it as a failure told
+    // operators their setup was broken when it was working.
+    //
+    // `on_error` is for capture actually going wrong once it is running
+    // -- a device disappearing, an underrun, a QAudio error code. Those
+    // deserve the sticky banner.
+    //
+    // They were one callback, and collapsing them cost twice: first the
+    // notice was raised as an error, and then, "fixing" that by
+    // reclassifying the whole channel as information, a genuine capture
+    // failure became a quiet log line with no banner at all. A channel
+    // that carries two severities cannot be given one.
     InputStream(const std::string& device_name, rx::RingBuffer& ring,
-                int samplerate = config::FS, Report on_error = {});
+                int samplerate = config::FS, Report on_opened = {},
+                Report on_error = {});
     ~InputStream();
 
     InputStream(const InputStream&) = delete;

--- a/native/core/checkpoint/qt_fetcher.cpp
+++ b/native/core/checkpoint/qt_fetcher.cpp
@@ -54,7 +54,8 @@ struct Response {
 
 // Follows redirects by hand so the intermediate headers stay visible;
 // see the header on why that matters.
-Response get_following_redirects(QNetworkAccessManager& nam, const QUrl& start) {
+Response get_following_redirects(QNetworkAccessManager& nam, const QUrl& start,
+                                 const OnProgress& on_progress) {
     QUrl url = start;
     QByteArray sha;
     for (int hop = 0; hop <= kMaxRedirects; ++hop) {
@@ -64,6 +65,16 @@ Response get_following_redirects(QNetworkAccessManager& nam, const QUrl& start) 
         request.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("sstvae"));
 
         std::unique_ptr<QNetworkReply> reply(nam.get(request));
+        // Live progress while the loop below runs. Redirect hops have no
+        // body to speak of, so in practice this reports the artifact
+        // itself; before this connection existed the callback fired
+        // exactly once, at 100%, which is no progress indication at all.
+        if (on_progress) {
+            QObject::connect(reply.get(), &QNetworkReply::downloadProgress,
+                             [&on_progress](qint64 received, qint64 total) {
+                                 on_progress(received, total < 0 ? 0 : total);
+                             });
+        }
         QEventLoop loop;
         QObject::connect(reply.get(), &QNetworkReply::finished, &loop, &QEventLoop::quit);
         loop.exec();
@@ -100,7 +111,7 @@ Fetcher qt_fetcher(OnProgress on_progress) {
 
         QNetworkAccessManager nam;
         const QUrl url(QString::fromStdString(artifact_url(filename)));
-        Response response = get_following_redirects(nam, url);
+        Response response = get_following_redirects(nam, url, on_progress);
         QNetworkReply& reply = *response.reply;
 
         if (reply.error() != QNetworkReply::NoError) {

--- a/native/core/images/images.cpp
+++ b/native/core/images/images.cpp
@@ -32,24 +32,49 @@ Picture resize(const Picture& img, int width, int height) {
     return out;
 }
 
-Picture fit(const Picture& img) {
-    if (img.width == IMG_W && img.height == IMG_H) return img;
+Picture fit(const Picture& img) { return fit(img, Framing{}); }
+
+Picture fit(const Picture& img, const Framing& framing) {
+    // The identity short-circuit only applies to the default framing:
+    // an operator who has zoomed or panned an already-4:3 picture means
+    // it, and returning the original would silently ignore them.
+    const bool defaulted = framing.zoom == 1.0 && framing.center_x == 0.5 &&
+                           framing.center_y == 0.5;
+    if (defaulted && img.width == IMG_W && img.height == IMG_H) return img;
     if (img.width <= 0 || img.height <= 0) {
         throw std::runtime_error("cannot fit an empty picture");
     }
 
-    // Scale to *cover* the target, then centre-crop -- the same shape of
-    // operation as images.py, though not the same filter.
+    // Scale to *cover* the target, then crop -- the same shape of
+    // operation as images.py, though not the same filter. Zoom below 1
+    // would expose edges with no picture behind them.
+    const double zoom = std::max(1.0, framing.zoom);
     const double scale = std::max(static_cast<double>(IMG_W) / img.width,
-                                  static_cast<double>(IMG_H) / img.height);
+                                  static_cast<double>(IMG_H) / img.height) *
+                         zoom;
     const int sw = std::max(IMG_W, static_cast<int>(std::lround(img.width * scale)));
     const int sh = std::max(IMG_H, static_cast<int>(std::lround(img.height * scale)));
 
     const Picture scaled = resize(img, sw, sh);
 
+    // `floor`, not `lround`: for the default centre this has to reduce
+    // to the old `(sw - IMG_W) / 2` integer division exactly, and those
+    // agree only under truncation of a non-negative value. With an odd
+    // `sw` they differ by one pixel, so adding framing would have
+    // silently shifted every odd-intermediate picture -- 1920x1080
+    // scales to 853 wide, so that is most photographs. `test_framing`
+    // pins this against the old formula written out; the Python parity
+    // suite cannot, since it deliberately skips `fit_image` wherever
+    // resampling is involved (PIL LANCZOS vs stb).
+    const auto offset = [](double center, int scaled_size, int target) {
+        const double raw = center * scaled_size - target / 2.0;
+        const int limit = scaled_size - target;
+        return std::clamp(static_cast<int>(std::floor(raw)), 0, limit);
+    };
+    const int left = offset(framing.center_x, sw, IMG_W);
+    const int top = offset(framing.center_y, sh, IMG_H);
+
     Picture out(IMG_W, IMG_H);
-    const int left = (sw - IMG_W) / 2;
-    const int top = (sh - IMG_H) / 2;
     for (int y = 0; y < IMG_H; ++y) {
         const std::uint8_t* src =
             scaled.rgb.data() + (static_cast<std::size_t>(y + top) * sw + left) * 3;

--- a/native/core/images/images.hpp
+++ b/native/core/images/images.hpp
@@ -32,12 +32,40 @@ inline constexpr int MIN_H = 240;
 // Already-correct input is returned untouched.
 Picture resize(const Picture& img, int width, int height);
 
+// How a picture is framed into the target rectangle.
+//
+// The pictures the codec sends are 4:3, and anything else has to lose
+// something. The default here is what this function has always done
+// silently -- scale to cover, crop the centre -- expressed as data so
+// the operator can move it. There is no letterbox option: padding
+// would spend airtime on black, and the decision (2026-08-01) was that
+// an operator who wants the whole frame pads the file themselves.
+struct Framing {
+    // Multiplier on the *cover* scale -- the smallest scale that fills
+    // the target. 1.0 is the tightest framing that keeps the picture
+    // full-bleed; above 1.0 crops in further. Below 1.0 would expose
+    // edges with nothing behind them, so callers clamp there.
+    double zoom = 1.0;
+    // Centre of the crop window in normalized source coordinates.
+    // (0.5, 0.5) is the middle of the picture, which is what the
+    // parameterless overload has always used.
+    double center_x = 0.5;
+    double center_y = 0.5;
+};
+
 // Any picture -> exactly IMG_W x IMG_H RGB, by scaling to cover the
-// target and centre-cropping. Deterministic and aspect-preserving.
+// target and cropping. Deterministic and aspect-preserving.
 //
 // Already-correct input is returned untouched, which is the path the
 // parity tests use.
+//
+// **The default framing is byte-identical to what this produced before
+// framing existed** -- the crop offset uses `floor`, which is what the
+// old `(scaled - target) / 2` integer division was for a non-negative
+// numerator. `test_framing` holds it to that by reimplementing the old
+// formula rather than by calling this function twice.
 Picture fit(const Picture& img);
+Picture fit(const Picture& img, const Framing& framing);
 
 // IMG_W x IMG_H RGB -> (3, IMG_H, IMG_W) float32 in [0,1].
 // Exact: a transpose and a divide by 255.

--- a/native/core/log/log.cpp
+++ b/native/core/log/log.cpp
@@ -1,0 +1,134 @@
+#include "log/log.hpp"
+
+#include <cstddef>
+#include <algorithm>
+#include <cstdio>
+#include <ctime>
+#include <system_error>
+#include <utility>
+
+namespace sstvae::log {
+
+namespace fs = std::filesystem;
+
+const char* severity_name(Severity s) {
+    switch (s) {
+        case Severity::Info: return "info";
+        case Severity::Warning: return "warn";
+        case Severity::Error: return "ERROR";
+    }
+    return "info";
+}
+
+std::string format_entry(const Entry& entry) {
+    const std::time_t seconds = static_cast<std::time_t>(entry.ms / 1000);
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &seconds);
+#else
+    localtime_r(&seconds, &tm);
+#endif
+    // **The year is clamped, and that is the point.** GCC cannot know
+    // `tm_year` is sane, so at any buffer size it warns that the year
+    // could truncate the rest of the stamp -- and growing the buffer
+    // only moves the warning to whatever formats the stamp next. Saying
+    // out loud that a four-digit year is all this format supports fixes
+    // it at the source; a clock returning year 70000 gets a wrong stamp
+    // rather than a silently cut one.
+    char stamp[32];
+    const int year = std::clamp(tm.tm_year + 1900, 0, 9999);
+    std::snprintf(stamp, sizeof stamp, "%04d-%02d-%02d %02d:%02d:%02d", year,
+                  tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+
+    // Fixed-width source and severity columns so a screenful of lines
+    // reads as a table. Built as a string rather than a second fixed
+    // buffer: the source is caller-supplied and has no length anyone
+    // here can promise.
+    auto column = [](std::string text, std::size_t width) {
+        if (text.size() < width) text.resize(width, ' ');
+        return text;
+    };
+    return std::string(stamp) + "  " + column(entry.source, 4) + " " +
+           column(severity_name(entry.severity), 5) + " " + entry.text;
+}
+
+StatusLog::StatusLog(std::size_t max_entries) : max_entries_(max_entries) {}
+
+void StatusLog::append(std::string source, Severity severity, std::string text) {
+    Entry entry;
+    entry.ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::system_clock::now().time_since_epoch())
+                   .count();
+    entry.source = std::move(source);
+    entry.severity = severity;
+    entry.text = std::move(text);
+
+    const std::lock_guard<std::mutex> lock(mutex_);
+    entries_.push_back(entry);
+    while (entries_.size() > max_entries_) entries_.pop_front();
+    for (const auto& sink : sinks_) sink(entry);
+}
+
+std::vector<Entry> StatusLog::snapshot() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return {entries_.begin(), entries_.end()};
+}
+
+void StatusLog::add_sink(std::function<void(const Entry&)> sink) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    sinks_.push_back(std::move(sink));
+}
+
+FileWriter::FileWriter(fs::path path, std::uint64_t max_bytes, int rotations)
+    : path_(std::move(path)), max_bytes_(max_bytes), rotations_(rotations) {
+    std::error_code ec;
+    // On a fresh install nothing has created the config directory yet
+    // -- settings::save() does, but the first session may never call
+    // it, and the first session is exactly the one whose log is worth
+    // having (first-run download failures live there).
+    if (path_.has_parent_path()) fs::create_directories(path_.parent_path(), ec);
+    const std::uint64_t existing = fs::file_size(path_, ec);
+    written_ = ec ? 0 : existing;
+    out_.open(path_, std::ios::app);
+    if (!out_) error_ = "cannot open " + path_.string() + " for append";
+}
+
+void FileWriter::write(const Entry& entry) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (!out_.is_open()) return;
+    if (written_ >= max_bytes_) rotate();
+    const std::string line = format_entry(entry);
+    out_ << line << '\n';
+    out_.flush();
+    if (!out_) {
+        if (error_.empty()) error_ = "write failed on " + path_.string();
+        out_.close();
+        return;
+    }
+    written_ += line.size() + 1;
+}
+
+std::string FileWriter::error() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return error_;
+}
+
+void FileWriter::rotate() {
+    // Called with mutex_ held. sstvae.log.<rotations> falls off the
+    // end; everything else shifts up by one; the live file restarts.
+    out_.close();
+    std::error_code ec;
+    fs::remove(path_.string() + "." + std::to_string(rotations_), ec);
+    for (int i = rotations_ - 1; i >= 1; --i) {
+        fs::rename(path_.string() + "." + std::to_string(i),
+                   path_.string() + "." + std::to_string(i + 1), ec);
+    }
+    fs::rename(path_, path_.string() + ".1", ec);
+    out_.open(path_, std::ios::trunc);
+    written_ = 0;
+    if (!out_ && error_.empty()) {
+        error_ = "cannot reopen " + path_.string() + " after rotation";
+    }
+}
+
+}  // namespace sstvae::log

--- a/native/core/log/log.hpp
+++ b/native/core/log/log.hpp
@@ -1,0 +1,107 @@
+// The application's status log: a bounded, timestamped record of what
+// happened, feeding both the GUI's log pane and an optional file.
+//
+// This exists because the app previously had *no* record of anything:
+// every status was a one-line label overwritten by the next write, so
+// "PTT OFF FAILED -- unkey it manually" was provably destroyed by the
+// "Sent" that followed it, and a dismissed dialog was unrecoverable.
+// The engines already emit everything worth keeping; this is where it
+// lands.
+//
+// Qt-free on purpose, like the engines: the GUI adapts entries to
+// signals, and a CLI could reuse the same sink. Thread-safe -- entries
+// arrive from the decode thread, the transmit thread, the rig worker
+// and the GUI thread alike.
+
+#ifndef SSTVAE_LOG_LOG_HPP
+#define SSTVAE_LOG_LOG_HPP
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace sstvae::log {
+
+enum class Severity { Info, Warning, Error };
+
+const char* severity_name(Severity s);  // "info" / "warn" / "ERROR"
+
+struct Entry {
+    // Wall-clock milliseconds since the epoch. Wall clock rather than
+    // steady: these lines are read next to a radio's own clock and a
+    // logbook, so they must agree with the wall.
+    std::int64_t ms = 0;
+    std::string source;  // "rig", "rx", "tx", "opt", "app"
+    Severity severity = Severity::Info;
+    std::string text;
+};
+
+// "2026-08-01 14:02:31  rig    ERROR  text" -- the one line format,
+// shared by the file and the pane's Copy button so a pasted bug report
+// and the on-disk log read the same.
+std::string format_entry(const Entry& entry);
+
+class StatusLog {
+public:
+    // How many entries to retain in memory. The file is not bounded by
+    // this; it has its own rotation.
+    explicit StatusLog(std::size_t max_entries = 2000);
+
+    void append(std::string source, Severity severity, std::string text);
+
+    // Everything currently retained, oldest first.
+    std::vector<Entry> snapshot() const;
+
+    // Called for every append, under the log's lock -- so a sink must
+    // be fast and must never call back into the log. The two intended
+    // sinks are: a queued Qt signal emission (non-blocking by design)
+    // and FileWriter::write.
+    void add_sink(std::function<void(const Entry&)> sink);
+
+private:
+    mutable std::mutex mutex_;
+    std::size_t max_entries_;
+    std::deque<Entry> entries_;
+    std::vector<std::function<void(const Entry&)>> sinks_;
+};
+
+// Appends formatted entries to a file, rotating at `max_bytes`:
+// sstvae.log -> sstvae.log.1 -> ... -> sstvae.log.<rotations>, oldest
+// deleted. Failures are recorded, not thrown -- a read-only directory
+// must not take the in-memory log down with it, but it must not be
+// silent either: the GUI shows `error()` in the pane header.
+class FileWriter {
+public:
+    explicit FileWriter(std::filesystem::path path,
+                        std::uint64_t max_bytes = 1u << 20,
+                        int rotations = 3);
+
+    void write(const Entry& entry);
+
+    const std::filesystem::path& path() const { return path_; }
+    // Empty while healthy; the first failure's description afterwards.
+    std::string error() const;
+
+private:
+    void rotate();
+
+    std::filesystem::path path_;
+    std::uint64_t max_bytes_;
+    int rotations_;
+
+    mutable std::mutex mutex_;
+    std::ofstream out_;
+    std::uint64_t written_ = 0;
+    std::string error_;
+};
+
+}  // namespace sstvae::log
+
+#endif

--- a/native/core/rig/controller.cpp
+++ b/native/core/rig/controller.cpp
@@ -76,7 +76,7 @@ struct RigSession {
         if (backend) backend->close();
     }
 
-    void publish_status(const std::string& text) {
+    void publish_status(const std::string& text, bool error) {
         // Locked because `stopping` and `last_status` are shared with
         // stop(); the callback itself runs unlocked so a slow UI cannot
         // stall the worker.
@@ -87,7 +87,7 @@ struct RigSession {
             last_status = text;
             fn = on_status;
         }
-        if (fn) fn(text);
+        if (fn) fn(text, error);
     }
 
     void publish_frequency(std::optional<double> hz) {
@@ -110,9 +110,9 @@ namespace {
 void run(std::shared_ptr<RigSession> s) {
     try {
         s->backend->open();
-        s->publish_status("Rig: " + s->backend->description());
+        s->publish_status("Rig: " + s->backend->description(), false);
     } catch (const std::exception& e) {
-        s->publish_status(first_line(e.what()));
+        s->publish_status(first_line(e.what()), true);
         return;
     }
 
@@ -185,7 +185,7 @@ void run(std::shared_ptr<RigSession> s) {
             if (s->stopping) return;
         }
         s->publish_frequency(value);
-        s->publish_status(status);
+        s->publish_status(status, !ok);
 
         interval = next_interval(interval, base, ok);
         next_poll = Clock::now() + secs(interval);
@@ -213,7 +213,7 @@ void RigController::start(std::unique_ptr<RigBackend> backend,
         std::lock_guard<std::mutex> lock(mutex_);
         session_ = s;
     }
-    if (on_status_) on_status_("Rig: connecting...");
+    if (on_status_) on_status_("Rig: connecting...", false);
     // Detached from birth. There is no point at which joining this
     // thread would be safe to do from a UI thread, so the ability is
     // not offered.

--- a/native/core/rig/controller.hpp
+++ b/native/core/rig/controller.hpp
@@ -80,8 +80,15 @@ struct RigConfig {
 };
 
 // Called from the worker thread, never from the caller's.
+//
+// `error` is true when the text is a failure report (open failed, a
+// poll raised) rather than a healthy status. The GUI needs the
+// distinction to treat the two differently -- a frequency readout is
+// routine, a CAT failure is an event worth logging with a timestamp --
+// and the text alone cannot carry it: failure text is whatever the
+// backend's exception said, with no reliable shape.
 using OnFrequency = std::function<void(std::optional<double> hz)>;
-using OnStatus = std::function<void(const std::string& text)>;
+using OnStatus = std::function<void(const std::string& text, bool error)>;
 
 class RigController {
 public:

--- a/native/core/settings/settings.cpp
+++ b/native/core/settings/settings.cpp
@@ -261,6 +261,30 @@ void read_transmit(const Reader& r, TransmitConfig& c) {
     r.report_unknown({"mode", "level", "optimize"});
 }
 
+void read_ui(const Reader& r, UiConfig& c) {
+    r.get("layout", c.layout);
+    r.get("waterfall_height", c.waterfall_height);
+    // Negative is meaningless and a huge value would push the panes off
+    // the window; clamp quietly rather than refuse, since the only way
+    // to get one is to hand-edit the file.
+    if (c.waterfall_height < 0 || c.waterfall_height > 2000) {
+        r.notes.add(r.path("waterfall_height"),
+                    "is out of range (0-2000); ignoring " +
+                        std::to_string(c.waterfall_height));
+        c.waterfall_height = 0;
+    }
+    // An unrecognised value falls back to "auto" *and says so*, rather
+    // than being kept and quietly meaning "side by side" downstream --
+    // this is the one setting whose wrong value makes the window
+    // unusable on the screen it was set for.
+    if (c.layout != "auto" && c.layout != "split" && c.layout != "tabs") {
+        r.notes.add(r.path("layout"), "unknown layout '" + c.layout +
+                                          "'; expected auto, split or tabs");
+        c.layout = "auto";
+    }
+    r.report_unknown({"layout", "waterfall_height"});
+}
+
 // Empty string <-> JSON null, for the fields Python declares optional.
 json or_null(const std::string& s) {
     if (s.empty()) return nullptr;
@@ -353,8 +377,9 @@ Config from_json(const std::string& text, std::vector<Note>* sink) {
     if (auto s = r.section("folders")) read_folders(*s, c.folders);
     if (auto s = r.section("receive")) read_receive(*s, c.receive);
     if (auto s = r.section("transmit")) read_transmit(*s, c.transmit);
+    if (auto s = r.section("ui")) read_ui(*s, c.ui);
     r.report_unknown({"callsign", "model_path", "precision", "version", "audio", "rig",
-                      "folders", "receive", "transmit"});
+                      "folders", "receive", "transmit", "ui"});
 
     if (c.version > CONFIG_VERSION) {
         notes.add("version",
@@ -412,6 +437,7 @@ std::string to_json(const Config& c) {
          {{"mode", c.transmit.mode},
           {"level", c.transmit.level},
           {"optimize", c.transmit.optimize}}},
+        {"ui", {{"layout", c.ui.layout}, {"waterfall_height", c.ui.waterfall_height}}},
         {"version", c.version},
     };
     return root.dump(2) + "\n";

--- a/native/core/settings/settings.hpp
+++ b/native/core/settings/settings.hpp
@@ -171,6 +171,31 @@ struct TransmitConfig {
     bool optimize = false;
 };
 
+// How the window arranges the receive and transmit halves.
+//
+// This is a *structural* setting, not a cosmetic one. A QSplitter's
+// minimum width is the sum of its children's; a QTabWidget's is the
+// max. Side by side is the better layout and the default -- you compose
+// the next picture while watching the current reception -- but it puts
+// a hard floor under the window that a small panel cannot meet, and no
+// amount of scrolling inside the panes removes it.
+struct UiConfig {
+    // How tall the spectrum strip is, in pixels. The operator drags it
+    // (2026-08-03), so this is their number and not a default anyone
+    // should tune -- 0 means "never set", which takes the initial
+    // height instead.
+    int waterfall_height = 0;
+
+    // "auto" | "split" | "tabs".
+    //
+    // "auto" is resolved **once, at startup, against the screen** --
+    // never against the window's own width. A live breakpoint cannot
+    // work here: while side by side is in force the splitter's minimum
+    // stops the window shrinking to the width that would trigger the
+    // switch, so the downward transition is unreachable by definition.
+    std::string layout = "auto";
+};
+
 struct Config {
     std::string callsign;
     // Empty = the published ONNX artifacts, fetched and cached on first
@@ -184,6 +209,7 @@ struct Config {
     FolderConfig folders;
     ReceiveConfig receive;
     TransmitConfig transmit;
+    UiConfig ui;
     int version = CONFIG_VERSION;
 };
 

--- a/native/gui/app_state.cpp
+++ b/native/gui/app_state.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "checkpoint/checkpoint.hpp"
+#include "checkpoint/qt_fetcher.hpp"
 #include "rig_config.hpp"
 
 namespace sstvae::gui {
@@ -26,17 +27,75 @@ codec::Resolver model_resolver(const std::string& path,
 
 AppState::AppState(QObject* parent)
     : QObject(parent),
-      config_(settings::load().config),
       rig_(
           // Both callbacks arrive on the rig's worker thread. Emitting
           // a Qt signal across threads is the supported way to hand
           // that to the GUI -- the connection becomes queued, so the
           // slot runs on the receiving object's thread and nothing on
-          // the GUI thread ever touches the rig.
+          // the GUI thread ever touches the rig. log_event is
+          // thread-safe by design, so logging here is fine too.
           [](std::optional<double>) {},
-          [this](const std::string& text) {
-              emit rigStatus(QString::fromStdString(text));
-          }) {}
+          [this](const std::string& text, bool error) {
+              const QString qtext = QString::fromStdString(text);
+              log_event("rig", error ? log::Severity::Error : log::Severity::Info,
+                        qtext);
+              emit rigStatus(qtext, error);
+          }) {
+    // Every append reaches the pane (queued signal; non-blocking from
+    // any thread) and, if it opened, the file. Registered before the
+    // first append so nothing is ever visible in one place and not the
+    // other.
+    log_.add_sink([this](const log::Entry& e) {
+        emit logEntry(static_cast<qlonglong>(e.ms),
+                      QString::fromStdString(e.source),
+                      static_cast<int>(e.severity),
+                      QString::fromStdString(e.text));
+    });
+    try {
+        file_log_ = std::make_unique<log::FileWriter>(
+            settings::config_path().parent_path() / "sstvae.log");
+        log_.add_sink([this](const log::Entry& e) {
+            file_log_->write(e);
+            // A write failure is permanent (FileWriter closes the
+            // stream), so it must be reported, once, whenever it
+            // happens -- a full disk hours in must not fail quietly.
+            if (!file_log_reported_.load(std::memory_order_relaxed)) {
+                const std::string err = file_log_->error();
+                if (!err.empty() && !file_log_reported_.exchange(true)) {
+                    emit fileLogFailed(QString::fromStdString(err));
+                }
+            }
+        });
+    } catch (const std::exception&) {
+        // No config directory at all; the in-memory log still works and
+        // log_file_note() reports the absence.
+    }
+
+    // The load happens here rather than in the member initializer so the
+    // validation notes can be kept: a corrupt or out-of-range field is
+    // coerced to its default *and reported*, where previously the notes
+    // were discarded wholesale.
+    const settings::LoadResult loaded = settings::load();
+    config_ = loaded.config;
+    for (const std::string& message : loaded.messages()) {
+        log_event("app", log::Severity::Warning,
+                  tr("config: %1").arg(QString::fromStdString(message)));
+    }
+
+    // The fetcher that downloads the published checkpoint, with live
+    // progress. Installed here rather than in main() so the progress
+    // hook has somewhere to land. Three threads fetch through it: the
+    // model thread (decoder preload), the transmit worker (the lazily
+    // loaded encoder) and the optimizer worker (the gradient graph).
+    // The `this` capture outlives all of them because ~MainWindow
+    // destroys the panels -- which join those workers -- *before* its
+    // AppState child, and ~AppState then joins the model thread.
+    checkpoint::install_qt_fetcher([this](std::int64_t received,
+                                          std::int64_t total) {
+        emit modelProgress(static_cast<qlonglong>(received),
+                           static_cast<qlonglong>(total));
+    });
+}
 
 AppState::~AppState() {
     // stop() detaches by design, so a worker may still be inside
@@ -80,6 +139,12 @@ void AppState::load_model_async() {
             model_ = std::move(loaded);
             model_error_ = error;
         }
+        if (error.isEmpty()) {
+            log_event("app", log::Severity::Info, tr("model ready"));
+        } else {
+            log_event("app", log::Severity::Error,
+                      tr("model failed to load: %1").arg(error));
+        }
         emit modelLoaded();
     });
 }
@@ -110,7 +175,7 @@ std::function<void(bool)> AppState::ptt() {
 void AppState::connect_rig() {
     rig_.stop();
     if (!config_.rig.enabled) {
-        emit rigStatus(QStringLiteral("Rig control off"));
+        emit rigStatus(QStringLiteral("Rig control off"), false);
         return;
     }
     rig_.start(make_backend(config_.rig), controller_config(config_.rig));
@@ -125,9 +190,32 @@ void AppState::resume_rig_polling() { rig_.resume_polling(); }
 void AppState::save_config() {
     try {
         settings::save(config_);
-    } catch (const std::exception&) {
-        // A read-only config directory must not break the session.
+    } catch (const std::exception& e) {
+        // A read-only config directory must not break the session --
+        // but the operator has to find out *somewhere* that their
+        // settings are not sticking.
+        log_event("app", log::Severity::Error,
+                  tr("could not save settings: %1").arg(QString::fromUtf8(e.what())));
     }
+}
+
+void AppState::log_event(const char* source, log::Severity severity,
+                         const QString& text) {
+    log_.append(source, severity, text.toStdString());
+}
+
+QString AppState::log_file_path() const {
+    if (!file_log_) return QString();
+    return QString::fromStdString(file_log_->path().string());
+}
+
+QString AppState::log_file_note() const {
+    if (!file_log_) return tr("(no log file: no config directory)");
+    const std::string error = file_log_->error();
+    if (!error.empty()) {
+        return tr("(log file unavailable: %1)").arg(QString::fromStdString(error));
+    }
+    return QString();
 }
 
 }  // namespace sstvae::gui

--- a/native/gui/app_state.hpp
+++ b/native/gui/app_state.hpp
@@ -23,6 +23,7 @@
 #include <QObject>
 #include <QString>
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -31,6 +32,7 @@
 #include <thread>
 
 #include "codec/codec.hpp"
+#include "log/log.hpp"
 #include "rig/controller.hpp"
 #include "settings/settings.hpp"
 
@@ -70,15 +72,50 @@ public:
     void pause_rig_polling();
     void resume_rig_polling();
 
-    // A read-only config directory must not break the session.
+    // A read-only config directory must not break the session -- but it
+    // must not be silent either: a failure is logged.
     void save_config();
+
+    // --- status log ----------------------------------------------------
+    // Append an entry. Thread-safe; callable from any thread. Every
+    // entry also reaches the file writer and the `logEntry` signal.
+    void log_event(const char* source, log::Severity severity,
+                   const QString& text);
+
+    // For the log pane: backfill via snapshot(), then follow logEntry.
+    const log::StatusLog& status_log() const { return log_; }
+    // Empty while the file log is healthy; a description otherwise.
+    QString log_file_note() const;
+    // Where the file log is being written, or empty if there is none.
+    // Asked rather than re-derived: a second copy of this path would
+    // keep compiling after the writer's location moved, and it is the
+    // path an operator is told to attach to a bug report.
+    QString log_file_path() const;
 
 signals:
     void modelLoaded();
-    void rigStatus(const QString& text);
+    // `error` distinguishes a CAT failure from a routine status; the
+    // text alone cannot (failure text is the backend's exception).
+    void rigStatus(const QString& text, bool error);
+    // Every log entry, queued to the GUI thread for the pane.
+    void logEntry(qlonglong ms, const QString& source, int severity,
+                  const QString& text);
+    // The file log's first failure, whenever it happens. Emitted from
+    // inside a StatusLog sink -- i.e. under the log's lock -- so the
+    // consumer MUST connect with Qt::QueuedConnection; a direct slot
+    // that calls log_event would deadlock on the non-recursive mutex.
+    void fileLogFailed(const QString& description);
+    // Model artifact download, live. Emitted from the model thread.
+    void modelProgress(qlonglong received, qlonglong total);
 
 private:
     settings::Config config_;
+
+    log::StatusLog log_;
+    std::unique_ptr<log::FileWriter> file_log_;
+    // First-failure guard for fileLogFailed; the failure itself is
+    // permanent (FileWriter stops writing), so one report is the truth.
+    std::atomic<bool> file_log_reported_{false};
 
     mutable std::mutex model_mutex_;
     std::unique_ptr<codec::OnnxCodec> model_;

--- a/native/gui/banner.cpp
+++ b/native/gui/banner.cpp
@@ -1,0 +1,65 @@
+#include "banner.hpp"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QPalette>
+#include <QStyle>
+
+namespace sstvae::gui {
+
+ErrorBanner::ErrorBanner(QWidget* parent) : QFrame(parent) {
+    setFrameStyle(QFrame::StyledPanel | QFrame::Plain);
+    // **Opaque, and with its own colours.** It used to sit on the pane
+    // background and inherit it; now it floats over the picture, which
+    // is nearly black in every theme -- so on a light desktop it drew
+    // dark bold text on a dark picture and was barely readable, with
+    // the picture's viewport showing through behind it. An alert
+    // surface has to carry its own contrast wherever it lands.
+    setAutoFillBackground(true);
+    QPalette alert = palette();
+    alert.setColor(QPalette::Window, QColor(0x7a, 0x1f, 0x1a));
+    alert.setColor(QPalette::WindowText, QColor(0xff, 0xf2, 0xf0));
+    setPalette(alert);
+
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(8, 4, 8, 4);
+
+    icon_ = new QLabel(this);
+    const int size = style()->pixelMetric(QStyle::PM_SmallIconSize);
+    icon_->setPixmap(style()
+                         ->standardIcon(QStyle::SP_MessageBoxCritical)
+                         .pixmap(size, size));
+    layout->addWidget(icon_);
+
+    text_ = new QLabel(this);
+    text_->setWordWrap(true);
+    // Inherit the banner's own palette rather than the window's.
+    text_->setForegroundRole(QPalette::WindowText);
+    // Bold rather than coloured: readable in every theme, and the icon
+    // already says "error".
+    QFont font = text_->font();
+    font.setBold(true);
+    text_->setFont(font);
+    layout->addWidget(text_, 1);
+
+    auto* dismiss = new QPushButton(tr("Dismiss"), this);
+    connect(dismiss, &QPushButton::clicked, this, &ErrorBanner::clear);
+    layout->addWidget(dismiss);
+
+    hide();
+}
+
+void ErrorBanner::show_error(const QString& message) {
+    text_->setText(message);
+    show();
+}
+
+void ErrorBanner::clear() {
+    text_->clear();
+    hide();
+}
+
+QString ErrorBanner::message() const { return text_->text(); }
+
+}  // namespace sstvae::gui

--- a/native/gui/banner.hpp
+++ b/native/gui/banner.hpp
@@ -1,0 +1,48 @@
+// A sticky, dismissable error strip for the top of a panel.
+//
+// This is the error tier of the status model: a message that must not
+// be lost to the next routine status write. The transmit and receive
+// panels each funnel every status they show through a single QLabel,
+// so before this existed "PTT OFF FAILED ... unkey it manually" was
+// guaranteed to be replaced -- by "Sent", within a second, on the same
+// label (the review's F3). Errors now land here and *stay* here until
+// the operator dismisses them or the owning panel clears them on a
+// clean restart of the same activity.
+//
+// Deliberately plain: the platform style's critical icon, bold text,
+// and a standard button. Palette only, no stylesheet -- see CLAUDE.md
+// on QStyleSheetStyle -- and no custom chrome.
+
+#ifndef SSTVAE_GUI_BANNER_HPP
+#define SSTVAE_GUI_BANNER_HPP
+
+#include <QFrame>
+#include <QString>
+
+class QLabel;
+
+namespace sstvae::gui {
+
+class ErrorBanner : public QFrame {
+    Q_OBJECT
+
+public:
+    explicit ErrorBanner(QWidget* parent = nullptr);
+
+    // Show (or replace) the message. A later error replaces an earlier
+    // one -- the log keeps the history; the banner shows the newest.
+    void show_error(const QString& message);
+
+    // Programmatic clear, for "the same activity started over cleanly".
+    void clear();
+
+    QString message() const;
+
+private:
+    QLabel* icon_ = nullptr;
+    QLabel* text_ = nullptr;
+};
+
+}  // namespace sstvae::gui
+
+#endif

--- a/native/gui/crop_dialog.cpp
+++ b/native/gui/crop_dialog.cpp
@@ -1,0 +1,289 @@
+#include "crop_dialog.hpp"
+
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QImage>
+#include <QLabel>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPixmap>
+#include <QPushButton>
+#include <QSlider>
+#include <QVBoxLayout>
+#include <QWheelEvent>
+
+#include <algorithm>
+#include <cmath>
+
+namespace sstvae::gui {
+
+namespace {
+
+// Zoom is exposed as integer slider steps because QSlider is integral;
+// 100 steps is 1.00x (exactly cover) and the top is a 4x crop, which is
+// tighter than anyone sensibly wants and still leaves the arithmetic
+// well away from the single-pixel end.
+constexpr int ZOOM_MIN = 100;
+constexpr int ZOOM_MAX = 400;
+
+double steps_to_zoom(int steps) { return steps / 100.0; }
+int zoom_to_steps(double zoom) {
+    return std::clamp(static_cast<int>(std::lround(zoom * 100.0)), ZOOM_MIN, ZOOM_MAX);
+}
+
+QPixmap to_pixmap(const images::Picture& picture) {
+    if (picture.empty()) return QPixmap();
+    const QImage view(picture.rgb.data(), picture.width, picture.height,
+                      picture.width * 3, QImage::Format_RGB888);
+    return QPixmap::fromImage(view.copy());
+}
+
+}  // namespace
+
+// --- CropView ---------------------------------------------------------------
+
+CropView::CropView(QWidget* parent) : QWidget(parent) {
+    setMinimumSize(280, 210);
+    // A move cursor, not a hand: `paintEvent` holds the picture still
+    // and moves the window over it, so what the pointer carries is the
+    // *window*. A hand would promise the other model -- picture sliding
+    // under a fixed frame -- and the two want opposite drag signs.
+    setCursor(Qt::SizeAllCursor);
+}
+
+QSize CropView::sizeHint() const { return {520, 390}; }
+
+void CropView::set_source(const images::Picture& source) {
+    source_ = source;
+    pixmap_ = to_pixmap(source);
+    update();
+}
+
+void CropView::set_framing(const images::Framing& framing) {
+    framing_ = framing;
+    clamp_center();
+    update();
+}
+
+QRectF CropView::source_rect() const {
+    if (source_.empty()) return {};
+    const double sw = source_.width;
+    const double sh = source_.height;
+    const double scale = std::min(width() / sw, height() / sh);
+    const double w = sw * scale;
+    const double h = sh * scale;
+    return {(width() - w) / 2.0, (height() - h) / 2.0, w, h};
+}
+
+QRectF CropView::crop_rect() const {
+    const QRectF area = source_rect();
+    if (area.isEmpty()) return {};
+
+    // The crop window's size as a *fraction of the source*, which is
+    // what the framing means: at zoom 1 the window is the largest 4:3
+    // rectangle that fits, and zoom shrinks it from there.
+    const double src_aspect =
+        static_cast<double>(source_.width) / source_.height;
+    const double target_aspect =
+        static_cast<double>(images::IMG_W) / images::IMG_H;
+
+    double frac_w = 1.0;
+    double frac_h = 1.0;
+    if (src_aspect > target_aspect) {
+        frac_w = target_aspect / src_aspect;  // wider than 4:3: lose width
+    } else {
+        frac_h = src_aspect / target_aspect;  // taller: lose height
+    }
+    const double zoom = std::max(1.0, framing_.zoom);
+    frac_w /= zoom;
+    frac_h /= zoom;
+
+    const double w = area.width() * frac_w;
+    const double h = area.height() * frac_h;
+    const double cx = area.left() + area.width() * framing_.center_x;
+    const double cy = area.top() + area.height() * framing_.center_y;
+    return {cx - w / 2.0, cy - h / 2.0, w, h};
+}
+
+void CropView::clamp_center() {
+    framing_.zoom = std::clamp(framing_.zoom, steps_to_zoom(ZOOM_MIN),
+                               steps_to_zoom(ZOOM_MAX));
+    if (source_.empty()) return;
+    const QRectF area = source_rect();
+    if (area.isEmpty()) return;
+    const QRectF crop = crop_rect();
+    // Half the window's size, as a fraction of the source: the centre
+    // cannot come closer to an edge than that without the window
+    // hanging over nothing.
+    const double half_w = crop.width() / area.width() / 2.0;
+    const double half_h = crop.height() / area.height() / 2.0;
+    framing_.center_x = std::clamp(framing_.center_x, half_w, 1.0 - half_w);
+    framing_.center_y = std::clamp(framing_.center_y, half_h, 1.0 - half_h);
+}
+
+void CropView::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event);
+    QPainter painter(this);
+    painter.fillRect(rect(), palette().window());
+    if (pixmap_.isNull()) return;
+
+    const QRectF area = source_rect();
+    // Smooth, like every other scaled picture in this app: a full-size
+    // photograph into a ~520 px preview is a 6x downscale, and
+    // nearest-neighbour point-sampling moires fine detail badly -- in a
+    // dialog whose whole job is showing the operator what they are
+    // giving up.
+    painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+    painter.drawPixmap(area, pixmap_, QRectF(pixmap_.rect()));
+
+    // Everything outside the window is dimmed rather than hidden, so
+    // the operator can see what is being given up -- which is the whole
+    // complaint this dialog answers.
+    const QRectF crop = crop_rect();
+    QPainterPath outside;
+    outside.addRect(area);
+    QPainterPath inside;
+    inside.addRect(crop);
+    painter.fillPath(outside.subtracted(inside), QColor(0, 0, 0, 140));
+
+    // A two-tone border, the same idiom the overlay editor's selection
+    // uses, so it reads on any picture.
+    painter.setPen(QPen(QColor(0, 0, 0, 160), 3));
+    painter.drawRect(crop);
+    painter.setPen(QPen(QColor(255, 255, 255, 230), 1));
+    painter.drawRect(crop);
+}
+
+void CropView::mousePressEvent(QMouseEvent* event) {
+    if (event->button() != Qt::LeftButton) {
+        QWidget::mousePressEvent(event);
+        return;
+    }
+    dragging_ = true;
+    drag_last_ = event->position();
+}
+
+void CropView::mouseMoveEvent(QMouseEvent* event) {
+    if (!dragging_) return;
+    const QRectF area = source_rect();
+    if (area.isEmpty()) return;
+    const QPointF delta = event->position() - drag_last_;
+    drag_last_ = event->position();
+    // The window follows the pointer, because the window is what moves
+    // on screen: `source_rect` has no framing dependence, so the
+    // picture is fixed and `crop_rect` is what the centre moves. The
+    // opposite sign would be right for a widget that panned the
+    // picture instead -- and it is the sign this had, so dragging right
+    // selected further *left*.
+    framing_.center_x += delta.x() / area.width();
+    framing_.center_y += delta.y() / area.height();
+    clamp_center();
+    update();
+    emit framingChanged();
+}
+
+void CropView::mouseReleaseEvent(QMouseEvent* event) {
+    if (event->button() == Qt::LeftButton) dragging_ = false;
+    QWidget::mouseReleaseEvent(event);
+}
+
+void CropView::wheelEvent(QWheelEvent* event) {
+    // Accumulated to whole notches rather than one step per event. A
+    // conventional wheel delivers 120 units per detent, but a trackpad
+    // or a high-resolution wheel delivers a handful of units per event
+    // -- so "one event, one 1.1x step" turns a small two-finger gesture
+    // into a run from 1x to the 4x ceiling.
+    wheel_accum_ += event->angleDelta().y();
+    constexpr int NOTCH = 120;
+    bool moved = false;
+    while (wheel_accum_ >= NOTCH) {
+        wheel_accum_ -= NOTCH;
+        framing_.zoom *= 1.1;
+        moved = true;
+    }
+    while (wheel_accum_ <= -NOTCH) {
+        wheel_accum_ += NOTCH;
+        framing_.zoom /= 1.1;
+        moved = true;
+    }
+    if (moved) {
+        clamp_center();
+        update();
+        emit framingChanged();
+    }
+    event->accept();
+}
+
+// --- CropDialog -------------------------------------------------------------
+
+CropDialog::CropDialog(const images::Picture& source,
+                       const images::Framing& initial, QWidget* parent)
+    : QDialog(parent) {
+    setWindowTitle(tr("Frame picture"));
+
+    auto* layout = new QVBoxLayout(this);
+
+    summary_ = new QLabel(this);
+    summary_->setText(tr("%1x%2 source, sent as %3x%4. Drag to reposition; "
+                         "the wheel or the slider zooms.")
+                          .arg(source.width)
+                          .arg(source.height)
+                          .arg(images::IMG_W)
+                          .arg(images::IMG_H));
+    summary_->setWordWrap(true);
+    layout->addWidget(summary_);
+
+    view_ = new CropView(this);
+    view_->set_source(source);
+    view_->set_framing(initial);
+    connect(view_, &CropView::framingChanged, this, &CropDialog::on_view_changed);
+    layout->addWidget(view_, 1);
+
+    auto* zoom_row = new QHBoxLayout();
+    zoom_row->addWidget(new QLabel(tr("Zoom:"), this));
+    zoom_ = new QSlider(Qt::Horizontal, this);
+    zoom_->setRange(ZOOM_MIN, ZOOM_MAX);
+    zoom_->setValue(zoom_to_steps(view_->framing().zoom));
+    connect(zoom_, &QSlider::valueChanged, this, &CropDialog::on_zoom_changed);
+    zoom_row->addWidget(zoom_, 1);
+    auto* reset = new QPushButton(tr("Reset"), this);
+    reset->setToolTip(tr("Back to the centred, full-width framing"));
+    connect(reset, &QPushButton::clicked, this, &CropDialog::reset_framing);
+    zoom_row->addWidget(reset);
+    layout->addLayout(zoom_row);
+
+    auto* buttons =
+        new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    // Enter accepts, and the default framing is the centre crop this
+    // function has always done -- so an operator who does not care pays
+    // one keypress and gets exactly the old behaviour.
+    buttons->button(QDialogButtonBox::Ok)->setDefault(true);
+    layout->addWidget(buttons);
+}
+
+images::Framing CropDialog::framing() const { return view_->framing(); }
+
+void CropDialog::on_zoom_changed(int steps) {
+    if (syncing_) return;
+    images::Framing framing = view_->framing();
+    framing.zoom = steps_to_zoom(steps);
+    view_->set_framing(framing);
+}
+
+void CropDialog::on_view_changed() {
+    // The wheel changes zoom inside the view, so the slider has to
+    // follow -- guarded, or its valueChanged would drive the view back.
+    syncing_ = true;
+    zoom_->setValue(zoom_to_steps(view_->framing().zoom));
+    syncing_ = false;
+}
+
+void CropDialog::reset_framing() {
+    view_->set_framing(images::Framing{});
+    on_view_changed();
+}
+
+}  // namespace sstvae::gui

--- a/native/gui/crop_dialog.hpp
+++ b/native/gui/crop_dialog.hpp
@@ -1,0 +1,112 @@
+// Choosing which part of a non-4:3 picture goes on the air.
+//
+// The codec sends 4:3, and `images::fit` has always resolved anything
+// else by scaling to cover and cropping the centre -- silently. A 16:9
+// photograph lost a quarter of its width and a portrait lost most of
+// its height, with no indication that anything had been discarded and
+// no way to choose differently. Worse, the editor letterboxes the
+// *already-cropped* canvas inside its widget, which reads as "your
+// photo was letterboxed" when it was cut.
+//
+// So: when a chosen picture is not 4:3, this dialog opens on top of
+// the original with an aspect-locked window over it. Accepting the
+// default is exactly the old behaviour, one keypress away, which is
+// what keeps it out of the way of an operator in a hurry. There is no
+// letterbox alternative (decided 2026-08-01): padding spends airtime
+// on black, and anyone who wants the whole frame can pad the file.
+//
+// The dialog owns no picture data beyond the source it is handed; what
+// it returns is a `images::Framing`, so the caller keeps the original
+// and can re-open this to adjust.
+
+#ifndef SSTVAE_GUI_CROP_DIALOG_HPP
+#define SSTVAE_GUI_CROP_DIALOG_HPP
+
+#include <QDialog>
+#include <QWidget>
+
+#include "images/images.hpp"
+#include "images/types.hpp"
+
+class QLabel;
+class QSlider;
+
+namespace sstvae::gui {
+
+// The interactive part: the source picture with a draggable,
+// aspect-locked crop window over it and the excluded area dimmed.
+//
+// A painted QWidget rather than a QGraphicsView, for the same reason
+// the overlay editor is one: there is a single thing to draw and a
+// scene would be a second representation that can drift from the
+// geometry `images::fit` actually uses.
+class CropView : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit CropView(QWidget* parent = nullptr);
+
+    void set_source(const images::Picture& source);
+    void set_framing(const images::Framing& framing);
+    const images::Framing& framing() const { return framing_; }
+
+    QSize sizeHint() const override;
+
+signals:
+    void framingChanged();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
+
+private:
+    // Where the whole source picture is drawn inside this widget,
+    // letterboxed to preserve its aspect.
+    QRectF source_rect() const;
+    // The crop window in widget coordinates, derived from `framing_` --
+    // never stored, so what is drawn cannot disagree with what is
+    // returned.
+    QRectF crop_rect() const;
+    // Keep the window inside the picture: the centre's legal range
+    // shrinks as the window grows.
+    void clamp_center();
+
+    images::Picture source_;
+    QPixmap pixmap_;
+    images::Framing framing_;
+    bool dragging_ = false;
+    QPointF drag_last_;
+    // Wheel deltas below one detent are kept rather than acted on, so a
+    // trackpad's small events add up to the same step a mouse notch
+    // gives in one.
+    int wheel_accum_ = 0;
+};
+
+class CropDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    // `source` is the picture as loaded, at its own size.
+    CropDialog(const images::Picture& source, const images::Framing& initial,
+               QWidget* parent = nullptr);
+
+    images::Framing framing() const;
+
+private slots:
+    void on_zoom_changed(int steps);
+    void on_view_changed();
+    void reset_framing();
+
+private:
+    CropView* view_ = nullptr;
+    QSlider* zoom_ = nullptr;
+    QLabel* summary_ = nullptr;
+    bool syncing_ = false;
+};
+
+}  // namespace sstvae::gui
+
+#endif

--- a/native/gui/flow_layout.cpp
+++ b/native/gui/flow_layout.cpp
@@ -1,0 +1,104 @@
+#include "flow_layout.hpp"
+
+#include <QWidget>
+
+#include <algorithm>
+
+namespace sstvae::gui {
+
+FlowLayout::FlowLayout(QWidget* parent, int margin, int hspace, int vspace)
+    : QLayout(parent), hspace_(hspace), vspace_(vspace) {
+    setContentsMargins(margin, margin, margin, margin);
+}
+
+FlowLayout::~FlowLayout() {
+    while (QLayoutItem* item = takeAt(0)) delete item;
+}
+
+void FlowLayout::addItem(QLayoutItem* item) { items_.append(item); }
+
+int FlowLayout::count() const { return static_cast<int>(items_.size()); }
+
+QLayoutItem* FlowLayout::itemAt(int index) const {
+    return (index >= 0 && index < items_.size()) ? items_.at(index) : nullptr;
+}
+
+QLayoutItem* FlowLayout::takeAt(int index) {
+    return (index >= 0 && index < items_.size()) ? items_.takeAt(index) : nullptr;
+}
+
+int FlowLayout::heightForWidth(int width) const {
+    return reflow(QRect(0, 0, width, 0), /*apply=*/false);
+}
+
+void FlowLayout::setGeometry(const QRect& rect) {
+    QLayout::setGeometry(rect);
+    reflow(rect, /*apply=*/true);
+}
+
+QSize FlowLayout::minimumSize() const {
+    // **The widest single item, not the sum.** That is the whole point:
+    // a row that can wrap only needs room for its largest control, so
+    // the window's floor stops being the total width of every button in
+    // the strip.
+    QSize widest(0, 0);
+    for (const QLayoutItem* item : items_) {
+        widest = widest.expandedTo(item->minimumSize());
+    }
+    const QMargins m = contentsMargins();
+    return widest + QSize(m.left() + m.right(), m.top() + m.bottom());
+}
+
+// What to lay an item out at.
+//
+// **Not simply `item->sizeHint()`.** `QWidgetItem::sizeHint()` returns
+// *zero* on any axis whose size policy is `Ignored` -- which is a
+// sensible answer to a layout that distributes stretch, and the wrong
+// one here, because this layout has no stretch to give. Several widgets
+// carry `Ignored` horizontally precisely so they cannot pin the
+// window's width, and they came out 0 px wide: the transmit status
+// label (which is where the refiner reports its progress) and the send
+// progress bar were both laid out at zero and simply were not there.
+// Reported by an operator who noticed the refiner had gone quiet.
+//
+// Asking the widget directly restores a real width. The floor is
+// unaffected, because `minimumSize()` still uses `item->minimumSize()`,
+// which stays zero for an Ignored axis -- so these widgets are visible
+// and still cannot stop the window being narrowed.
+QSize FlowLayout::item_size(const QLayoutItem* item) {
+    QSize want = item->sizeHint();
+    if (const QWidget* w = item->widget()) {
+        if (want.width() <= 0) want.setWidth(w->sizeHint().width());
+        if (want.height() <= 0) want.setHeight(w->sizeHint().height());
+    }
+    return want;
+}
+
+int FlowLayout::reflow(const QRect& rect, bool apply) const {
+    const QMargins m = contentsMargins();
+    const QRect inner = rect.adjusted(m.left(), m.top(), -m.right(), -m.bottom());
+    int x = inner.x();
+    int y = inner.y();
+    int line_height = 0;
+
+    for (QLayoutItem* item : items_) {
+        const QSize want = item_size(item);
+        int next = x + want.width();
+        // Wrap when this item would cross the right edge -- unless it is
+        // the first on the line, in which case there is nowhere better
+        // for it to go and it is allowed to overhang rather than be
+        // dropped somewhere invisible.
+        if (next > inner.right() + 1 && line_height > 0) {
+            x = inner.x();
+            y += line_height + vspace_;
+            next = x + want.width();
+            line_height = 0;
+        }
+        if (apply) item->setGeometry(QRect(QPoint(x, y), want));
+        x = next + hspace_;
+        line_height = std::max(line_height, want.height());
+    }
+    return y + line_height - rect.y() + m.bottom();
+}
+
+}  // namespace sstvae::gui

--- a/native/gui/flow_layout.hpp
+++ b/native/gui/flow_layout.hpp
@@ -1,0 +1,69 @@
+// A layout that wraps its items onto as many lines as they need.
+//
+// **This exists because a narrow window mangled the controls rather
+// than reflowing them.** A `QHBoxLayout` has exactly one line: below
+// the width its items want, it crushes them -- a caption collapses to a
+// sliver, a combo loses its text, the field at the end is cut off by
+// the edge. And because several of those items are
+// `QSizePolicy::Ignored` (so they cannot pin the window's width), the
+// *reported* minimum understates what the row actually needs, so the
+// window happily resizes to a size at which its own controls are
+// broken. Reported by an operator, and reproduced at exactly the
+// minimum width the window would accept.
+//
+// Wrapping fixes both halves at once: the controls stay legible at any
+// width, and the floor drops to the widest single item rather than the
+// sum of all of them -- which is what makes the window shrink usefully
+// far, which is the other half of the same report.
+//
+// `heightForWidth` is the whole mechanism here and is *safe* in this
+// direction: this layout's height grows as it gets narrower, so it can
+// never act as the width-following ratchet that
+// `overlay_editor.hpp` records. Qt's own Flow Layout example is the
+// shape; the spacing and the comments are ours.
+
+#ifndef SSTVAE_GUI_FLOW_LAYOUT_HPP
+#define SSTVAE_GUI_FLOW_LAYOUT_HPP
+
+#include <QLayout>
+#include <QList>
+#include <QRect>
+#include <QLayoutItem>
+#include <QSize>
+
+namespace sstvae::gui {
+
+class FlowLayout : public QLayout {
+public:
+    explicit FlowLayout(QWidget* parent = nullptr, int margin = 0, int hspace = 6,
+                        int vspace = 4);
+    ~FlowLayout() override;
+
+    void addItem(QLayoutItem* item) override;
+    int count() const override;
+    QLayoutItem* itemAt(int index) const override;
+    QLayoutItem* takeAt(int index) override;
+
+    Qt::Orientations expandingDirections() const override { return {}; }
+    bool hasHeightForWidth() const override { return true; }
+    int heightForWidth(int width) const override;
+    QSize sizeHint() const override { return minimumSize(); }
+    QSize minimumSize() const override;
+    void setGeometry(const QRect& rect) override;
+
+private:
+    // `apply` false measures, true also moves the items. One routine for
+    // both so a measured height cannot disagree with a laid-out one.
+    // See the .cpp: an `Ignored` axis reports zero through the item,
+    // which this layout must not take literally.
+    static QSize item_size(const QLayoutItem* item);
+    int reflow(const QRect& rect, bool apply) const;
+
+    QList<QLayoutItem*> items_;
+    int hspace_;
+    int vspace_;
+};
+
+}  // namespace sstvae::gui
+
+#endif

--- a/native/gui/log_pane.cpp
+++ b/native/gui/log_pane.cpp
@@ -1,0 +1,171 @@
+#include "log_pane.hpp"
+
+#include <QClipboard>
+#include <QComboBox>
+#include <QFontDatabase>
+#include <QGuiApplication>
+#include <QDockWidget>
+#include <QHBoxLayout>
+#include <QStyle>
+#include <QToolButton>
+#include <QLabel>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QScrollBar>
+#include <QTextCharFormat>
+#include <QTextCursor>
+#include <QVBoxLayout>
+
+#include <string>
+
+namespace sstvae::gui {
+
+namespace {
+
+// "All" plus the sources AppState hands out. A source not in this list
+// still logs and still shows under All; it just has no dedicated
+// filter entry, which is the right default for a source added later.
+const char* const FILTERS[] = {"All", "rig", "rx", "tx", "opt", "app"};
+
+}  // namespace
+
+LogPane::LogPane(const log::StatusLog* log, QWidget* parent)
+    : QWidget(parent), log_(log) {
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(2);
+
+    // Kept as a widget rather than a bare layout, so it can be lifted
+    // out and used as the dock's title bar (see `take_title_row`).
+    header_ = new QWidget(this);
+    auto* header = new QHBoxLayout(header_);
+    header->setContentsMargins(4, 2, 4, 2);
+    header->addWidget(new QLabel(tr("Filter:"), header_));
+    filter_ = new QComboBox(header_);
+    for (const char* name : FILTERS) {
+        filter_->addItem(QString::fromLatin1(name));
+    }
+    connect(filter_, &QComboBox::currentIndexChanged, this, &LogPane::refill);
+    header->addWidget(filter_);
+
+    file_note_ = new QLabel(header_);
+    file_note_->setWordWrap(false);
+    header->addWidget(file_note_, 1);
+
+    auto* copy = new QPushButton(tr("Copy"), header_);
+    copy->setToolTip(tr("Copy the whole log (unfiltered) to the clipboard"));
+    connect(copy, &QPushButton::clicked, this, &LogPane::copy_all);
+    header->addWidget(copy);
+    layout->addWidget(header_);
+
+    text_ = new QPlainTextEdit(this);
+    text_->setReadOnly(true);
+    text_->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+    text_->setLineWrapMode(QPlainTextEdit::NoWrap);
+    // Matches StatusLog's own retention, so the view cannot outgrow
+    // the model it claims to show.
+    text_->setMaximumBlockCount(2000);
+    text_->setMinimumHeight(text_->fontMetrics().lineSpacing() * 3);
+    layout->addWidget(text_, 1);
+
+    refill();
+}
+
+QSize LogPane::sizeHint() const {
+    const int line = text_->fontMetrics().lineSpacing();
+    return {QWidget::sizeHint().width(), line * 5 + filter_->sizeHint().height() + 10};
+}
+
+void LogPane::set_file_note(const QString& note) {
+    file_note_->setText(note);
+}
+
+bool LogPane::passes_filter(const std::string& source) const {
+    const QString wanted = filter_->currentText();
+    return wanted == QLatin1String("All") ||
+           wanted == QString::fromStdString(source);
+}
+
+void LogPane::append_line(const log::Entry& entry) {
+    // Follow the tail only when the operator is already at it, and
+    // never through their cursor: setTextCursor would clear a
+    // selection mid-drag, and unconditional following yanks the view
+    // away from the older line they scrolled up to read.
+    QScrollBar* vbar = text_->verticalScrollBar();
+    const bool at_bottom = vbar->value() >= vbar->maximum();
+
+    QTextCursor cursor(text_->document());
+    cursor.movePosition(QTextCursor::End);
+    QTextCharFormat format;
+    // Bold rather than coloured (the traditional-look decision): an
+    // error line stands out in every theme without inventing chrome.
+    format.setFontWeight(entry.severity == log::Severity::Error ? QFont::Bold
+                                                                : QFont::Normal);
+    if (cursor.position() != 0) cursor.insertBlock();
+    cursor.setCharFormat(format);
+    cursor.insertText(QString::fromStdString(log::format_entry(entry)));
+
+    if (at_bottom) {
+        vbar->setValue(vbar->maximum());
+        // A long line would otherwise drag the view right and take the
+        // timestamp column off the left edge -- seen in the first
+        // gui-shot render. Follow vertically, never horizontally.
+        text_->horizontalScrollBar()->setValue(0);
+    }
+}
+
+void LogPane::append(qlonglong ms, const QString& source, int severity,
+                     const QString& text) {
+    if (!passes_filter(source.toStdString())) return;
+    log::Entry entry;
+    entry.ms = ms;
+    entry.source = source.toStdString();
+    entry.severity = static_cast<log::Severity>(severity);
+    entry.text = text.toStdString();
+    append_line(entry);
+}
+
+void LogPane::refill() {
+    text_->clear();
+    if (log_ == nullptr) return;
+    for (const log::Entry& entry : log_->snapshot()) {
+        if (passes_filter(entry.source)) append_line(entry);
+    }
+}
+
+QWidget* LogPane::take_title_row(const QString& title, QDockWidget* dock) {
+    auto* row = qobject_cast<QHBoxLayout*>(header_->layout());
+    if (row == nullptr) return nullptr;
+    // The dock's name goes at the front, bold, where a title bar's would
+    // be; the close button at the end, where one belongs.
+    auto* name = new QLabel(title, header_);
+    QFont bold = name->font();
+    bold.setBold(true);
+    name->setFont(bold);
+    row->insertWidget(0, name);
+
+    auto* close = new QToolButton(header_);
+    close->setAutoRaise(true);
+    close->setIcon(style()->standardIcon(QStyle::SP_TitleBarCloseButton));
+    close->setToolTip(tr("Hide the status log (View > Status log brings it back)"));
+    connect(close, &QToolButton::clicked, dock, &QDockWidget::close);
+    row->addWidget(close);
+
+    // Reparented to the dock by setTitleBarWidget; taking it out of our
+    // own layout first keeps the pane from reserving space for a row it
+    // no longer owns.
+    header_->setParent(nullptr);
+    return header_;
+}
+
+void LogPane::copy_all() {
+    if (log_ == nullptr) return;
+    QString all;
+    for (const log::Entry& entry : log_->snapshot()) {
+        all += QString::fromStdString(log::format_entry(entry));
+        all += QLatin1Char('\n');
+    }
+    QGuiApplication::clipboard()->setText(all);
+}
+
+}  // namespace sstvae::gui

--- a/native/gui/log_pane.hpp
+++ b/native/gui/log_pane.hpp
@@ -1,0 +1,69 @@
+// The status log pane: a scrolling, timestamped record of everything
+// the app has said, docked at the bottom of the main window.
+//
+// Fed from `log::StatusLog` via `AppState::logEntry` -- a queued
+// signal, so entries may originate on any thread. On construction the
+// pane backfills from `snapshot()`, which is how startup entries
+// (config validation notes, the first rig status) appear even though
+// they were logged before the pane existed.
+//
+// Filtering is by source, and it re-renders from the log rather than
+// hiding blocks: the log is the truth, the pane is a view. The Copy
+// button copies the *unfiltered* log in the same one-line format the
+// file uses, so a pasted bug report and the on-disk log read the same.
+
+#ifndef SSTVAE_GUI_LOG_PANE_HPP
+#define SSTVAE_GUI_LOG_PANE_HPP
+
+#include <QWidget>
+
+#include "log/log.hpp"
+
+class QComboBox;
+class QDockWidget;
+class QLabel;
+class QPlainTextEdit;
+
+namespace sstvae::gui {
+
+class LogPane : public QWidget {
+    Q_OBJECT
+
+public:
+    // Hand the filter/Copy row back, with a name and a close button
+    // folded in, so it can serve as the dock's title bar. Saves a whole
+    // row of height at the bottom of the window -- see main_window.cpp.
+    QWidget* take_title_row(const QString& title, QDockWidget* dock);
+
+    explicit LogPane(const log::StatusLog* log, QWidget* parent = nullptr);
+
+    // ~5 log lines tall by default (the settled Q4 decision); the dock
+    // is user-resizable from there.
+    QSize sizeHint() const override;
+
+    // Shown next to the filter so a read-only config directory is not
+    // silent: pass FileWriter::error() when it is set.
+    void set_file_note(const QString& note);
+
+public slots:
+    void append(qlonglong ms, const QString& source, int severity,
+                const QString& text);
+
+private slots:
+    void refill();
+    void copy_all();
+
+private:
+    bool passes_filter(const std::string& source) const;
+    void append_line(const log::Entry& entry);
+
+    const log::StatusLog* log_ = nullptr;
+    QWidget* header_ = nullptr;
+    QComboBox* filter_ = nullptr;
+    QLabel* file_note_ = nullptr;
+    QPlainTextEdit* text_ = nullptr;
+};
+
+}  // namespace sstvae::gui
+
+#endif

--- a/native/gui/main.cpp
+++ b/native/gui/main.cpp
@@ -3,7 +3,6 @@
 #include <QApplication>
 #include <QIcon>
 
-#include "checkpoint/qt_fetcher.hpp"
 #include "main_window.hpp"
 
 int main(int argc, char** argv) {
@@ -24,12 +23,10 @@ int main(int argc, char** argv) {
     icon.addFile(QStringLiteral(":/sstvae-256.png"));
     QApplication::setWindowIcon(icon);
 
-    // Make the published checkpoint fetchable before anything asks for
-    // it. Only the *download* needs this; resolving an explicit --model
-    // and finding a warm cache are path arithmetic in sstvae_core, so a
-    // second run works with the network gone.
-    sstvae::checkpoint::install_qt_fetcher();
-
+    // The checkpoint fetcher is installed by AppState (inside the
+    // window), which supplies the download-progress hook -- the fetch
+    // itself cannot start before then, because only the model load
+    // triggers it and AppState is what starts that.
     sstvae::gui::MainWindow window;
     window.show();
     return app.exec();

--- a/native/gui/main_window.cpp
+++ b/native/gui/main_window.cpp
@@ -2,19 +2,35 @@
 
 #include <QAction>
 #include <QCloseEvent>
+#include <QDateTime>
+#include <QDockWidget>
+#include <QGroupBox>
 #include <QKeySequence>
 #include <QLabel>
 #include <QMenu>
 #include <QMenuBar>
+#include <QActionGroup>
+#include <QPainter>
+#include <QSplitter>
+#include <QSplitterHandle>
 #include <QMessageBox>
+#include <QScreen>
 #include <QStatusBar>
-#include <QTabWidget>
+#include <QTimer>
+#include <QVBoxLayout>
 #include <QWidget>
 
+#include <algorithm>
+
 #include "app_state.hpp"
+#include "log_pane.hpp"
+#include "pane_container.hpp"
+#include "waterfall.hpp"
+#include "rig/hamlib.hpp"
 #include "rx_panel.hpp"
-#include "tx_panel.hpp"
 #include "settings_dialog.hpp"
+#include "tx/engine.hpp"
+#include "tx_panel.hpp"
 
 namespace sstvae::gui {
 
@@ -22,18 +38,100 @@ namespace {
 
 constexpr auto APP_NAME = "SSTVAE";
 
+// The spectrum strip before anyone has dragged it. Deliberately
+// shallow: at 150 px most of it was black most of the time, and the
+// height is worth more to the pictures.
+constexpr int DEFAULT_WATERFALL_H = 96;
+
+// A splitter handle that looks like one.
+//
+// Qt's default handle is a flat gap: on a dark theme it is invisible,
+// so the waterfall was resizable with nothing on screen saying so. Three
+// short dashes in the middle is the plain desktop idiom for a grip, and
+// painting it keeps us out of stylesheets -- one stylesheet anywhere
+// makes Qt wrap the application style and strips the padding from every
+// combo and spin box in the app.
+class GripHandle : public QSplitterHandle {
+public:
+    GripHandle(Qt::Orientation orientation, QSplitter* parent)
+        : QSplitterHandle(orientation, parent) {
+        setCursor(orientation == Qt::Horizontal ? Qt::SplitHCursor : Qt::SplitVCursor);
+    }
+
+protected:
+    void paintEvent(QPaintEvent* event) override {
+        QSplitterHandle::paintEvent(event);
+        QPainter painter(this);
+        painter.setPen(QPen(palette().color(QPalette::Mid), 1));
+        const int cx = width() / 2;
+        const int cy = height() / 2;
+        // Three marks, 6 px long, 3 px apart, across the drag axis.
+        for (int i = -1; i <= 1; ++i) {
+            if (orientation() == Qt::Vertical) {
+                painter.drawLine(cx - 12 + i * 12, cy, cx - 6 + i * 12, cy);
+            } else {
+                painter.drawLine(cx, cy - 12 + i * 12, cx, cy - 6 + i * 12);
+            }
+        }
+    }
+};
+
+class GripSplitter : public QSplitter {
+public:
+    using QSplitter::QSplitter;
+
+protected:
+    QSplitterHandle* createHandle() override {
+        return new GripHandle(orientation(), this);
+    }
+};
+
 }  // namespace
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent) {
     state_ = new AppState(this);
     setWindowTitle(QString::fromLatin1(APP_NAME));
-    resize(1100, 800);
+    // Wider than the tabbed window it replaces, because two panes are
+    // side by side now and their minimums add (see main_window.hpp).
+    // The height is unchanged from the tabbed window.
+    resize(1360, 800);
 
-    tabs_ = new QTabWidget(this);
-    rx_panel_ = new ReceivePanel(state_, tabs_);
-    tabs_->addTab(rx_panel_, tr("Receive"));
-    tx_panel_ = new TransmitPanel(state_, tabs_);
-    tabs_->addTab(tx_panel_, tr("Transmit"));
+    // **The spectrum spans the whole window, above both panes** -- and
+    // above the *tab widget* too, so it is on screen in both layouts.
+    // It is the one widget here whose job is resolving detail across a
+    // frequency axis, and inside the receive pane it had about a third
+    // of the width to do it in. The receive panel still drives it (it
+    // owns the ring buffer), so ownership moved and control did not.
+    //
+    // Keeping it outside the tabs is deliberate: tabs exist for a
+    // narrow screen, and what you give up there is seeing the band
+    // while you compose. The strip is the cheapest way to keep it.
+    waterfall_ = new Waterfall(this);
+    // A floor, and no ceiling: the operator sets the height now, and a
+    // maximum would silently ignore a value they had chosen.
+    waterfall_->setMinimumHeight(60);
+
+    rx_panel_ = new ReceivePanel(state_);
+    tx_panel_ = new TransmitPanel(state_);
+    rx_panel_->attach_waterfall(waterfall_);
+
+    // **Each pane is named.** The tabs this replaced carried the only
+    // labels that said which half was which, and dropping them left two
+    // similar-looking columns of controls whose identity you had to
+    // infer from a button caption ("Start receiving", "Send"). Driving
+    // it settles the question: inferring is not the same as seeing.
+    //
+    // The titles go on the container rather than inside the panels
+    // because that is where the pairing lives -- neither panel has any
+    // business knowing it sits beside the other one -- and it is also
+    // what lets the same two words be a group-box title in one layout
+    // and a tab label in the other.
+    panes_ = new PaneContainer(rx_panel_, tr("Receive"), tx_panel_, tr("Transmit"), this);
+    // Equal panes are not equal pictures on their own -- the two halves
+    // carry different controls beneath. Matching the *strips* is what
+    // makes the pictures match, without taking space off either.
+    panes_->set_control_strips(rx_panel_->control_strip(),
+                               tx_panel_->control_strip());
 
     // Half duplex: our own transmission must not be decoded back into a
     // received picture. Frequency polling pauses too -- the answer is
@@ -50,24 +148,216 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent) {
     // The most recent picture becomes available as a transmit inset.
     connect(rx_panel_, &ReceivePanel::imageReceived, tx_panel_,
             &TransmitPanel::set_last_rx_image);
-    setCentralWidget(tabs_);
+    // **The waterfall's height is the operator's** (decided
+    // 2026-08-03). A fixed strip was the alternative and the
+    // recommendation; a handle won because 150 px is too much most of
+    // the time and not enough occasionally, and something set once
+    // costs nothing afterwards. The position is remembered in
+    // `ui.waterfall_height`.
+    //
+    // A vertical handle here is unrelated to the horizontal one that
+    // was removed to lock the panes equal -- that one decided which
+    // pane won, and this one only decides how much spectrum history is
+    // on screen.
+    stack_ = new GripSplitter(Qt::Vertical, this);
+    stack_->addWidget(waterfall_);
+    stack_->addWidget(panes_);
+    stack_->setStretchFactor(0, 0);
+    stack_->setStretchFactor(1, 1);
+    // Neither half may be dragged out of existence: a waterfall of zero
+    // height reads as a broken capture, and the panes are the app.
+    stack_->setChildrenCollapsible(false);
+    stack_->setHandleWidth(6);
+    setCentralWidget(stack_);
+    restore_waterfall_height();
+    connect(stack_, &QSplitter::splitterMoved, this,
+            [this](int, int) { remember_waterfall_height(); });
 
     build_menu();
     build_status_bar();
+    build_log_dock();
 
     connect(state_, &AppState::modelLoaded, this, &MainWindow::on_model_loaded);
-    connect(state_, &AppState::rigStatus, rig_label_, &QLabel::setText);
+    connect(state_, &AppState::rigStatus, this, &MainWindow::on_rig_status);
+    connect(state_, &AppState::modelProgress, this,
+            &MainWindow::on_model_progress);
+    // The PTT lamp follows the transmit phase; the rig chip greys while
+    // polling is paused so a frozen frequency does not read as current.
+    connect(tx_panel_, &TransmitPanel::stateChanged, this,
+            [this](int phase, double, const QString&) { on_tx_state(phase); });
+    connect(tx_panel_, &TransmitPanel::sendFinished, this,
+            [this](bool) { on_tx_state(static_cast<int>(tx::TxPhase::Idle)); });
+    connect(tx_panel_, &TransmitPanel::transmitStarted, this,
+            [this] { rig_label_->setEnabled(false); });
+    connect(tx_panel_, &TransmitPanel::transmitFinished, this,
+            [this] { rig_label_->setEnabled(true); });
     connect(rx_panel_, &ReceivePanel::receptionSaved, this,
             [this](const QString& path) {
                 statusBar()->showMessage(tr("Saved %1").arg(path), 5000);
             });
+
+    // The receive status is mirrored into the status bar while tabbed,
+    // so composing a picture is not done blind through someone else's
+    // over -- which is the one thing the side-by-side layout buys and
+    // tabs give straight back. Connected in both layouts: a switch mid
+    // reception then has a current line to show rather than a stale one
+    // or none.
+    connect(rx_panel_, &ReceivePanel::statusChanged, this, &MainWindow::on_rx_status);
+    connect(panes_, &PaneContainer::modeChanged, this, &MainWindow::on_layout_changed);
+    on_layout_changed(panes_->mode());
+
+    panes_->set_mode(startup_layout());
+    // After the layout is chosen, since the chosen one decides the size.
+    fit_to_screen();
 
     state_->load_model_async();
     state_->connect_rig();
     update_station_label();
 }
 
-MainWindow::~MainWindow() = default;
+MainWindow::~MainWindow() {
+    // Destruction order is load-bearing. `state_` is this window's
+    // first child and the panels live inside the central widget, its
+    // second -- so QObject's forward-order child deletion would destroy
+    // AppState *before* the panels, whose teardown still uses it
+    // (~ReceivePanel calls stop(); ~TransmitPanel joins the transmit
+    // and optimizer workers, which may be mid-fetch through the
+    // AppState-captured progress hook). Deleting the central widget by
+    // hand first means every panel -- and every worker thread they own
+    // -- is gone while AppState is still alive.
+    //
+    // **The panels' signals are severed first, and that is not
+    // belt-and-braces.** `~ReceivePanel` calls `stop()`, which writes
+    // its status line, which now emits `statusChanged` -- and the slot
+    // for it reaches back into `panes_`. But the panels are children of
+    // `panes_`, so by the time they are being destroyed `~PaneContainer`
+    // has already run its body and destroyed its `QString` members,
+    // while remaining a live QObject whose slots still fire. Without
+    // this the last act of every quit is `set_first_note` reading a
+    // destructed QString. Qt's automatic disconnect does not help: it
+    // happens in `~QObject`, which is after the derived members are
+    // gone.
+    disconnect(rx_panel_, nullptr, this, nullptr);
+    disconnect(tx_panel_, nullptr, this, nullptr);
+    delete takeCentralWidget();
+}
+
+void MainWindow::build_layout_menu() {
+    // A submenu with two exclusive checkable entries rather than one
+    // "Tabbed layout" toggle: the two arrangements are peers, and a
+    // checkbox would make the operator work out which state its unticked
+    // form means.
+    //
+    // Deliberately no "Auto" entry, even though "auto" is a value the
+    // config holds. Auto is a *first-run guess*, and offering it back to
+    // someone who has already seen the window would be asking them to
+    // choose "whatever you think" over an answer they can see. Picking
+    // either entry writes a concrete value and ends the guessing.
+    QMenu* layout = view_menu_->addMenu(tr("&Layout"));
+    auto* group = new QActionGroup(this);
+    group->setExclusive(true);
+
+    split_action_ = layout->addAction(tr("&Side by side"));
+    split_action_->setCheckable(true);
+    split_action_->setActionGroup(group);
+    connect(split_action_, &QAction::triggered, this,
+            [this] { choose_layout(PaneLayout::Split); });
+
+    tabs_action_ = layout->addAction(tr("&Tabbed"));
+    tabs_action_->setCheckable(true);
+    tabs_action_->setActionGroup(group);
+    connect(tabs_action_, &QAction::triggered, this,
+            [this] { choose_layout(PaneLayout::Tabs); });
+
+    view_menu_->addSeparator();
+}
+
+PaneLayout MainWindow::startup_layout() const {
+    // What the side-by-side arrangement actually needs, measured rather
+    // than guessed: the panels' minimums move whenever either gains a
+    // control, and a hardcoded breakpoint would silently stop matching
+    // the layout it was chosen for.
+    const QSize required = panes_->minimumSizeHint();
+    const QSize available = available_screen();
+    const PaneLayout mode =
+        resolve_layout(state_->config().ui.layout, available, required);
+    if (mode == PaneLayout::Tabs && state_->config().ui.layout == "auto") {
+        // Which axis, and by how much. "Starting in tabs" on its own
+        // reads as an arbitrary decision; the numbers make it checkable
+        // and tell the operator what would have to change.
+        state_->log_event(
+            "app", log::Severity::Info,
+            tr("screen is %1x%2 and side by side needs %3x%4; starting in tabs "
+               "(View > Layout)")
+                .arg(available.width())
+                .arg(available.height())
+                .arg(required.width())
+                .arg(required.height()));
+    }
+    return mode;
+}
+
+QSize MainWindow::available_screen() const {
+    const QScreen* screen = this->screen();
+    return screen != nullptr ? screen->availableGeometry().size() : QSize();
+}
+
+void MainWindow::fit_to_screen() {
+    const QSize available = available_screen();
+    if (!available.isValid()) return;
+    // **The window may not open larger than the screen.** If it does,
+    // the menu bar goes off the edge with everything else, so View >
+    // Layout -- the way out of a layout that does not fit -- cannot be
+    // reached from inside the application at all. That is what an
+    // operator actually hit.
+    const QSize want = size();
+    const QSize fitted = want.boundedTo(available);
+    if (fitted == want) return;
+    resize(fitted);
+    state_->log_event("app", log::Severity::Info,
+                      tr("window would not fit the %1x%2 screen; opened at %3x%4")
+                          .arg(available.width())
+                          .arg(available.height())
+                          .arg(fitted.width())
+                          .arg(fitted.height()));
+}
+
+void MainWindow::on_layout_changed(PaneLayout mode) {
+    const bool tabbed = mode == PaneLayout::Tabs;
+    // The receive summary earns its place in the status bar only when
+    // the receive pane can be off screen. In split mode it would be the
+    // same words twice, an arm's length apart.
+    rx_status_label_->setVisible(tabbed);
+    if (split_action_ != nullptr) split_action_->setChecked(!tabbed);
+    if (tabs_action_ != nullptr) tabs_action_->setChecked(tabbed);
+}
+
+void MainWindow::on_rx_status(const QString& text) {
+    rx_status_text_ = text;
+    // Written unconditionally, *not* only while the label is visible.
+    // `QStatusBar` hides every non-permanent widget for the duration of
+    // a `showMessage` -- and this window posts one for five seconds
+    // after each saved reception. Skipping the update while hidden
+    // means an operator who presses Stop inside that window gets the
+    // message replaced by the line from *before* it, which in tabbed
+    // mode is their only view of a receiver that is no longer running.
+    rx_status_label_->setText(text);
+    // The tab label carries the short form, because the status bar is
+    // at the other end of the window from the tab the operator is
+    // deciding whether to look at.
+    panes_->set_first_note(rx_panel_->listening() ? tr("listening") : QString());
+}
+
+void MainWindow::choose_layout(PaneLayout mode) {
+    // An explicit choice ends "auto". Auto is a guess about the screen,
+    // and a person who has just answered the question should not be
+    // re-guessed at on the next launch -- including when they pick the
+    // layout auto would have picked anyway, since the screen may be a
+    // different one next time.
+    state_->config().ui.layout = mode == PaneLayout::Tabs ? "tabs" : "split";
+    state_->save_config();
+    panes_->set_mode(mode);
+}
 
 void MainWindow::build_menu() {
     // The explicit NoRole calls are load-bearing on macOS. Qt's Cocoa
@@ -93,17 +383,149 @@ void MainWindow::build_menu() {
     quit_action->setMenuRole(QAction::NoRole);
     quit_action->setShortcut(QKeySequence::Quit);
     connect(quit_action, &QAction::triggered, this, &MainWindow::close);
+
+    // View > Status log: the dock's own toggle action, so the menu
+    // entry and the dock's close button cannot disagree about state.
+    // The action is added in build_log_dock(), which runs after this;
+    // the menu pointer is kept on the window via findChild-free means.
+    view_menu_ = menuBar()->addMenu(tr("&View"));
+    build_layout_menu();
+
+    QMenu* help = menuBar()->addMenu(tr("&Help"));
+    QAction* about = help->addAction(tr("&About SSTVAE"));
+    about->setMenuRole(QAction::NoRole);  // as above: keep it in this menu
+    connect(about, &QAction::triggered, this, &MainWindow::show_about);
+}
+
+void MainWindow::restore_waterfall_height() {
+    const int wanted = state_->config().ui.waterfall_height;
+    // 0 means the operator has never dragged it. Qt's own initial split
+    // is a reasonable first answer, so leave it alone rather than
+    // inventing a default that would then look like a chosen value.
+    // Never dragged: pick a shallow default rather than letting Qt
+    // split the window evenly. The strip only needs enough rows to see
+    // a signal arrive -- history is what the handle is for.
+    const int height = wanted > 0 ? wanted : DEFAULT_WATERFALL_H;
+    const int total = stack_->height();
+    // Before the window is shown `height()` is not meaningful yet; the
+    // sizes are applied anyway and Qt scales them to the real height on
+    // the first layout, which is what makes this work from a
+    // constructor.
+    const int rest = std::max(1, total - height);
+    stack_->setSizes({height, rest});
+}
+
+void MainWindow::remember_waterfall_height() {
+    const QList<int> sizes = stack_->sizes();
+    if (sizes.isEmpty()) return;
+    if (state_->config().ui.waterfall_height == sizes.front()) return;
+    state_->config().ui.waterfall_height = sizes.front();
+    // Saved on the drag rather than at exit: an app that is killed --
+    // or that crashes in a backend -- still owes the operator the
+    // layout they set.
+    state_->save_config();
+}
+
+void MainWindow::show_about() {
+    // The version of the *library that talks to the radio* matters as
+    // much as ours: "which Hamlib" is the first question any rig
+    // problem raises, and an operator should not have to find a
+    // terminal to answer it. Same for the log's location, which is
+    // what a bug report needs attached.
+    QString text = tr("<b>SSTVAE</b><br>"
+                      "Image transmission over HF radio.<br><br>"
+                      "Hamlib %1<br>Qt %2")
+                       .arg(QString::fromStdString(rig::hamlib_version()),
+                            QString::fromLatin1(qVersion()));
+    const QString log_note = state_->log_file_note();
+    if (log_note.isEmpty()) {
+        text += tr("<br><br>Status log: %1").arg(state_->log_file_path());
+    } else {
+        text += QStringLiteral("<br><br>") + log_note;
+    }
+    QMessageBox::about(this, tr("About SSTVAE"), text);
 }
 
 void MainWindow::build_status_bar() {
     auto* bar = new QStatusBar(this);
     setStatusBar(bar);
+    // The PTT lamp: hidden except while the rig is keyed. Bold red
+    // text on the standard background -- a state indicator, not chrome
+    // -- because "the radio is transmitting" is the one state in the
+    // app that must be visible at a glance.
+    ptt_label_ = new QLabel(tr("TX"), this);
+    QFont ptt_font = ptt_label_->font();
+    ptt_font.setBold(true);
+    ptt_label_->setFont(ptt_font);
+    QPalette ptt_palette = ptt_label_->palette();
+    ptt_palette.setColor(QPalette::WindowText, QColor(0xb3, 0x26, 0x1e));
+    ptt_label_->setPalette(ptt_palette);
+    ptt_label_->hide();
+
+    // The receive summary, for tabbed mode -- hidden in split mode,
+    // where the receive pane is on screen saying the same thing.
+    // `Ignored` so a long reception line ("Receiving mode C: frame
+    // 431/440 (98%) -- SNR 12.4 dB de W1AW") cannot pin the window's
+    // minimum width, which is the whole reason the tabbed layout exists.
+    rx_status_label_ = new QLabel(QString(), this);
+    rx_status_label_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    rx_status_label_->hide();
+    bar->addWidget(rx_status_label_, 1);
+
     station_label_ = new QLabel(QString(), this);
     rig_label_ = new QLabel(tr("Rig control off"), this);
     model_label_ = new QLabel(tr("Loading model..."), this);
-    for (QLabel* label : {station_label_, rig_label_, model_label_}) {
+    for (QLabel* label : {ptt_label_, station_label_, rig_label_, model_label_}) {
         bar->addPermanentWidget(label);
     }
+
+    rig_error_timer_ = new QTimer(this);
+    rig_error_timer_->setInterval(5000);
+    connect(rig_error_timer_, &QTimer::timeout, this,
+            &MainWindow::refresh_rig_error_age);
+}
+
+void MainWindow::build_log_dock() {
+    log_pane_ = new LogPane(&state_->status_log(), this);
+    log_pane_->set_file_note(state_->log_file_note());
+    connect(state_, &AppState::logEntry, log_pane_, &LogPane::append);
+
+    log_dock_ = new QDockWidget(tr("Status log"), this);
+    // **One row, not two.** A QDockWidget's own title bar is a full row
+    // of height carrying nothing but a word and a close button, and the
+    // pane already had a row of its own for the filter and Copy. At the
+    // bottom of the window those two rows cost more than the log they
+    // introduce. The pane's row becomes the title bar, with the name
+    // and the close button folded into it.
+    log_dock_->setTitleBarWidget(log_pane_->take_title_row(tr("Status log"), log_dock_));
+    // Closable so it can be put away; not floatable or movable -- it is
+    // a log strip, not a tool window, and the bottom is its place.
+    log_dock_->setFeatures(QDockWidget::DockWidgetClosable);
+    log_dock_->setAllowedAreas(Qt::BottomDockWidgetArea);
+    log_dock_->setWidget(log_pane_);
+    addDockWidget(Qt::BottomDockWidgetArea, log_dock_);
+    view_menu_->addAction(log_dock_->toggleViewAction());
+
+    // An error re-opens a closed dock: the log is where the detail
+    // lives, and an error with the log hidden would be exactly the
+    // silent failure this pane exists to end.
+    connect(state_, &AppState::logEntry, this,
+            [this](qlonglong, const QString&, int severity, const QString&) {
+                if (severity == static_cast<int>(log::Severity::Error)) {
+                    log_dock_->show();
+                }
+            });
+
+    // Queued is mandatory, not a preference: the signal is emitted
+    // under the StatusLog lock, and this slot appends to that same log.
+    connect(
+        state_, &AppState::fileLogFailed, this,
+        [this](const QString& what) {
+            log_pane_->set_file_note(tr("(log file unavailable: %1)").arg(what));
+            state_->log_event("app", log::Severity::Error,
+                              tr("file log failed: %1").arg(what));
+        },
+        Qt::QueuedConnection);
 }
 
 void MainWindow::update_station_label() {
@@ -131,8 +553,72 @@ void MainWindow::on_model_loaded() {
     tx_panel_->sync_from_config();
 }
 
+void MainWindow::on_rig_status(const QString& text, bool error) {
+    if (error) {
+        rig_error_text_ = text;
+        rig_error_since_ms_ = QDateTime::currentMSecsSinceEpoch();
+        rig_label_->setText(text);
+        rig_error_timer_->start();
+    } else {
+        rig_error_text_.clear();
+        rig_error_timer_->stop();
+        rig_label_->setText(text);
+    }
+}
+
+void MainWindow::refresh_rig_error_age() {
+    if (rig_error_text_.isEmpty()) return;
+    const qint64 seconds =
+        (QDateTime::currentMSecsSinceEpoch() - rig_error_since_ms_) / 1000;
+    // The controller deduplicates identical failures and backs its poll
+    // off to a minute, so without this a stale error is indistinguishable
+    // from a fresh one.
+    rig_label_->setText(tr("%1 (%2 s ago)").arg(rig_error_text_).arg(seconds));
+}
+
+void MainWindow::on_model_progress(qlonglong received, qlonglong total) {
+    // The hook is global, so this fires for *every* artifact -- the
+    // decoder during the initial load, but also the encoder fetched
+    // lazily on the first Send and the gradient graph on the first
+    // refinement. The fetcher always ends with a final
+    // (size, size) call, which is the reset point: without it the
+    // label would read "downloading" for the rest of the session
+    // after any of those later fetches.
+    if (total > 0 && received >= total) {
+        model_label_->setText(state_->model() != nullptr
+                                  ? tr("Model ready")
+                                  : tr("Loading model..."));
+        return;
+    }
+    if (total > 0) {
+        model_label_->setText(tr("Model: downloading %1 / %2 MB")
+                                  .arg(received / 1e6, 0, 'f', 1)
+                                  .arg(total / 1e6, 0, 'f', 1));
+    } else {
+        model_label_->setText(
+            tr("Model: downloading %1 MB").arg(received / 1e6, 0, 'f', 1));
+    }
+}
+
+void MainWindow::on_tx_state(int phase) {
+    // Keyed is Keying through Unkeying inclusive: the lamp exists for
+    // "the radio is (or should be) transmitting right now".
+    const auto p = static_cast<tx::TxPhase>(phase);
+    const bool keyed = p == tx::TxPhase::Keying || p == tx::TxPhase::Sending ||
+                       p == tx::TxPhase::Unkeying;
+    ptt_label_->setVisible(keyed);
+}
+
 void MainWindow::open_settings() {
     SettingsDialog dialog(state_->config(), this);
+    // Test CAT / Test PTT results are shown in a message box the
+    // operator dismisses; the log keeps what it said.
+    connect(&dialog, &SettingsDialog::rigTestFinished, state_,
+            [this](bool ok, const QString& message) {
+                state_->log_event("rig",
+                                  ok ? log::Severity::Info : log::Severity::Error,
+                                  tr("rig test: %1").arg(message));
+            });
     if (dialog.exec() != QDialog::Accepted) return;
 
     // The sequence is the window's, not the dialog's: apply, save,

--- a/native/gui/main_window.hpp
+++ b/native/gui/main_window.hpp
@@ -1,8 +1,28 @@
 // The application window.
 //
-// A straight port of `MainWindow` in `sstvae/gui/app.py`: a tab widget
-// with the receive and transmit panels, a File menu, and a status bar
-// carrying callsign, rig and model state.
+// **The receive and transmit panels sit side by side in a splitter,
+// not in tabs.** The reference (and this port until now) put them in a
+// `QTabWidget`, which meant composing a picture was done blind: no
+// waterfall, no decode progress, no incoming preview. On the band that
+// is the wrong trade -- you prepare the next transmission *while*
+// listening, and the thing you most want to see while composing is
+// whether someone else is sending.
+//
+// **The price is the window's minimum width, and it is not small.** A
+// `QSplitter`'s minimum is the *sum* of its children's, not the max a
+// tab widget got away with, and a collapsed pane still counts because
+// it is not hidden. Measured with `sstvae-gui-shot`, which prints each
+// pane's `minimumSizeHint`: transmit 545, receive 464, so the window
+// floor is ~1015 px against ~738 before. Progress-tier labels are
+// therefore set `QSizePolicy::Ignored` wherever they would otherwise
+// pin a width -- that alone took transmit from 738 to 545.
+//
+// **Tabs remain available for a screen that cannot meet that floor**
+// (`ui.layout`, View > Layout). Scrolling inside the panes was the
+// other candidate and treats the symptom: the floor is a property of
+// the arrangement, and only the arrangement can move it. See
+// `pane_container.hpp` for the switch and why "auto" measures the
+// screen rather than the window.
 //
 // The wiring between the panels lives here rather than in either of
 // them, because all of it is about the pair: half duplex (our own
@@ -14,14 +34,23 @@
 #define SSTVAE_GUI_MAIN_WINDOW_HPP
 
 #include <QMainWindow>
+#include <QSize>
 
+#include "pane_container.hpp"
+
+class QAction;
+class QSplitter;
+class QDockWidget;
 class QLabel;
-class QTabWidget;
+class QMenu;
+class QTimer;
 
 namespace sstvae::gui {
 
 class AppState;
+class LogPane;
 class ReceivePanel;
+class Waterfall;
 class TransmitPanel;
 
 class MainWindow : public QMainWindow {
@@ -39,17 +68,68 @@ protected:
 
 private:
     void build_menu();
+    void build_layout_menu();
+    // Switch layout and record the operator's choice. Distinct from
+    // `PaneContainer::set_mode`, which is told what to do: this is the
+    // path that also stops the setting being "auto", because a person
+    // has now answered the question auto was guessing at.
+    void choose_layout(PaneLayout mode);
+    // What the config and the screen between them say to start in.
+    PaneLayout startup_layout() const;
+    // The screen's usable area, or an invalid size if the platform did
+    // not report one.
+    QSize available_screen() const;
+    // Shrink the window to the screen if it opened larger, and say so.
+    void fit_to_screen();
+    void on_layout_changed(PaneLayout mode);
+    // The receive status line, mirrored into the status bar while
+    // tabbed -- see `on_rx_status`.
+    void on_rx_status(const QString& text);
     void build_status_bar();
+    void build_log_dock();
     void update_station_label();
     void on_model_loaded();
+    void on_rig_status(const QString& text, bool error);
+    void on_model_progress(qlonglong received, qlonglong total);
+    void on_tx_state(int phase);
+    void show_about();
+    // The waterfall's share of the window, persisted so a handle set
+    // once stays set. Saved on every drag rather than at exit, because
+    // an app that is killed still owes the operator their layout.
+    void restore_waterfall_height();
+    void remember_waterfall_height();
+    void refresh_rig_error_age();
 
     AppState* state_ = nullptr;
-    QTabWidget* tabs_ = nullptr;
+    QSplitter* stack_ = nullptr;
+    PaneContainer* panes_ = nullptr;
+    Waterfall* waterfall_ = nullptr;
     ReceivePanel* rx_panel_ = nullptr;
     TransmitPanel* tx_panel_ = nullptr;
+    QLabel* ptt_label_ = nullptr;
     QLabel* station_label_ = nullptr;
     QLabel* rig_label_ = nullptr;
     QLabel* model_label_ = nullptr;
+    QDockWidget* log_dock_ = nullptr;
+    LogPane* log_pane_ = nullptr;
+    QMenu* view_menu_ = nullptr;
+    QAction* split_action_ = nullptr;
+    QAction* tabs_action_ = nullptr;
+
+    // The receive panel's own status line, shown in the status bar
+    // *only* while tabbed. Kept even in split mode so a switch mid
+    // reception has something to display at once rather than waiting
+    // for the next poll.
+    QLabel* rx_status_label_ = nullptr;
+    QString rx_status_text_;
+
+    // The rig label's error-age display: a CAT failure keeps its text,
+    // and this pair appends "(N s ago)" so a stale error cannot pass
+    // for a fresh one (the controller deduplicates identical repeats,
+    // so the text alone never says how old it is).
+    QString rig_error_text_;
+    qint64 rig_error_since_ms_ = 0;
+    QTimer* rig_error_timer_ = nullptr;
 };
 
 }  // namespace sstvae::gui

--- a/native/gui/overlay_editor.cpp
+++ b/native/gui/overlay_editor.cpp
@@ -1,13 +1,16 @@
 #include "overlay_editor.hpp"
 
 #include <QImage>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPen>
+#include <QResizeEvent>
 
 #include <algorithm>
 #include <cmath>
 #include <utility>
+#include <variant>
 
 #include "images/images.hpp"
 #include "overlay/render.hpp"
@@ -19,6 +22,15 @@ namespace {
 // Side of the square resize grip, in widget pixels.
 constexpr int HANDLE = 10;
 
+// The empty canvas, matching `PictureBox`'s empty state exactly so the
+// two panes look like a pair before either holds a picture. Kept in
+// step with picture_box.cpp by hand -- two constants rather than a
+// shared header, because the receive side is a palette on a QLabel and
+// this side is a painter fill, and a shared symbol would imply they are
+// applied the same way.
+const QColor EMPTY_CANVAS(0x20, 0x20, 0x24);
+const QColor EMPTY_CANVAS_TEXT(0x88, 0x88, 0x88);
+
 QImage to_qimage(const images::Picture& picture) {
     const QImage view(picture.rgb.data(), picture.width, picture.height,
                       picture.width * 3, QImage::Format_RGB888);
@@ -29,8 +41,34 @@ QImage to_qimage(const images::Picture& picture) {
 
 OverlayEditor::OverlayEditor(QWidget* parent) : QWidget(parent) {
     setMinimumSize(320, 240);
+    // **No `setHeightForWidth`.** It is the third form of the same
+    // ratchet as `setFixedHeight` (see picture_box.hpp), and the most
+    // deceptive, because `minimumSizeHint()` never consults it -- a
+    // test asserting on the hint sees nothing wrong. What Qt actually
+    // applies at layout time is `minimumHeightForWidth(width)`, and
+    // with the flag set that is `width * 3/4`.
+    //
+    // It stayed harmless for as long as it did because a `QSplitter`
+    // does not propagate `hasHeightForWidth` and a `QTabWidget` does.
+    // So the tabbed layout exposed it to the window for the first time,
+    // and measured on the container: at 900 px wide it demanded 1107 px
+    // of height, at 1400 px 1375, at **2020 px 1840**. The window grew
+    // past the bottom of the screen, and switching back to side by side
+    // did not shrink it again -- Qt lowers a minimum without resizing.
+    //
+    // Nothing is lost. `resizeEvent` caps the height at 4:3 (a maximum,
+    // which constrains nothing upward) and `canvas_rect()` letterboxes
+    // in both directions, so the canvas is still exactly 4:3 at any
+    // shape this widget is given.
+    // Expanding both ways: this is what absorbs the pane's spare
+    // room. It imposes no cap of its own -- `canvas_rect()` centres
+    // a 4:3 canvas in whatever it is given.
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setMouseTracking(false);
-    setFocusPolicy(Qt::ClickFocus);
+    // Strong, not ClickFocus: the arrow keys and Delete are useless to
+    // an operator who cannot get focus onto this widget, and ClickFocus
+    // keeps it out of the Tab chain entirely.
+    setFocusPolicy(Qt::StrongFocus);
 }
 
 OverlayEditor::~OverlayEditor() = default;
@@ -60,6 +98,10 @@ void OverlayEditor::add_text(const std::string& text) {
     item.text = text;
     doc_.items.push_back(item);
     select(static_cast<int>(doc_.items.size()) - 1);
+    // The button that ran this has the focus, so the keyboard would
+    // otherwise be dead on exactly the flow the nudge exists for --
+    // add a callsign, then line it up against another.
+    setFocus(Qt::OtherFocusReason);
     emit documentChanged();
 }
 
@@ -68,6 +110,10 @@ void OverlayEditor::add_image_inset(const std::string& path) {
     item.source = path;
     doc_.items.push_back(item);
     select(static_cast<int>(doc_.items.size()) - 1);
+    // The button that ran this has the focus, so the keyboard would
+    // otherwise be dead on exactly the flow the nudge exists for --
+    // add a callsign, then line it up against another.
+    setFocus(Qt::OtherFocusReason);
     emit documentChanged();
 }
 
@@ -75,6 +121,10 @@ void OverlayEditor::add_last_rx_inset() {
     overlay::ImageItem item;  // defaults to SOURCE_LAST_RX
     doc_.items.push_back(item);
     select(static_cast<int>(doc_.items.size()) - 1);
+    // The button that ran this has the focus, so the keyboard would
+    // otherwise be dead on exactly the flow the nudge exists for --
+    // add a callsign, then line it up against another.
+    setFocus(Qt::OtherFocusReason);
     emit documentChanged();
 }
 
@@ -185,14 +235,29 @@ void OverlayEditor::paintEvent(QPaintEvent*) {
 
     if (!composed_valid_) rerender();
     if (composed_.empty()) {
-        painter.fillRect(this->rect(), palette().window());
-        painter.setPen(palette().color(QPalette::Disabled, QPalette::WindowText));
-        painter.drawText(this->rect(), Qt::AlignCenter,
-                         tr("Choose a picture to send"));
+        // **Draw the empty canvas as a 4:3 box, not as nothing.** The
+        // two panes are locked to the same width so the pictures are
+        // the same size, but an empty composer that painted only its
+        // own background made one side a dark rectangle and the other
+        // a void -- so they measured equal and did not read equal. The
+        // same fill and the same disabled text as `PictureBox`, which
+        // is the receive side's empty state, so the pair is symmetric
+        // before either has a picture in it.
+        // Viewport, then the 4:3 frame inside it -- the composer has to
+        // show the shape it will send before anything is in it, for the
+        // same reason the receive box does.
+        painter.fillRect(this->rect(), EMPTY_CANVAS);
+        painter.fillRect(rect, QColor(0x31, 0x31, 0x3a));
+        painter.setPen(QColor(0x55, 0x55, 0x61));
+        painter.drawRect(rect.adjusted(0, 0, -1, -1));
+        painter.setPen(EMPTY_CANVAS_TEXT);
+        painter.drawText(rect, Qt::AlignCenter, tr("Choose a picture to send"));
         return;
     }
 
-    painter.fillRect(this->rect(), Qt::black);
+    // The same fill as the empty state, so the viewport around the
+    // canvas does not change colour the moment a picture arrives.
+    painter.fillRect(this->rect(), EMPTY_CANVAS);
     painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
     painter.drawImage(rect, to_qimage(composed_));
 
@@ -299,6 +364,68 @@ void OverlayEditor::mouseMoveEvent(QMouseEvent* event) {
 void OverlayEditor::mouseReleaseEvent(QMouseEvent* event) {
     Q_UNUSED(event);
     drag_ = Drag::None;
+}
+
+void OverlayEditor::resizeEvent(QResizeEvent* event) {
+    QWidget::resizeEvent(event);
+    // **Nothing here, deliberately.** This widget used to cap its own
+    // height at 4:3 -- first with `setFixedHeight`, which is a hard
+    // *minimum* and made a wide pane raise a window floor that
+    // narrowing never lowered (measured 611 px at 545 wide, 925 at
+    // 1348, 1274 at 1900); then with a maximum, which was safe but was
+    // still one of two caps on one property, so whichever `resizeEvent`
+    // ran last decided the size.
+    //
+    // Now the canvas is drawn *inside* the widget rather than being the
+    // widget, so none of it is needed: `canvas_rect()` letterboxes in
+    // both directions, the composer is exactly 4:3 at any shape this is
+    // handed, and nothing is imposed upward on the window.
+}
+
+void OverlayEditor::keyPressEvent(QKeyEvent* event) {
+    overlay::Item* item = selected_item();
+    if (item == nullptr) {
+        QWidget::keyPressEvent(event);
+        return;
+    }
+
+    if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace) {
+        remove_selected();
+        event->accept();
+        return;
+    }
+
+    // A fraction of the canvas, not a pixel: positions are normalized,
+    // so a fixed step means the same nudge whatever the window size.
+    // Shift is the coarse step, for getting somewhere; the fine one is
+    // roughly a canvas pixel at 640 wide.
+    constexpr double FINE = 1.0 / 640.0;
+    constexpr double COARSE = 1.0 / 64.0;
+    const double step =
+        (event->modifiers() & Qt::ShiftModifier) ? COARSE : FINE;
+
+    double dx = 0.0;
+    double dy = 0.0;
+    switch (event->key()) {
+        case Qt::Key_Left: dx = -step; break;
+        case Qt::Key_Right: dx = step; break;
+        case Qt::Key_Up: dy = -step; break;
+        case Qt::Key_Down: dy = step; break;
+        default:
+            QWidget::keyPressEvent(event);
+            return;
+    }
+
+    // The same clamp a drag uses, so an item cannot be nudged somewhere
+    // a drag could not have put it.
+    std::visit(
+        [dx, dy](auto& i) {
+            i.x = std::clamp(i.x + dx, -0.5, 1.5);
+            i.y = std::clamp(i.y + dy, -0.5, 1.5);
+        },
+        *item);
+    refresh_item();
+    event->accept();
 }
 
 }  // namespace sstvae::gui

--- a/native/gui/overlay_editor.hpp
+++ b/native/gui/overlay_editor.hpp
@@ -22,6 +22,7 @@
 #include <QRect>
 #include <QWidget>
 
+
 #include <optional>
 #include <string>
 
@@ -39,6 +40,24 @@ public:
     ~OverlayEditor() override;
 
     QSize sizeHint() const override;
+    // **No `heightForWidth`, deliberately.** It was here, with a
+    // comment saying a `QSplitter` ignores it -- true, and the reason it
+    // did no visible harm for as long as it did. A `QTabWidget`
+    // *propagates* it, so the tabbed layout handed the window a
+    // minimum height of `width * 3/4`: 1840 px at 2020 px wide,
+    // measured. The window grew off the bottom of the screen and did
+    // not come back when the layout was switched again, because Qt
+    // lowers a minimum without resizing.
+    //
+    // It is also the one form of the ratchet a test on
+    // `minimumSizeHint()` cannot see, since that never consults
+    // `heightForWidth` -- Qt applies `minimumHeightForWidth` at layout
+    // time instead. `test_overlay_editor.cpp` measures a *container's*
+    // `minimumHeightForWidth` for that reason.
+    //
+    // The 4:3 shape is kept by `resizeEvent` (a maximum, which
+    // constrains nothing upward) and by `canvas_rect()`, which
+    // letterboxes both ways.
 
     // The picture the overlay sits on, already framed to the transmit
     // size by the caller.
@@ -87,6 +106,14 @@ protected:
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
+    // Delete removes the selection; the arrows nudge it. Nudging is
+    // what a mouse cannot do: items are placed in normalized
+    // coordinates, so the smallest useful drag is one widget pixel,
+    // which is a different distance on every window size. A key press
+    // is a fixed fraction of the canvas, so two callsigns can actually
+    // be lined up.
+    void keyPressEvent(QKeyEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
 private:
     enum class Drag { None, Move, Resize };

--- a/native/gui/pane_container.cpp
+++ b/native/gui/pane_container.cpp
@@ -1,0 +1,253 @@
+#include "pane_container.hpp"
+
+#include <QFont>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLayout>
+#include <QResizeEvent>
+#include <QSizePolicy>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+#include <algorithm>
+#include <utility>
+
+namespace sstvae::gui {
+
+PaneLayout resolve_layout(const std::string& setting, QSize available,
+                          QSize split_minimum) {
+    if (setting == "split") return PaneLayout::Split;
+    if (setting == "tabs") return PaneLayout::Tabs;
+    // "auto", and anything else -- settings.cpp has already normalised
+    // an unrecognised value to "auto" and said so, so reaching here with
+    // one means the caller bypassed it, and auto is the safe answer.
+    //
+    // A screen whose width we could not learn (0 or negative) is not a
+    // small screen, it is an unanswered question; side by side is the
+    // better layout, so an unknown falls to it rather than to the
+    // fallback for a constraint nobody measured.
+    if (available.width() <= 0 || available.height() <= 0) return PaneLayout::Split;
+    const bool fits = split_minimum.width() <= available.width() &&
+                      split_minimum.height() <= available.height();
+    return fits ? PaneLayout::Split : PaneLayout::Tabs;
+}
+
+PaneContainer::PaneContainer(QWidget* first, QString first_title, QWidget* second,
+                             QString second_title, QWidget* parent)
+    : QWidget(parent),
+      first_(first),
+      second_(second),
+      first_title_(std::move(first_title)),
+      second_title_(std::move(second_title)) {
+    layout_ = new QVBoxLayout(this);
+    // No margins: this widget is pure structure, and the panes inside
+    // carry their own spacing.
+    layout_->setContentsMargins(0, 0, 0, 0);
+    install(build_split());
+    mode_ = PaneLayout::Split;
+}
+
+void PaneContainer::install(QWidget* container) {
+    container_ = container;
+    layout_->addWidget(container_);
+    // **Not redundant, and measured.** Every `addWidget`/`addTab` above
+    // performs a `QWidget::setParent`, which *hides* the widget; the
+    // thing that normally un-hides it is the parent transitioning from
+    // hidden to visible. On a mode switch the parent is already
+    // visible, so that transition never happens and nothing shows the
+    // new container -- the window renders empty and no call has failed.
+    // `test_pane_container.cpp` caught exactly this on its first run.
+    //
+    // One `show()` on the container is enough: `setParent` marks a
+    // widget hidden but not *explicitly* hidden, so showing an ancestor
+    // recursively shows it -- and a tab widget's background page, which
+    // its stacked layout hides deliberately, stays hidden.
+    container_->show();
+}
+
+QWidget* PaneContainer::titled(QWidget* content, const QString& title) {
+    auto* box = new QGroupBox(title);
+    // Bold, because this is the label that answers "which half am I
+    // looking at" and the boxes nested inside it are titled too. The
+    // font is the only change -- no stylesheet, no colour.
+    QFont heading = box->font();
+    heading.setBold(true);
+    box->setFont(heading);
+    auto* layout = new QVBoxLayout(box);
+    layout->setContentsMargins(6, 4, 6, 6);
+    // The content keeps the default weight; only the title is bold.
+    QFont body = content->font();
+    body.setBold(false);
+    content->setFont(body);
+    layout->addWidget(content);
+    return box;
+}
+
+QWidget* PaneContainer::build_split() {
+    tabs_ = nullptr;
+    // **Locked equal, and a plain layout rather than a splitter**
+    // (decided 2026-08-03). The complaint this answers is that the
+    // composer had roughly 2.5x the received picture's area, and the
+    // received picture is the one you cannot ask for again.
+    //
+    // A `QSplitter` cannot deliver "equal" on its own, and the reason is
+    // worth keeping: it satisfies both children's *minimum* widths
+    // before it applies any stretch factor. The transmit pane's minimum
+    // was far larger than the receive pane's, so a 1:1 weighting still
+    // produced 440 px against 1090 px -- which is what stalled this
+    // layout the first time it was attempted.
+    //
+    // The fix is to **equalise the minimums** rather than to ignore
+    // them. Give both panes the larger of the two floors and a 1:1
+    // stretch, and equal width follows arithmetically at every size:
+    // the layout satisfies two identical minimums and then splits what
+    // is left in half. Ignoring the demands instead would have "worked"
+    // by letting the wider pane's controls clip, which is trading a
+    // visible problem for a hidden one.
+    //
+    // It only became affordable once the transmit pane stopped asking
+    // for 1088 px (a duplicate properties box was sitting in its tool
+    // row); it now asks 547 against the receive pane's 464, so the
+    // shared floor costs the receive side 83 px rather than 624.
+    auto* row = new QWidget;
+    auto* layout = new QHBoxLayout(row);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(6);
+    QWidget* boxes[2] = {titled(first_, first_title_), titled(second_, second_title_)};
+    const int shared_floor =
+        std::max({PANE_MIN_W, boxes[0]->minimumSizeHint().width(),
+                  boxes[1]->minimumSizeHint().width()});
+    for (QWidget* pane : boxes) {
+        pane->setMinimumWidth(shared_floor);
+        layout->addWidget(pane, 1);
+    }
+    // Undo the tab widget's work, if we are coming back from it. A
+    // `QTabWidget` hides its background page with `hide()`, which marks
+    // it *explicitly* hidden -- and unlike the implicit hide a reparent
+    // leaves, showing an ancestor does not clear that. Without these
+    // two lines the pane that was in the background tab never comes
+    // back, and half the window is blank with nothing having failed.
+    // (Harmless on the first build, where nothing is hidden yet.)
+    first_->show();
+    second_->show();
+    return row;
+}
+
+QWidget* PaneContainer::build_tabs() {
+    auto* tabs = new QTabWidget;
+    tabs->addTab(first_, first_title_);
+    tabs->addTab(second_, second_title_);
+    tabs_ = tabs;
+    // Re-apply whatever note was current, so switching to tabs mid
+    // reception does not lose the one cue this mode has.
+    set_first_note(first_note_);
+    return tabs;
+}
+
+void PaneContainer::set_mode(PaneLayout mode) {
+    if (mode == mode_) return;
+
+    // Build first, delete second. The new container's addWidget/addTab
+    // reparents `first_` and `second_` out of the old one, so by the
+    // time it is deleted it owns neither -- and neither is ever left
+    // parentless, which is what would mark them explicitly hidden. See
+    // the header.
+    QWidget* previous = container_;
+    install(mode == PaneLayout::Tabs ? build_tabs() : build_split());
+    delete previous;
+
+    mode_ = mode;
+    emit modeChanged(mode_);
+}
+
+void PaneContainer::set_control_strips(QWidget* first_strip, QWidget* second_strip) {
+    first_strip_ = first_strip;
+    second_strip_ = second_strip;
+    equalise_strips();
+}
+
+// What a strip needs *at the width it has*.
+//
+// Not `sizeHint()`: the rows inside wrap, so a strip's height is a
+// function of its width, and `sizeHint` on a wrapping layout reports a
+// single line. Reading it gave both strips a one-row minimum and let
+// their real heights diverge -- which put the two pictures back to
+// different sizes at exactly the narrow widths the wrapping was added
+// to rescue.
+static int strip_height_for_width(QWidget* strip) {
+    QLayout* layout = strip->layout();
+    if (layout != nullptr && layout->hasHeightForWidth() && strip->width() > 0) {
+        return layout->minimumHeightForWidth(strip->width());
+    }
+    return strip->sizeHint().height();
+}
+
+void PaneContainer::equalise_strips() {
+    QWidget* a = first_strip_.data();
+    QWidget* b = second_strip_.data();
+    if (a == nullptr || b == nullptr) return;
+
+    // **Settle, rather than measure once.** Raising a strip's minimum
+    // takes height from the picture above it, which re-lays the pane
+    // out -- and with wrapping rows, a strip's required height depends
+    // on the width it ends up with. One pass measured a width the panes
+    // no longer had, so at narrow sizes the two strips kept different
+    // row counts and the pictures came out 521 against 444.
+    //
+    // Two extra passes is enough for the widths to stop moving (they
+    // are fixed by the panes, which are locked equal); the loop exits
+    // early when nothing changed, so the common case is one pass.
+    for (int pass = 0; pass < 3; ++pass) {
+        // Released before measuring: carrying the last pass's minimum
+        // in would ratchet the strips taller and never let them shrink.
+        a->setMinimumHeight(0);
+        b->setMinimumHeight(0);
+        if (a->layout() != nullptr) a->layout()->activate();
+        if (b->layout() != nullptr) b->layout()->activate();
+        const int tallest =
+            std::max(strip_height_for_width(a), strip_height_for_width(b));
+        if (tallest <= 0) return;
+        const bool settled = a->minimumHeight() == tallest && b->minimumHeight() == tallest;
+        a->setMinimumHeight(tallest);
+        b->setMinimumHeight(tallest);
+        if (settled) return;
+        // **Re-run the panes, not just the strips.** Raising a strip's
+        // minimum changes how much is left for the picture above it, and
+        // that division is made by the *pane's* layout. Activating only
+        // the strip and the container left the receive pane still
+        // holding the picture height it computed before the minimum
+        // existed -- so its strip ran 68 px off the bottom of the pane
+        // and the two pictures came out 521 against 444.
+        for (QWidget* pane : {first_, second_}) {
+            if (pane->layout() != nullptr) pane->layout()->activate();
+        }
+        if (layout() != nullptr) layout()->activate();
+    }
+}
+
+void PaneContainer::resizeEvent(QResizeEvent* event) {
+    QWidget::resizeEvent(event);
+    // Queued: a resize event arrives *before* Qt lays the children out,
+    // so measuring here would read the previous pass's widths -- and
+    // strip height now depends on width. One in flight at a time, since
+    // a drag emits a resize per pixel.
+    if (equalise_queued_) return;
+    equalise_queued_ = true;
+    QMetaObject::invokeMethod(
+        this,
+        [this] {
+            equalise_queued_ = false;
+            equalise_strips();
+        },
+        Qt::QueuedConnection);
+}
+
+void PaneContainer::set_first_note(const QString& note) {
+    first_note_ = note;
+    if (tabs_ == nullptr) return;
+    tabs_->setTabText(0, note.isEmpty() ? first_title_
+                                        : QStringLiteral("%1 (%2)")
+                                              .arg(first_title_, note));
+}
+
+}  // namespace sstvae::gui

--- a/native/gui/pane_container.hpp
+++ b/native/gui/pane_container.hpp
@@ -1,0 +1,157 @@
+// Holds the receive and transmit halves, either side by side or in tabs.
+//
+// **Why this is a widget of its own rather than four lines in
+// `MainWindow`.** The switch is the part that can be wrong, and every
+// way it can be wrong is invisible: a panel deleted along with its old
+// container (taking a decode thread with it), a panel that survives but
+// comes back hidden, or a "small screen" mode whose minimum width is no
+// smaller than the one it replaced. None of those look like bugs in a
+// screenshot -- the first two crash or blank later, and the third is a
+// feature that silently does nothing. Behind a class they are all
+// reachable from a test with two plain `QWidget`s and no engines,
+// which is what `tests/test_pane_container.cpp` does.
+//
+// **The structural fact this exists for:** a `QSplitter`'s minimum
+// width is the *sum* of its children's and a collapsed pane still
+// counts (it is not hidden); a `QTabWidget`'s is the *max*. So tabs are
+// the only arrangement that fits both halves on a narrow panel, and no
+// amount of scrolling inside the panes changes that. Side by side stays
+// the default because it is the better layout -- on this mode you
+// prepare the next picture while listening to the current reception.
+//
+// **The order of operations in `set_mode` is load-bearing**: the new
+// container is built *first*, which reparents the two content widgets
+// out of the old one, and only then is the old container deleted. The
+// obvious alternative -- detach with `setParent(nullptr)`, delete, then
+// re-add -- sets Qt's explicit-hidden flag on both panels, and a widget
+// hidden that way stays hidden when it is added to a visible layout.
+
+#ifndef SSTVAE_GUI_PANE_CONTAINER_HPP
+#define SSTVAE_GUI_PANE_CONTAINER_HPP
+
+#include <QPointer>
+#include <QSize>
+#include <QString>
+#include <QWidget>
+
+#include <string>
+
+class QTabWidget;
+class QVBoxLayout;
+
+namespace sstvae::gui {
+
+enum class PaneLayout {
+    Split,  // side by side in a splitter
+    Tabs,   // one at a time
+};
+
+// Which layout a config setting asks for, given the room available.
+//
+// `setting` is `ui.layout`: "split" and "tabs" are the operator's
+// explicit choice and are honoured whatever the screen says -- an
+// operator who wants both halves on a small panel may scroll the window
+// off the edge if they like, and one who prefers tabs on a large screen
+// is not overruled. Only "auto" measures.
+//
+// **Both axes.** It compared width only, which was defensible while the
+// split layout's height floor was fixed. It is not once the control rows
+// wrap: the height floor then *rises* as the window narrows, so a screen
+// that is wide enough and short enough would get side by side and not
+// fit. Either axis failing is enough to choose tabs.
+//
+// **"auto" is resolved against the screen, once, and never against the
+// window's own width.** A live breakpoint reads like the obvious
+// implementation and cannot work: while side by side is in force, the
+// splitter's minimum is exactly what stops the window reaching the
+// narrow width that would trigger a switch away from it. The downward
+// transition is unreachable, so the layout would only ever get *more*
+// cramped, never less.
+PaneLayout resolve_layout(const std::string& setting, QSize available,
+                          QSize split_minimum);
+
+class PaneContainer : public QWidget {
+    Q_OBJECT
+
+public:
+    // Lower bound on each pane's width when side by side. The actual
+    // floor is the larger of this and what either pane asks for -- both
+    // panes then share one minimum, which is what makes a 1:1 stretch
+    // produce genuinely equal widths. See `build_split`.
+    static constexpr int PANE_MIN_W = 380;
+
+    // `first` and `second` are shown in that order, left to right or as
+    // tabs. Ownership passes to this widget's current container, and
+    // survives every mode switch -- see the class comment.
+    PaneContainer(QWidget* first, QString first_title, QWidget* second,
+                  QString second_title, QWidget* parent = nullptr);
+
+    // The two panes' control strips, held to the same height.
+    //
+    // **This is how the pictures end up equal**, and it is the whole
+    // mechanism. The panes are already locked to the same width; make
+    // the controls beneath them the same height and each picture gets
+    // `pane - strip`, the same number on both sides, without anything
+    // being cut down to match.
+    //
+    // The approach this replaced measured the two *pictures* and shrank
+    // the larger to the smaller. That produced equal pictures and threw
+    // away the space it took -- 650x480 where 970x727 was available,
+    // the difference showing as grey margin. Equalising the thing that
+    // actually differs is both smaller and better.
+    //
+    // Optional: a test may drive this class with plain widgets.
+    void set_control_strips(QWidget* first_strip, QWidget* second_strip);
+
+    PaneLayout mode() const { return mode_; }
+    void set_mode(PaneLayout mode);
+
+    // Append a parenthesised note to the first tab's label, e.g.
+    // "Receive (receiving)". No-op in split mode, where the pane is on
+    // screen and needs no summary. Empty clears it.
+    void set_first_note(const QString& note);
+
+signals:
+    void modeChanged(PaneLayout mode);
+
+protected:
+    void resizeEvent(QResizeEvent* event) override;
+
+
+private:
+    // Give both strips the taller one's height. Cheap and idempotent,
+    // so it can be called again whenever a caption or a font could have
+    // changed the answer.
+    void equalise_strips();
+
+
+    QWidget* build_split();
+    QWidget* build_tabs();
+    // Make `container` the one on screen. The explicit `show()` inside
+    // is load-bearing on every switch after the first -- see the .cpp.
+    void install(QWidget* container);
+    // A pane wrapped in a titled box, so which half is which is read
+    // rather than inferred from a button caption. Split mode only: a
+    // tab label already says it, and a second copy inside the tab would
+    // spend a line of height saying nothing.
+    QWidget* titled(QWidget* content, const QString& title);
+
+    QVBoxLayout* layout_ = nullptr;
+    QWidget* container_ = nullptr;
+    QTabWidget* tabs_ = nullptr;  // null unless mode_ == Tabs
+
+    QWidget* first_ = nullptr;
+    QWidget* second_ = nullptr;
+    QPointer<QWidget> first_strip_;
+    QPointer<QWidget> second_strip_;
+    QString first_title_;
+    QString second_title_;
+    QString first_note_;
+
+    bool equalise_queued_ = false;
+    PaneLayout mode_ = PaneLayout::Split;
+};
+
+}  // namespace sstvae::gui
+
+#endif

--- a/native/gui/picture_box.cpp
+++ b/native/gui/picture_box.cpp
@@ -1,0 +1,98 @@
+#include "picture_box.hpp"
+
+#include <QLabel>
+#include <QPalette>
+#include <QPainter>
+#include <QResizeEvent>
+#include <QSizePolicy>
+
+#include <algorithm>
+
+#include "images/images.hpp"
+
+namespace sstvae::gui {
+
+PictureBox::PictureBox(const QString& text, QWidget* parent) : QWidget(parent) {
+    // **The dark fills the whole widget**, not just the picture. The
+    // spare width in a pane wider than 4:3 needs then reads as viewport
+    // rather than as a gap someone forgot to close -- and it lets this
+    // widget stop caring about its own height, which is what retired
+    // the cap that kept fighting the layout.
+    //
+    // Palette, not a stylesheet: a stylesheet anywhere makes Qt wrap the
+    // application style in QStyleSheetStyle, which resets padding to
+    // zero across every combo and spin box in the app -- including the
+    // settings dialog, which has nothing to do with this widget.
+    setAutoFillBackground(true);
+    QPalette dark = palette();
+    dark.setColor(QPalette::Window, QColor(0x20, 0x20, 0x24));
+    dark.setColor(QPalette::WindowText, QColor(0x88, 0x88, 0x88));
+    setPalette(dark);
+
+    label_ = new QLabel(text, this);
+    label_->setAlignment(Qt::AlignCenter);
+    // Transparent: the box behind it is already the right colour, and a
+    // second opaque rectangle would put a visible seam at the 4:3 edge.
+    label_->setAttribute(Qt::WA_TranslucentBackground);
+
+    // Expanding in both directions: this is the thing that should absorb
+    // the pane's spare room. It asks for 4:3 through `sizeHint` and is
+    // content with anything.
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+}
+
+QSize PictureBox::sizeHint() const {
+    return QSize(width(), std::max(MIN_H, width() * images::IMG_H / images::IMG_W));
+}
+
+void PictureBox::set_picture(const QPixmap& picture) {
+    source_ = picture;
+    rescale();
+}
+
+QRect PictureBox::picture_rect() const { return label_->geometry(); }
+
+void PictureBox::resizeEvent(QResizeEvent* event) {
+    QWidget::resizeEvent(event);
+
+    // The largest 4:3 rectangle that fits, centred. No height cap, no
+    // external limit, nothing imposed upward -- this widget's only job
+    // is to place a rectangle inside whatever it was handed.
+    int w = width();
+    int h = height();
+    if (w * images::IMG_H > h * images::IMG_W) {
+        w = h * images::IMG_W / images::IMG_H;
+    } else {
+        h = w * images::IMG_H / images::IMG_W;
+    }
+    label_->setGeometry((width() - w) / 2, (height() - h) / 2, w, h);
+
+    // Rescaled here rather than from the panel's resizeEvent, which is a
+    // staleness trap: by this point the label's geometry is the one it
+    // will keep.
+    rescale();
+}
+
+void PictureBox::paintEvent(QPaintEvent* event) {
+    QWidget::paintEvent(event);
+    if (!source_.isNull()) return;  // the picture is its own frame
+
+    QPainter painter(this);
+    const QRect frame = label_->geometry();
+    // A shade lighter than the viewport, plus a hairline: enough to read
+    // as "the picture goes here" without competing with a picture once
+    // one arrives. Colours from the palette this widget already carries,
+    // never a stylesheet -- one stylesheet anywhere re-styles every combo
+    // and spin box in the application.
+    painter.fillRect(frame, QColor(0x31, 0x31, 0x3a));
+    painter.setPen(QColor(0x55, 0x55, 0x61));
+    painter.drawRect(frame.adjusted(0, 0, -1, -1));
+}
+
+void PictureBox::rescale() {
+    if (source_.isNull()) return;
+    label_->setPixmap(
+        source_.scaled(label_->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+}
+
+}  // namespace sstvae::gui

--- a/native/gui/picture_box.hpp
+++ b/native/gui/picture_box.hpp
@@ -1,0 +1,79 @@
+// The received picture: a dark viewport that fills its share of the
+// pane, with the 4:3 picture centred inside it.
+//
+// **The box is not the picture** (decided 2026-08-03). It used to be --
+// the widget was sized to exactly 4:3, so pane colour showed at the
+// sides whenever the pane was wider than the picture needed. That reads
+// as a gap someone forgot to close rather than as a choice, and it
+// forced this widget to impose a 4:3 *height cap* on the layout, which
+// is where a long run of sizing bugs came from: a cap is one more thing
+// that can fight another cap, and with two on one property whichever
+// `resizeEvent` ran last won.
+//
+// Filling the area retires all of it. This widget asks for nothing in
+// particular, takes what the layout gives it, and centres a 4:3
+// rectangle in the middle. Two of these come out the same size when
+// their panes are the same width and the controls below them are the
+// same height -- a property of the *layout*, checkable in one place,
+// rather than an agreement between two widgets that has to be
+// maintained.
+//
+// No Q_OBJECT: plain virtual overrides, nothing for moc to do.
+
+#ifndef SSTVAE_GUI_PICTURE_BOX_HPP
+#define SSTVAE_GUI_PICTURE_BOX_HPP
+
+#include <QPixmap>
+#include <QString>
+#include <QWidget>
+
+class QLabel;
+
+namespace sstvae::gui {
+
+class PictureBox : public QWidget {
+public:
+    // Small, and constant. The floor stops the box vanishing in a very
+    // short window; it deliberately does not follow the width, because
+    // a minimum that follows the width is a ratchet -- see
+    // `overlay_editor.hpp` for what that one cost.
+    static constexpr int MIN_W = 160;
+    static constexpr int MIN_H = 120;
+
+    explicit PictureBox(const QString& text, QWidget* parent = nullptr);
+
+    // What a 4:3 picture would like at this width. Preferred only: the
+    // layout may give more (the surplus becomes viewport) or less (the
+    // picture narrows to stay 4:3).
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override { return QSize(MIN_W, MIN_H); }
+
+    // The picture at its own size. Kept unscaled, so a resize rescales
+    // from the original rather than compounding losses.
+    void set_picture(const QPixmap& picture);
+
+    // The 4:3 rectangle inside this widget -- what a viewer would call
+    // "the picture", as distinct from the viewport around it. For tests:
+    // an inverted axis or a dropped centring offset still looks like a
+    // working preview until something is in it.
+    QRect picture_rect() const;
+
+protected:
+    void resizeEvent(QResizeEvent* event) override;
+    // Draws the viewport and, inside it, the 4:3 frame the picture will
+    // occupy. **The frame has to be visible before there is a picture**:
+    // once the box started filling the pane there was nothing on screen
+    // showing where a 640x480 would land, so an empty pane gave no clue
+    // what shape it was going to be.
+    void paintEvent(QPaintEvent* event) override;
+
+private:
+    void rescale();
+
+    QLabel* label_ = nullptr;
+    QPixmap source_;
+};
+
+}  // namespace sstvae::gui
+
+#endif

--- a/native/gui/rx_panel.cpp
+++ b/native/gui/rx_panel.cpp
@@ -1,6 +1,7 @@
 #include "rx_panel.hpp"
 
 #include <QCheckBox>
+#include <QDesktopServices>
 #include <QSignalBlocker>
 #include <QFileDialog>
 #include <QGroupBox>
@@ -13,9 +14,12 @@
 #include <QResizeEvent>
 #include <QSizePolicy>
 #include <QSplitter>
+#include <QTime>
 #include <QTimer>
+#include <QUrl>
 #include <QVBoxLayout>
 
+#include <algorithm>
 #include <cmath>
 #include <exception>
 #include <filesystem>
@@ -24,8 +28,11 @@
 #include "app_state.hpp"
 #include "audio/qt/qtaudio.hpp"
 #include "audio/wavio.hpp"
+#include "banner.hpp"
 #include "codec/codec.hpp"
 #include "images/images.hpp"
+#include "flow_layout.hpp"
+#include "picture_box.hpp"
 #include "settings/settings.hpp"
 #include "waterfall.hpp"
 
@@ -57,6 +64,19 @@ fs::path unique_path(fs::path path) {
     return path;
 }
 
+// SNR for display, with a placeholder when there is none.
+//
+// `rx::fmt_snr` returns an empty string for NaN, which is right for it
+// -- it mirrors Python's and feeds the CLI. But on screen an absent
+// field is indistinguishable from a field that was never going to be
+// there: the operator cannot tell "no SNR estimate yet" from "this
+// build does not show SNR". The engine formats; the panel decides how
+// to show absence.
+QString snr_text(double snr_db) {
+    const QString formatted = QString::fromStdString(rx::fmt_snr(snr_db));
+    return formatted.isEmpty() ? QStringLiteral("  SNR --") : formatted;
+}
+
 }  // namespace
 
 ReceivePanel::ReceivePanel(AppState* state, QWidget* parent)
@@ -78,50 +98,69 @@ ReceivePanel::ReceivePanel(AppState* state, QWidget* parent)
 ReceivePanel::~ReceivePanel() { stop(); }
 
 void ReceivePanel::build_ui() {
-    // Picture on the left, waterfall down the right -- the same shape as
-    // the transmit panel. The pictures are 4:3, so on the wide monitor
-    // most people have, stacking the waterfall on top would leave the
-    // sides empty and squeeze the thing you actually want to look at.
+    // Picture, then a control strip -- and nothing else. The waterfall
+    // used to be at the top of this pane in its own vertical splitter;
+    // it now spans the whole window and belongs to `MainWindow`, which
+    // drives it through `attach_waterfall`.
+    //
+    // The strip is the unit whose height the container matches against
+    // the transmit pane's, so everything below the picture has to be
+    // inside it. The picture then takes the rest, which is the same
+    // number on both sides.
     auto* layout = new QVBoxLayout(this);
-    auto* splitter = new QSplitter(Qt::Horizontal, this);
 
-    auto* left = new QWidget(splitter);
-    auto* left_layout = new QVBoxLayout(left);
-    left_layout->setContentsMargins(0, 0, 0, 0);
+    // The error tier: sticky, dismissable, and never overwritten by the
+    // 500 ms status refresh below -- which is exactly what happened to
+    // every receive error before (visible for at most half a second).
+    // **Over the picture, not above it.** In the layout it displaced
+    // everything below it -- so an error in one pane pushed that pane's
+    // picture down and the two stopped lining up, which is precisely
+    // what the equal-size work exists to prevent. Floating it costs no
+    // layout at all: it appears, it is dismissed, and nothing moves.
+    banner_ = new ErrorBanner(this);
+    banner_->hide();
 
-    auto* preview_box = new QGroupBox(tr("Picture"), left);
-    auto* preview_layout = new QVBoxLayout(preview_box);
-    preview_ = new QLabel(tr("Nothing received yet"), preview_box);
-    preview_->setAlignment(Qt::AlignCenter);
-    preview_->setMinimumHeight(240);
-    preview_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    // Palette, not a stylesheet: a stylesheet anywhere makes Qt wrap the
-    // application style in QStyleSheetStyle, which resets padding to
-    // zero across every combo and spin box in the app -- including the
-    // settings dialog, which has nothing to do with this widget.
-    preview_->setAutoFillBackground(true);
-    QPalette dark = preview_->palette();
-    dark.setColor(QPalette::Window, QColor(0x20, 0x20, 0x24));
-    dark.setColor(QPalette::WindowText, QColor(0x88, 0x88, 0x88));
-    preview_->setPalette(dark);
-    preview_layout->addWidget(preview_);
-    left_layout->addWidget(preview_box, 1);
+    // No inner "Picture" box: the pane itself is titled, and a group
+    // box between the layout and the picture would swallow the room the
+    // picture is supposed to be taking.
+    preview_ = new PictureBox(tr("Nothing received yet"), this);
+    // Stretch 1 and no trailing spacer: the picture *is* what the spare
+    // room is for. Everything else lives in the strip below, whose
+    // height is fixed by agreement with the transmit pane.
+    layout->addWidget(preview_);
 
-    status_ = new QLabel(tr("Stopped"), left);
-    left_layout->addWidget(status_);
+    strip_ = new QWidget(this);
+    auto* lower_layout = new QVBoxLayout(strip_);
+    lower_layout->setContentsMargins(0, 0, 0, 0);
+    lower_layout->setSpacing(4);
+    QWidget* lower = strip_;
 
-    progress_ = new QProgressBar(left);
+    status_ = new QLabel(tr("Stopped"), lower);
+    // A progress-tier surface must not set a width floor. Its longest
+    // line ("Receiving mode C: frame 220/220 ... de KD8XYZ") is ~400 px,
+    // and both panes are locked to one width, so every such floor is
+    // paid twice. Errors go to the banner, so what clips here is
+    // progress text that is rebuilt twice a second anyway.
+    status_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    lower_layout->addWidget(status_);
+
+    progress_ = new QProgressBar(lower);
     progress_->setRange(0, 100);
-    left_layout->addWidget(progress_);
+    lower_layout->addWidget(progress_);
 
-    waterfall_ = new Waterfall(splitter);
-    splitter->addWidget(left);
-    splitter->addWidget(waterfall_);
-    splitter->setStretchFactor(0, 3);
-    splitter->setStretchFactor(1, 1);
-    layout->addWidget(splitter, 1);
+    // The last completed reception's details, which nothing kept
+    // before: the engine wipes mode, callsign and SNR from its shared
+    // state two seconds after a reception finishes, so the "Complete
+    // SNR x" line erased itself while the operator was still looking at
+    // the picture it described.
+    last_card_ = new QLabel(lower);
+    last_card_->setTextFormat(Qt::PlainText);
+    last_card_->setWordWrap(true);
+    last_card_->setEnabled(false);  // reads as secondary until it has content
+    lower_layout->addWidget(last_card_);
 
-    auto* controls = new QHBoxLayout();
+    // Wraps rather than crushes -- see flow_layout.hpp.
+    auto* controls = new FlowLayout();
     start_button_ = new QPushButton(tr("Start receiving"), this);
     connect(start_button_, &QPushButton::clicked, this, &ReceivePanel::start);
     stop_button_ = new QPushButton(tr("Stop"), this);
@@ -130,6 +169,11 @@ void ReceivePanel::build_ui() {
     save_button_ = new QPushButton(tr("Save image"), this);
     connect(save_button_, &QPushButton::clicked, this, &ReceivePanel::save_current);
     save_button_->setEnabled(false);
+    folder_button_ = new QPushButton(tr("Show folder"), this);
+    folder_button_->setToolTip(tr("Open the folder holding the last saved picture"));
+    connect(folder_button_, &QPushButton::clicked, this,
+            &ReceivePanel::open_saved_folder);
+    folder_button_->setEnabled(false);
     autosave_ = new QCheckBox(tr("Autosave"), this);
     autosave_->setChecked(app_->config().receive.autosave);
     connect(autosave_, &QCheckBox::toggled, this,
@@ -138,9 +182,32 @@ void ReceivePanel::build_ui() {
     controls->addWidget(start_button_);
     controls->addWidget(stop_button_);
     controls->addWidget(save_button_);
+    controls->addWidget(folder_button_);
     controls->addWidget(autosave_);
-    controls->addStretch(1);
-    layout->addLayout(controls);
+    // Into the strip, not the panel: the strip is the unit whose height
+    // is matched against the transmit pane's, so anything left outside
+    // it would break the equality it exists to give.
+    lower_layout->addLayout(controls);
+
+    layout->addWidget(strip_);
+}
+
+void ReceivePanel::resizeEvent(QResizeEvent* event) {
+    QWidget::resizeEvent(event);
+    place_banner();
+}
+
+void ReceivePanel::place_banner() {
+    if (banner_ == nullptr || preview_ == nullptr) return;
+    const QRect over = preview_->geometry();
+    // `heightForWidth`, not `sizeHint`: the message wraps, and a hint
+    // taken at unconstrained width is one line -- so a long device name
+    // was clipped to a sliver of its own text. Measured at the width it
+    // will actually get.
+    const int wanted = banner_->heightForWidth(over.width());
+    banner_->setGeometry(over.x(), over.y(), over.width(),
+                         std::max(banner_->sizeHint().height(), wanted));
+    banner_->raise();
 }
 
 bool ReceivePanel::listening() const { return running_.load(); }
@@ -166,17 +233,31 @@ bool ReceivePanel::start() {
 
     const settings::Config& config = app_->config();
     ring_ = std::make_shared<rx::RingBuffer>(config.receive.buffer_seconds);
-    waterfall_->set_ring(ring_);
+    if (Waterfall* w = fall()) w->set_ring(ring_);
 
     try {
         stream_ = std::make_unique<audio::qt::InputStream>(
             config.audio.input_device, *ring_, config::FS,
+            // What opened, and at what rate: information. The resampler
+            // being in the path is the normal case -- very little
+            // hardware is natively 8 kHz -- and a sticky red banner
+            // saying so told operators their setup was broken when it
+            // was working.
+            [this](const std::string& message) {
+                app_->log_event("rx", log::Severity::Info,
+                                QString::fromStdString(message));
+            },
+            // Capture actually failing: banner and log, as before. This
+            // is the half that must not be quiet.
             [this](const std::string& message) {
                 emit errorOccurred(QString::fromStdString(message));
             });
     } catch (const std::exception& e) {
-        waterfall_->set_ring(nullptr);
+        if (Waterfall* w = fall()) w->set_ring(nullptr);
         ring_.reset();
+        app_->log_event("rx", log::Severity::Error,
+                        tr("could not open the input device: %1")
+                            .arg(QString::fromUtf8(e.what())));
         QMessageBox::critical(
             this, tr("Could not open the input device"),
             tr("%1\n\nCheck the input device in Settings.")
@@ -227,12 +308,23 @@ bool ReceivePanel::start() {
 
     start_button_->setEnabled(false);
     stop_button_->setEnabled(true);
-    status_->setText(tr("Listening at %1 Hz").arg(device_rate));
+    set_status(tr("Listening at %1 Hz").arg(device_rate));
+    // A clean restart of the activity clears its error banner; the log
+    // keeps the history.
+    banner_->clear();
+    was_receiving_ = false;
+    app_->log_event("rx", log::Severity::Info,
+                    tr("listening (device at %1 Hz)").arg(device_rate));
     emit listeningChanged(true);
     return true;
 }
 
 void ReceivePanel::stop() {
+    // Idempotence matters here: closeEvent stops the panel and the
+    // destructor stops it again, and only the transition from "was
+    // actually listening" deserves a log line.
+    const bool was_listening = thread_.joinable();
+
     stop_flag_.set();
     // The stream first: it is what feeds the loop, and stopping it means
     // the loop's next poll sees no new audio rather than racing us.
@@ -240,31 +332,52 @@ void ReceivePanel::stop() {
     if (thread_.joinable()) thread_.join();
     running_.store(false);
 
-    if (waterfall_ != nullptr) waterfall_->set_ring(nullptr);
+    if (Waterfall* w = fall()) w->set_ring(nullptr);
     ring_.reset();
 
     if (start_button_ != nullptr) {
         start_button_->setEnabled(true);
         stop_button_->setEnabled(false);
-        status_->setText(tr("Stopped"));
+        set_status(tr("Stopped"));
     }
-    emit listeningChanged(false);
+    if (was_listening) {
+        app_->log_event("rx", log::Severity::Info, tr("stopped"));
+        emit listeningChanged(false);
+    }
 }
 
 void ReceivePanel::suspend_for_transmit() {
     if (!listening()) return;
     suspended_for_tx_ = true;
     stop();
-    status_->setText(tr("Paused -- transmitting"));
+    // This pane is on screen throughout the over now, so a half-duplex
+    // pause has to look deliberate rather than like a receiver that
+    // died: the waterfall stops dead when the ring goes away, and
+    // without this it is the same picture as a wedged capture.
+    set_status(tr("Paused -- transmitting"));
+    preview_->setEnabled(false);
+    if (Waterfall* w = fall()) w->setEnabled(false);
+    // And the button that would undo half duplex. `stop()` re-enables
+    // it on its way through, and this pane is now in front of the
+    // operator for the whole over: clicking Start here would open
+    // capture while the rig is keyed, feed our own transmission to the
+    // decoder, and -- because `start()` returns early when already
+    // listening -- deny `resume_after_transmit` the fresh ring buffer
+    // that is what keeps the tail of our own signal out of a
+    // "reception".
+    start_button_->setEnabled(false);
 }
 
 void ReceivePanel::resume_after_transmit() {
     if (!suspended_for_tx_) return;
     suspended_for_tx_ = false;
+    preview_->setEnabled(true);
+    if (Waterfall* w = fall()) w->setEnabled(true);
+    start_button_->setEnabled(true);  // start() disables it again
     // start() allocates a fresh ring buffer, so the tail of our own
     // transmission is dropped rather than decoded back as a reception.
     start();
-    waterfall_->clear();
+    if (Waterfall* w = fall()) w->clear();
 }
 
 // --- the sink, on the decode thread -----------------------------------------
@@ -339,9 +452,37 @@ void ReceivePanel::save_audio_beside(const std::string& image_path) {
 
 // --- the GUI thread ---------------------------------------------------------
 
+QWidget* ReceivePanel::picture_area() const { return preview_; }
+
+QWidget* ReceivePanel::control_strip() const { return strip_; }
+
+void ReceivePanel::set_status(const QString& text) {
+    status_->setText(text);
+    emit statusChanged(text);
+}
+
 void ReceivePanel::refresh_status() {
     if (!listening()) return;
     const rx::Progress progress = shared_->get();
+
+    // The engine has no "sync acquired" event -- acquisition is just the
+    // first poll whose status reads "receiving" -- so the edge is
+    // detected and logged here (once per acquisition).
+    if (progress.status == rx::Status::Receiving && !was_receiving_) {
+        was_receiving_ = true;
+        QString acquired = tr("sync acquired");
+        if (progress.mode_name) {
+            acquired += tr(": mode %1").arg(QString::fromStdString(*progress.mode_name));
+        } else {
+            acquired += tr(" (blind)");
+        }
+        if (!progress.callsign.empty()) {
+            acquired += tr(" de %1").arg(QString::fromStdString(progress.callsign));
+        }
+        app_->log_event("rx", log::Severity::Info, acquired);
+    } else if (progress.status == rx::Status::Listening) {
+        was_receiving_ = false;
+    }
 
     QString text;
     if (progress.status == rx::Status::Listening) {
@@ -359,12 +500,12 @@ void ReceivePanel::refresh_status() {
             text = tr("Receiving (blind sync): %1% of latents")
                        .arg(100.0 * progress.progress_frac, 0, 'f', 0);
         }
-        text += QString::fromStdString(rx::fmt_snr(progress.snr_db));
+        text += snr_text(progress.snr_db);
         if (!progress.callsign.empty()) {
             text += tr("  de %1").arg(QString::fromStdString(progress.callsign));
         }
     } else {
-        text = tr("Complete%1").arg(QString::fromStdString(rx::fmt_snr(progress.snr_db)));
+        text = tr("Complete%1").arg(snr_text(progress.snr_db));
         if (last_saved_path_) {
             text += tr(" -- saved %1")
                         .arg(QString::fromStdString(
@@ -372,7 +513,7 @@ void ReceivePanel::refresh_status() {
         }
     }
 
-    status_->setText(text);
+    set_status(text);
     progress_->setValue(static_cast<int>(100.0 * progress.progress_frac));
 
     if (progress.image && progress.image.get() != shown_) {
@@ -394,11 +535,65 @@ void ReceivePanel::on_reception(const QString& saved_path) {
         saved_path.isEmpty() ? std::nullopt
                              : std::optional<std::string>(saved_path.toStdString());
     set_displayed(reception->image, reception->callsign, reception->mode_name);
+
+    // The one durable record of a completed reception: mode, callsign,
+    // SNR, frame count and the *full* saved path -- which was previously
+    // shown only in a 5-second status bar flash before this line existed.
+    QString line = tr("reception complete");
+    if (reception->mode_name) {
+        line += tr(": mode %1").arg(QString::fromStdString(*reception->mode_name));
+    }
+    if (!reception->callsign.empty()) {
+        line += tr(" de %1").arg(QString::fromStdString(reception->callsign));
+    }
+    if (reception->n_frames_expected) {
+        line += tr(", %1/%2 frames")
+                    .arg(reception->frames_received.value_or(0))
+                    .arg(*reception->n_frames_expected);
+    }
+    const QString snr = QString::fromStdString(rx::fmt_snr(reception->snr_db));
+    if (!snr.isEmpty()) line += tr(",%1").arg(snr);
+    if (!saved_path.isEmpty()) line += tr(" -- saved %1").arg(saved_path);
+    app_->log_event("rx", log::Severity::Info, line);
+
+    // And the same facts on screen, where they stay. The engine resets
+    // its shared state two seconds after a reception, so everything
+    // below this point was previously unrecoverable from the UI.
+    QString card = tr("Last: %1").arg(QTime::currentTime().toString(QStringLiteral("HH:mm")));
+    if (reception->mode_name) {
+        card += tr(" - mode %1").arg(QString::fromStdString(*reception->mode_name));
+    }
+    if (!reception->callsign.empty()) {
+        card += tr(" - de %1").arg(QString::fromStdString(reception->callsign));
+    }
+    const QString card_snr = QString::fromStdString(rx::fmt_snr(reception->snr_db));
+    if (!card_snr.isEmpty()) card += QStringLiteral(" -") + card_snr;
+    if (reception->n_frames_expected) {
+        card += tr(" - %1/%2 frames")
+                    .arg(reception->frames_received.value_or(0))
+                    .arg(*reception->n_frames_expected);
+    }
+    if (!saved_path.isEmpty()) {
+        card += tr(" - %1").arg(
+            QString::fromStdString(fs::path(saved_path.toStdString()).filename().string()));
+    }
+    last_card_->setText(card);
+    last_card_->setEnabled(true);
+    folder_button_->setEnabled(!saved_path.isEmpty());
+
     emit imageReceived(reception->image);
     if (!saved_path.isEmpty()) emit receptionSaved(saved_path);
 }
 
-void ReceivePanel::on_error(const QString& message) { status_->setText(message); }
+void ReceivePanel::on_error(const QString& message) {
+    // Sticky (the banner) plus durable (the log). Deliberately not the
+    // status label: that is the progress tier, the next 500 ms refresh
+    // would overwrite it anyway, and a single-line label given a long
+    // error inflates the panel's minimum width.
+    place_banner();
+    banner_->show_error(message);
+    app_->log_event("rx", log::Severity::Error, message);
+}
 
 void ReceivePanel::on_autosave_toggled(bool on) {
     app_->config().receive.autosave = on;
@@ -406,10 +601,11 @@ void ReceivePanel::on_autosave_toggled(bool on) {
 }
 
 void ReceivePanel::show_image(const images::Picture& image) {
-    preview_pixmap_ = to_pixmap(image);
-    if (preview_pixmap_.isNull()) return;
-    preview_->setPixmap(preview_pixmap_.scaled(preview_->size(), Qt::KeepAspectRatio,
-                                               Qt::SmoothTransformation));
+    const QPixmap pixmap = to_pixmap(image);
+    if (pixmap.isNull()) return;
+    // The box keeps the original and rescales itself on every resize;
+    // the panel no longer has to notice.
+    preview_->set_picture(pixmap);
 }
 
 void ReceivePanel::set_displayed(const images::Picture& image,
@@ -449,19 +645,69 @@ void ReceivePanel::save_current() {
     try {
         images::save_png(*displayed_, path.toStdString());
     } catch (const std::exception& e) {
+        app_->log_event("rx", log::Severity::Error,
+                        tr("could not save %1: %2")
+                            .arg(path, QString::fromUtf8(e.what())));
         QMessageBox::critical(this, tr("Could not save"),
                               QString::fromUtf8(e.what()));
         return;
     }
     last_saved_path_ = path.toStdString();
+    folder_button_->setEnabled(true);
+    // The card claims to name the file the last picture went to, so a
+    // manual save has to update it -- otherwise the button points at
+    // one file while the card names another (or names none at all,
+    // with autosave off).
+    const QString name = QString::fromStdString(
+        fs::path(path.toStdString()).filename().string());
+    if (last_card_->text().isEmpty()) {
+        last_card_->setText(tr("Saved %1").arg(name));
+        last_card_->setEnabled(true);
+    } else {
+        last_card_->setText(tr("%1 - saved %2").arg(last_card_->text(), name));
+    }
     emit receptionSaved(path);
 }
 
-void ReceivePanel::resizeEvent(QResizeEvent* event) {
-    QWidget::resizeEvent(event);
-    if (!preview_pixmap_.isNull()) {
-        preview_->setPixmap(preview_pixmap_.scaled(
-            preview_->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+void ReceivePanel::fill_for_screenshot() {
+    // The longest line `refresh_status` can build, the longest card
+    // `on_reception` can build, and the banner inside the layout.
+    set_status(
+        tr("Receiving mode C: frame 220/220 (100%)  SNR 8.3dB  de KD8XYZ"));
+    progress_->setValue(100);
+    last_card_->setText(
+        tr("Last: 14:32 - mode C - de KD8XYZ - SNR 8.3dB - 220/220 frames"
+           " - KD8XYZ-C-14230000.png"));
+    last_card_->setEnabled(true);
+    save_button_->setEnabled(true);
+    folder_button_->setEnabled(true);
+    place_banner();
+    banner_->show_error(
+        tr("could not save received image: read-only file system"));
+}
+
+void ReceivePanel::open_saved_folder() {
+    if (!last_saved_path_) return;
+    // The containing folder rather than the file: opening the picture
+    // itself would launch an image viewer, and what the operator wants
+    // here is the directory their captures are piling up in.
+    const QString dir =
+        QString::fromStdString(fs::path(*last_saved_path_).parent_path().string());
+    // Logged unconditionally, before the call. `openUrl` reports only
+    // whether a *handler could be launched*: on Unix it ends in a
+    // detached `xdg-open`, which returns true as soon as the process
+    // starts and says nothing about whether a file manager ever
+    // appeared. So a false return is worth reporting, but a true one is
+    // not evidence of success -- and the case this button exists to
+    // survive (a minimal desktop with nothing registered) is precisely
+    // the one that returns true and does nothing. The log line is what
+    // makes that debuggable instead of baffling.
+    app_->log_event("rx", log::Severity::Info, tr("opening %1").arg(dir));
+    if (!QDesktopServices::openUrl(QUrl::fromLocalFile(dir))) {
+        app_->log_event("rx", log::Severity::Error,
+                        tr("could not open %1 -- no handler for local "
+                           "folders on this desktop")
+                            .arg(dir));
     }
 }
 

--- a/native/gui/rx_panel.hpp
+++ b/native/gui/rx_panel.hpp
@@ -21,6 +21,7 @@
 #define SSTVAE_GUI_RX_PANEL_HPP
 
 #include <QPixmap>
+#include <QPointer>
 #include <QWidget>
 
 #include <atomic>
@@ -30,6 +31,10 @@
 #include <thread>
 
 #include "images/types.hpp"
+#include "picture_box.hpp"
+// Complete type, not a forward declaration: QPointer<T> instantiates
+// static_casts through QObject and needs to know T derives from it.
+#include "waterfall.hpp"
 #include "rx/engine.hpp"
 #include "rx/ringbuffer.hpp"
 
@@ -45,7 +50,7 @@ class InputStream;
 namespace sstvae::gui {
 
 class AppState;
-class Waterfall;
+class ErrorBanner;
 
 class ReceivePanel : public QWidget {
     Q_OBJECT
@@ -56,6 +61,29 @@ public:
 
     bool listening() const;
 
+    // The spectrum strip now spans the whole window rather than living
+    // in this pane -- it is the one widget whose job is resolving
+    // detail across a frequency axis, and a third of the window was
+    // never enough for it. The panel still drives it (it owns the ring
+    // buffer), so ownership moved to MainWindow while control did not.
+    // Null until attached, and every use is guarded.
+    void attach_waterfall(Waterfall* waterfall) { waterfall_ = waterfall; }
+    // Null-safe accessor. **Not defensive programming for its own
+    // sake**: moving the strip up to the window made it a *sibling* of
+    // this panel rather than a child, and it is added to the central
+    // widget's layout first -- so at teardown `~QWidget` deletes it
+    // before the panel whose `stop()` still calls `set_ring(nullptr)`.
+    // A `QPointer` goes null when the widget dies, which turns a
+    // use-after-free at every exit into a no-op.
+    Waterfall* fall() const { return waterfall_.data(); }
+    // The 4:3 picture area. Read by tests and by the screenshot tool;
+    // nothing sizes it from outside any more.
+    QWidget* picture_area() const;
+    // Everything below the picture, as one widget, so the container can
+    // hold it to the same height as the transmit pane's strip -- which
+    // is what makes the two pictures the same size.
+    QWidget* control_strip() const;
+
     // Re-read the settings the panel mirrors in its own controls. The
     // autosave checkbox exists in both places, so a change made in the
     // dialog has to show up here or the two disagree about what is on.
@@ -65,6 +93,16 @@ public slots:
     bool start();
     void stop();
     void save_current();
+    // Reveal the last saved picture in the desktop's file manager.
+    void open_saved_folder();
+
+    // Fill every text surface with the longest content it can hold, for
+    // `sstvae-gui-shot`. A slot for the same reason `Waterfall::tick`
+    // is one: the layout facts worth looking at -- whether the status
+    // line, the card and the five-button controls row fit a narrow pane
+    // -- are invisible on a freshly constructed panel, where all three
+    // are empty. Touches no engine and starts nothing.
+    void fill_for_screenshot();
 
     // Half duplex. Our own audio would otherwise be decoded straight
     // back into a "received" picture.
@@ -77,6 +115,11 @@ signals:
     // partial one would be a poor keepsake.
     void imageReceived(const images::Picture& image);
     void listeningChanged(bool listening);
+    // Whatever the panel's own status line now reads. Emitted for every
+    // change, so a second display of it (the status bar, while the
+    // window is tabbed and this pane may be behind the other one) cannot
+    // drift from the first.
+    void statusChanged(const QString& text);
 
     // Emitted from the decode thread; connected queued to the slots
     // below so the work lands on the GUI thread.
@@ -84,6 +127,7 @@ signals:
     void errorOccurred(const QString& message);
 
 protected:
+    // Only to keep the error banner sitting over the top of the picture.
     void resizeEvent(QResizeEvent* event) override;
 
 private slots:
@@ -94,6 +138,12 @@ private slots:
 
 private:
     void build_ui();
+    // Keeps the floating error banner across the top of the picture.
+    void place_banner();
+    // The one way the status line is written. A bare `status_->setText`
+    // would leave the status bar's copy stale on whichever of the five
+    // call sites someone forgot.
+    void set_status(const QString& text);
     void show_image(const images::Picture& image);
     void set_displayed(const images::Picture& image, const std::string& callsign,
                        const std::optional<std::string>& mode_name);
@@ -104,13 +154,17 @@ private:
     AppState* app_ = nullptr;
 
     // --- widgets
-    QLabel* preview_ = nullptr;
+    ErrorBanner* banner_ = nullptr;
+    PictureBox* preview_ = nullptr;
+    QWidget* strip_ = nullptr;
     QLabel* status_ = nullptr;
+    QLabel* last_card_ = nullptr;
     QProgressBar* progress_ = nullptr;
-    Waterfall* waterfall_ = nullptr;
+    QPointer<Waterfall> waterfall_;
     QPushButton* start_button_ = nullptr;
     QPushButton* stop_button_ = nullptr;
     QPushButton* save_button_ = nullptr;
+    QPushButton* folder_button_ = nullptr;
     QCheckBox* autosave_ = nullptr;
 
     // --- reception
@@ -129,9 +183,6 @@ private:
     std::optional<images::Picture> displayed_;
     std::string displayed_callsign_;
     std::optional<std::string> displayed_mode_;
-    // Unscaled, so a resize rescales from the original rather than
-    // compounding losses.
-    QPixmap preview_pixmap_;
     // Identity check, to avoid repainting a picture already on screen.
     const images::Picture* shown_ = nullptr;
 
@@ -142,6 +193,10 @@ private:
 
     std::optional<std::string> last_saved_path_;
     bool suspended_for_tx_ = false;
+    // Edge detection for the log: the engine has no "sync acquired"
+    // event, only a status that polls as "receiving", so the transition
+    // is detected here and logged once per acquisition.
+    bool was_receiving_ = false;
 };
 
 }  // namespace sstvae::gui

--- a/native/gui/settings_dialog.cpp
+++ b/native/gui/settings_dialog.cpp
@@ -715,6 +715,23 @@ QWidget* SettingsDialog::transmit_tab() {
                          "Send arrives before it has settled, it finishes "
                          "quickly and sends what it has."),
                       page));
+
+    // The transmit level itself stays on the send bar, where it is
+    // adjusted, and keeps a short tooltip there. What lives here is the
+    // *procedure*, because a tooltip only ever reaches an operator who
+    // already suspects they have it wrong -- and drive is the one
+    // adjustment that ruins a transmission silently. The two texts name
+    // the same target on purpose; if this one changes, change the
+    // tooltip in `tx_panel.cpp` with it.
+    form->addRow(note(tr("Transmit level is on the Transmit panel, beside the "
+                         "mode.\n\n"
+                         "Set it so the radio shows no ALC action at all. ALC "
+                         "is a compressor: it flattens the peaks this waveform "
+                         "carries information in, and the far end sees that as "
+                         "a lower SNR and a mangled picture -- while your own "
+                         "meters look healthy. Start low and raise it until "
+                         "power output stops rising, then back off."),
+                      page));
     return page;
 }
 

--- a/native/gui/tx_panel.cpp
+++ b/native/gui/tx_panel.cpp
@@ -1,21 +1,31 @@
 #include "tx_panel.hpp"
 
+#include <QColor>
 #include <QColorDialog>
 #include <QComboBox>
 #include <QDoubleSpinBox>
+#include <QDragEnterEvent>
+#include <QDropEvent>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QHBoxLayout>
+#include <QIcon>
 #include <QLabel>
 #include <QMessageBox>
+#include <QMimeData>
+#include <QPainter>
+#include <QPixmap>
 #include <QPlainTextEdit>
 #include <QProgressBar>
 #include <QPushButton>
+#include <QResizeEvent>
 #include <QSlider>
 #include <QSplitter>
+#include <QStyle>
 #include <QTimer>
+#include <QUrl>
 #include <QVBoxLayout>
 
 #include <algorithm>
@@ -26,11 +36,14 @@
 
 #include "app_state.hpp"
 #include "audio/qt/qtaudio.hpp"
+#include "banner.hpp"
 #include "checkpoint/checkpoint.hpp"
 #include "codec/codec.hpp"
 #include "codec/grad_session.hpp"
 #include "config.hpp"
+#include "crop_dialog.hpp"
 #include "images/images.hpp"
+#include "flow_layout.hpp"
 #include "overlay_editor.hpp"
 #include "settings/settings.hpp"
 
@@ -118,6 +131,7 @@ void TransmitPanel::rebuild_optimizer() {
         awaiting_optimizer_ = false;
         send_picture_.reset();
         send_button_->setEnabled(true);
+        set_picture_controls_enabled(true);
         progress_->setRange(0, 100);
         progress_->setValue(0);
     }
@@ -189,6 +203,7 @@ void TransmitPanel::schedule_optimization() {
     }
     // The encode runs on the optimizer's worker, after the debounce --
     // so a drag that produces twenty of these pays for none of them.
+    optimizer_result_logged_ = false;  // a fresh run gets a fresh log line
     optimizer_->picture_changed(
         array, [model, array] { return model->encode(array); }, *mode);
 }
@@ -215,57 +230,149 @@ void TransmitPanel::on_optimizer_progress() {
         // Whatever ended it -- plateau, either budget, or Send cutting
         // it short -- the gain it did reach stays on screen.
         status_->setText(tr("Picture refined: %1 est.").arg(gain));
+        if (!optimizer_result_logged_) {
+            // The status label cannot say *why* it stopped, so plateau
+            // and out-of-time looked identical -- and the figure
+            // itself was erased the moment transmit started. The log
+            // keeps both.
+            optimizer_result_logged_ = true;
+            app_->log_event(
+                "opt", log::Severity::Info,
+                tr("refined %1 est. (%2, %3 steps, %4 s)")
+                    .arg(gain)
+                    .arg(QString::fromStdString(optimize::to_string(st.stop)))
+                    .arg(st.progress.step)
+                    .arg(st.progress.elapsed_s, 0, 'f', 1));
+        }
     } else if (st.finished) {
         // Finished without a single measured step: the artifact was
         // missing or the encode failed, and the encoder's own latents
         // are what will be sent.
         status_->setText(tr("Sending unrefined"));
+        if (!optimizer_result_logged_) {
+            optimizer_result_logged_ = true;
+            app_->log_event("opt", log::Severity::Warning,
+                            tr("refinement produced no result; sending the "
+                               "encoder's own latents"));
+        }
     }
 }
 
-void TransmitPanel::build_ui() {
-    auto* layout = new QVBoxLayout(this);
-    auto* splitter = new QSplitter(Qt::Horizontal, this);
+QWidget* TransmitPanel::picture_area() const { return editor_; }
 
-    editor_ = new OverlayEditor(splitter);
+QWidget* TransmitPanel::control_strip() const { return strip_; }
+
+void TransmitPanel::build_ui() {
+    // Dropping a file on the composer loads it -- the gesture every
+    // other picture application answers, and the one an operator
+    // reaches for before finding "Choose image...".
+    setAcceptDrops(true);
+
+    auto* layout = new QVBoxLayout(this);
+
+    // The error tier. Everything the transmit path says shares one
+    // status label at the end of the send bar, so before this existed
+    // "PTT OFF FAILED ... unkey it manually" was replaced by "Sent"
+    // within a second. Errors now also land here and stay until
+    // dismissed or the next send starts cleanly.
+    // **Over the picture, not above it.** In the layout it displaced
+    // everything below it -- so an error in one pane pushed that pane's
+    // picture down and the two stopped lining up, which is precisely
+    // what the equal-size work exists to prevent. Floating it costs no
+    // layout at all: it appears, it is dismissed, and nothing moves.
+    banner_ = new ErrorBanner(this);
+    banner_->hide();
+
+    editor_ = new OverlayEditor(this);
     connect(editor_, &OverlayEditor::selectionChanged, this,
             &TransmitPanel::on_selection);
     connect(editor_, &OverlayEditor::documentChanged, this,
             &TransmitPanel::schedule_optimization);
-    splitter->addWidget(editor_);
-    splitter->addWidget(build_side_panel());
-    splitter->setStretchFactor(0, 3);
-    splitter->setStretchFactor(1, 1);
-    layout->addWidget(splitter, 1);
-    layout->addWidget(build_send_bar());
+    // Tools *under* the canvas, not beside it. Beside it they cost the
+    // composer ~195 px of width that the receive preview does not pay,
+    // so the two pictures could never be the same size however the
+    // splitter was weighted -- and the received picture is the one you
+    // cannot get back, so it is the one that should not lose.
+    // Stretch 10, matching the receive pane's picture: without it the
+    // trailing spacer below took the surplus and the canvas stopped at
+    // its 640x480 sizeHint, so the two pictures agreed at every window
+    // size and both stopped growing at 480 px. Bounded either way --
+    // the editor caps itself at 4:3.
+    // Stretch 1 and no trailing spacer: the canvas is what the spare
+    // room is for. Everything else goes in the strip, whose height is
+    // matched against the receive pane's.
+    layout->addWidget(editor_);
+
+    strip_ = new QWidget(this);
+    auto* strip_layout = new QVBoxLayout(strip_);
+    strip_layout->setContentsMargins(0, 0, 0, 0);
+    strip_layout->setSpacing(4);
+    strip_layout->addWidget(build_tool_row());
+    properties_ = build_properties(strip_);
+    // **Always present, disabled when nothing is selected** -- not
+    // hidden. A row that appears on selection moves the picture under
+    // the cursor every time an item is clicked, which is the one thing
+    // a composing surface must not do. Its height is part of the strip
+    // and therefore part of what the receive pane matches.
+    properties_->setEnabled(false);
+    strip_layout->addWidget(properties_);
+    strip_layout->addWidget(build_send_bar());
+    layout->addWidget(strip_);
 }
 
-QWidget* TransmitPanel::build_side_panel() {
+// One horizontal row of tools under the canvas, replacing the column
+// that used to sit beside it. The groupings the column had (Picture /
+// Overlay) are carried by separator lines rather than by boxes: three
+// nested titled boxes in a row would cost more height than the buttons.
+QWidget* TransmitPanel::build_tool_row() {
     auto* panel = new QWidget(this);
-    auto* column = new QVBoxLayout(panel);
+    // Wraps rather than crushes -- see flow_layout.hpp.
+    auto* column = new FlowLayout(panel);
 
-    auto* source = new QGroupBox(tr("Picture"), panel);
-    auto* source_layout = new QVBoxLayout(source);
-    choose_button_ = new QPushButton(tr("Choose image..."), source);
+    auto* source = panel;
+    auto* source_layout = column;
+    choose_button_ = new QPushButton(tr("Picture..."), source);
     connect(choose_button_, &QPushButton::clicked, this,
             &TransmitPanel::choose_image);
     image_label_ = new QLabel(tr("No image selected"), source);
     image_label_->setWordWrap(true);
+    frame_button_ = new QPushButton(tr("Framing..."), source);
+    frame_button_->setToolTip(
+        tr("Choose which part of the picture is sent, for anything that is "
+           "not 4:3"));
+    frame_button_->setEnabled(false);
+    connect(frame_button_, &QPushButton::clicked, this,
+            &TransmitPanel::choose_framing);
+    // The caption is the one thing here that is text rather than a
+    // control, and it is the widest; it gets the row's slack and elides
+    // rather than setting a width floor for the whole window.
+    image_label_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
     source_layout->addWidget(choose_button_);
+    source_layout->addWidget(frame_button_);
     source_layout->addWidget(image_label_);
-    column->addWidget(source);
 
-    auto* overlay_box = new QGroupBox(tr("Overlay"), panel);
-    auto* overlay_layout = new QVBoxLayout(overlay_box);
-    auto* add_text = new QPushButton(tr("Add text"), overlay_box);
+    auto* rule = new QFrame(panel);
+    rule->setFrameShape(QFrame::VLine);
+    rule->setFrameShadow(QFrame::Sunken);
+    column->addWidget(rule);
+
+    auto* overlay_box = panel;
+    auto* overlay_layout = column;
+    auto* add_text = new QPushButton(tr("+ Text"), overlay_box);
     connect(add_text, &QPushButton::clicked, this, [this] {
         const std::string& callsign = app_->config().callsign;
         editor_->add_text(callsign.empty() ? std::string("TEXT") : callsign);
     });
-    add_rx_button_ = new QPushButton(tr("Add last received image"), overlay_box);
+    add_rx_button_ = new QPushButton(tr("+ Last RX"), overlay_box);
+    // Nothing to insert until something has been received: the item it
+    // adds resolves at render time, so before the first reception it
+    // drew nothing and looked like a button that did not work.
+    add_rx_button_->setEnabled(false);
+    add_rx_button_->setToolTip(
+        tr("Insert the last received picture. Available once one has arrived."));
     connect(add_rx_button_, &QPushButton::clicked, editor_,
             &OverlayEditor::add_last_rx_inset);
-    auto* add_image = new QPushButton(tr("Add image from file..."), overlay_box);
+    auto* add_image = new QPushButton(tr("+ Image..."), overlay_box);
     connect(add_image, &QPushButton::clicked, this, [this] {
         const QString path = QFileDialog::getOpenFileName(
             this, tr("Choose an inset image"),
@@ -273,31 +380,57 @@ QWidget* TransmitPanel::build_side_panel() {
             QString::fromLatin1(IMAGE_FILTER));
         if (!path.isEmpty()) editor_->add_image_inset(path.toStdString());
     });
-    auto* remove = new QPushButton(tr("Remove selected"), overlay_box);
+    auto* remove = new QPushButton(tr("Remove"), overlay_box);
     connect(remove, &QPushButton::clicked, editor_,
             &OverlayEditor::remove_selected);
     for (QPushButton* button : {add_text, add_rx_button_, add_image, remove}) {
         overlay_layout->addWidget(button);
     }
-    column->addWidget(overlay_box);
-
-    properties_ = build_properties(panel);
-    column->addWidget(properties_);
-    column->addStretch(1);
+    // **No `column->addWidget(overlay_box)` here.** `overlay_box` is an
+    // alias for `panel`, whose layout `column` *is*, so that line asked
+    // Qt to add a widget to its own child layout. Qt refuses and prints
+    // "QLayout: Cannot add parent widget to its child layout" on every
+    // construction -- of the app, of the screenshot tool, of any test --
+    // while the four buttons had already been added by the loop above.
+    // A permanently dead line and a permanent warning in our own
+    // diagnostics.
+    //
+    // **The properties box is NOT built here either.** `build_ui` owns it, so
+    // constructing a second one in this row left an orphan that nothing
+    // ever updated -- and, because it sat in the row, it added 535 px to
+    // the transmit pane's minimum width. That is most of the imbalance
+    // that made the two pictures unequal: 1088 px against the receive
+    // pane's 464.
     return panel;
 }
 
 QGroupBox* TransmitPanel::build_properties(QWidget* parent) {
     auto* box = new QGroupBox(tr("Selected item"), parent);
     box->setEnabled(false);
-    auto* form = new QFormLayout(box);
+    // Horizontal: a form stacks its rows, which under the canvas would
+    // cost five rows of height. Side by side it is one.
+    // Wrapping, for the same reason as the tool row: five fields on a
+    // half-width pane is exactly where a single line gives up.
+    auto* form = new FlowLayout(box);
 
     // Multi-line: a station's callsign, grid and name belong to one
     // item, not three stacked by hand. Enter inserts a newline, so Tab
     // has to be what leaves the field.
     text_edit_ = new QPlainTextEdit(box);
     text_edit_->setTabChangesFocus(true);
-    text_edit_->setFixedHeight(80);
+    // The panel advertises "drop a picture here"; this widget would
+    // answer that gesture by inserting the file's URL as overlay text
+    // and sending it on the air. Let the drop fall through to the
+    // panel, which loads it.
+    text_edit_->setAcceptDrops(false);
+    // Two lines rather than four: still multi-line (a callsign, a grid
+    // and a name belong to one item), but in a row under the canvas the
+    // height is the picture's.
+    text_edit_->setFixedHeight(46);
+    // Ignored horizontally: in a row this would otherwise be a width
+    // floor under the whole window, which is what the tool row's long
+    // button captions already were.
+    text_edit_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
     connect(text_edit_, &QPlainTextEdit::textChanged, this, [this] {
         if (auto* item = editing_item()) {
             if (auto* text = std::get_if<overlay::TextItem>(item)) {
@@ -306,7 +439,8 @@ QGroupBox* TransmitPanel::build_properties(QWidget* parent) {
             }
         }
     });
-    form->addRow(tr("Text"), text_edit_);
+    form->addWidget(new QLabel(tr("Text"), box));
+    form->addWidget(text_edit_);
 
     align_combo_ = new QComboBox(box);
     align_combo_->addItem(tr("Left"), QStringLiteral("left"));
@@ -320,7 +454,8 @@ QGroupBox* TransmitPanel::build_properties(QWidget* parent) {
             }
         }
     });
-    form->addRow(tr("Align"), align_combo_);
+    form->addWidget(new QLabel(tr("Align"), box));
+    form->addWidget(align_combo_);
 
     size_spin_ = new QDoubleSpinBox(box);
     size_spin_->setRange(0.01, 1.5);
@@ -336,7 +471,8 @@ QGroupBox* TransmitPanel::build_properties(QWidget* parent) {
         }
         editor_->refresh_item();
     });
-    form->addRow(tr("Size"), size_spin_);
+    form->addWidget(new QLabel(tr("Size"), box));
+    form->addWidget(size_spin_);
 
     rotation_spin_ = new QDoubleSpinBox(box);
     rotation_spin_->setRange(-180.0, 180.0);
@@ -348,7 +484,8 @@ QGroupBox* TransmitPanel::build_properties(QWidget* parent) {
                 std::visit([value](auto& i) { i.rotation = value; }, *item);
                 editor_->refresh_item();
             });
-    form->addRow(tr("Rotation"), rotation_spin_);
+    form->addWidget(new QLabel(tr("Rotation"), box));
+    form->addWidget(rotation_spin_);
 
     color_button_ = new QPushButton(tr("Colour..."), box);
     connect(color_button_, &QPushButton::clicked, this, [this] {
@@ -360,15 +497,19 @@ QGroupBox* TransmitPanel::build_properties(QWidget* parent) {
             QColor(QString::fromStdString(text->color)), this);
         if (!color.isValid()) return;
         text->color = color.name().toStdString();
+        set_color_swatch(color);
         editor_->refresh_item();
     });
-    form->addRow(tr("Colour"), color_button_);
+    form->addWidget(new QLabel(tr("Colour"), box));
+    form->addWidget(color_button_);
     return box;
 }
 
 QWidget* TransmitPanel::build_send_bar() {
     auto* bar = new QWidget(this);
-    auto* layout = new QHBoxLayout(bar);
+    // Wraps: the mode name, the level slider, Send, Cancel and the
+    // status field do not fit one line on a narrow pane.
+    auto* layout = new FlowLayout(bar);
     layout->setContentsMargins(0, 0, 0, 0);
 
     mode_combo_ = new QComboBox(bar);
@@ -393,12 +534,22 @@ QWidget* TransmitPanel::build_send_bar() {
                             0);
     level_slider_->setSingleStep(1);
     level_slider_->setPageStep(2);  // one whole dB
-    level_slider_->setFixedWidth(140);
+    // Wide enough to aim with, but a *minimum* rather than a fixed
+    // width so the send bar can be narrowed; the slider gives up its
+    // extra length before anything starts clipping.
+    level_slider_->setMinimumWidth(80);
+    level_slider_->setMaximumWidth(140);
+    // The short form. The full procedure is in Settings > Transmit,
+    // where it can be read before the first send rather than only by
+    // someone who already suspects the level is wrong -- and the two
+    // must name the *same* target, because "barely moving ALC" and "no
+    // ALC action" are different drive levels and an operator following
+    // either should land in the same place.
     level_slider_->setToolTip(
         tr("Output level, dB relative to full scale.\n\n"
-           "Set it so the radio's ALC barely moves. The waveform is already "
-           "conditioned for a ~4 dB envelope peak; driving it into ALC "
-           "compression will spread it across the band."));
+           "Set it so the radio shows no ALC action at all -- ALC is a "
+           "compressor, and it flattens the peaks this waveform carries "
+           "information in. Full procedure in Settings > Transmit."));
     // Set before connecting, so restoring the saved value is not itself
     // treated as an edit worth writing back.
     level_slider_->setValue(static_cast<int>(
@@ -426,7 +577,15 @@ QWidget* TransmitPanel::build_send_bar() {
 
     progress_ = new QProgressBar(bar);
     progress_->setRange(0, 100);
+    // The bar stretches, so it needs no width of its own; without this
+    // its default hint is a floor under the whole send bar.
+    progress_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
     status_ = new QLabel(tr("Ready"), bar);
+    // Progress-tier text must not set a width floor: the two panes sit
+    // in a splitter whose minimum is the *sum* of its children's, so
+    // every pixel this label demands is a pixel the window cannot be
+    // narrowed by. Errors go to the banner above, which wraps.
+    status_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
 
     layout->addWidget(new QLabel(tr("Mode:"), bar));
     layout->addWidget(mode_combo_);
@@ -435,7 +594,7 @@ QWidget* TransmitPanel::build_send_bar() {
     layout->addWidget(level_label_);
     layout->addWidget(send_button_);
     layout->addWidget(cancel_button_);
-    layout->addWidget(progress_, 1);
+    layout->addWidget(progress_);
     layout->addWidget(status_);
     return bar;
 }
@@ -470,25 +629,193 @@ void TransmitPanel::choose_image() {
 }
 
 void TransmitPanel::load_image(const QString& path) {
+    if (picture_locked()) return;
+    images::Picture loaded;
     try {
-        // Framed to the transmit size here, not at send time: the
-        // overlay's coordinates are fractions of the canvas, so the
-        // operator has to be composing against the frame that will
-        // actually go out.
-        editor_->set_base_image(images::fit(images::load(path.toStdString())));
+        loaded = images::load(path.toStdString());
     } catch (const std::exception& e) {
+        app_->log_event("tx", log::Severity::Error,
+                        tr("could not open image %1: %2")
+                            .arg(path, QString::fromUtf8(e.what())));
         QMessageBox::critical(this, tr("Could not open image"),
                               QString::fromUtf8(e.what()));
         return;
     }
-    image_label_->setText(QFileInfo(path).fileName());
+
+    // The *original* is kept, not the framed result: re-framing has to
+    // start from the picture the operator chose, or each adjustment
+    // would crop what the last one had already cropped.
+    source_ = std::move(loaded);
+    source_path_ = path;
+    framing_ = images::Framing{};
+
+    if (source_->width < images::MIN_W || source_->height < images::MIN_H) {
+        // Upscaled without comment until now. It still is -- refusing
+        // would be worse -- but the operator should know why the
+        // picture looks soft.
+        app_->log_event(
+            "tx", log::Severity::Warning,
+            tr("%1 is %2x%3, below the %4x%5 minimum; it will be upscaled")
+                .arg(QFileInfo(path).fileName())
+                .arg(source_->width)
+                .arg(source_->height)
+                .arg(images::MIN_W)
+                .arg(images::MIN_H));
+    }
+
+    // 4:3 needs no decision, so it is not asked for. Compared as a
+    // ratio of integers rather than a float equality, so 640x480 and
+    // 1600x1200 both count as exact.
+    const bool four_by_three =
+        source_->width * images::IMG_H == source_->height * images::IMG_W;
+    if (!four_by_three) {
+        CropDialog dialog(*source_, framing_, this);
+        if (dialog.exec() == QDialog::Accepted) framing_ = dialog.framing();
+    }
+    // Once, either way: cancelling the dialog means "the default
+    // framing", not "do not show me the picture".
+    apply_framing();
+
     app_->config().folders.transmit_dir =
         QFileInfo(path).absolutePath().toStdString();
     app_->save_config();
 }
 
+bool TransmitPanel::picture_locked() const {
+    // Between the Send click and the end of the transmission the
+    // picture is committed, so changing it is refused rather than
+    // queued. The reason is sharper than tidiness: both entry points
+    // can open a *modal* dialog, whose nested event loop keeps pumping
+    // timers -- including `wait_timer_`, which starts the transmission.
+    // The radio would key while a framing dialog covered the Cancel
+    // button. The buttons are disabled to say so; this guard is what
+    // makes it true for a dropped file, which reaches no button.
+    return transmitting() || awaiting_optimizer_;
+}
+
+void TransmitPanel::set_picture_controls_enabled(bool on) {
+    choose_button_->setEnabled(on);
+    frame_button_->setEnabled(on && source_.has_value());
+}
+
+void TransmitPanel::choose_framing() {
+    if (picture_locked()) return;
+    if (!source_) return;
+    CropDialog dialog(*source_, framing_, this);
+    // Cancel changes nothing, so nothing is re-applied -- re-fitting
+    // would also throw away a speculative optimization that is still
+    // valid for the picture on screen.
+    if (dialog.exec() != QDialog::Accepted) return;
+    framing_ = dialog.framing();
+    apply_framing();
+}
+
+void TransmitPanel::apply_framing() {
+    if (!source_) return;
+    images::Picture framed;
+    try {
+        // Framed to the transmit size here, not at send time: the
+        // overlay's coordinates are fractions of the canvas, so the
+        // operator has to be composing against the frame that will
+        // actually go out.
+        //
+        // In the try because it allocates and resamples: a huge source
+        // at a high zoom can throw, and this runs from a slot, where an
+        // escaping exception takes the process down instead of showing
+        // a message. It used to sit inside `load_image`'s handler.
+        framed = images::fit(*source_, framing_);
+    } catch (const std::exception& e) {
+        app_->log_event("tx", log::Severity::Error,
+                        tr("could not frame %1: %2")
+                            .arg(QFileInfo(source_path_).fileName(),
+                                 QString::fromUtf8(e.what())));
+        QMessageBox::critical(this, tr("Could not frame the picture"),
+                              QString::fromUtf8(e.what()));
+        return;
+    }
+    editor_->set_base_image(framed);
+
+    // An honest caption. The old one said the filename and nothing
+    // else, so a picture that had lost a quarter of its width looked
+    // exactly like one that had not.
+    QString caption = QFileInfo(source_path_).fileName();
+    caption += tr("\n%1x%2").arg(source_->width).arg(source_->height);
+    const bool four_by_three =
+        source_->width * images::IMG_H == source_->height * images::IMG_W;
+    if (!four_by_three || framing_.zoom > 1.0) {
+        caption += tr(", cropped to 4:3");
+    }
+    image_label_->setText(caption);
+    frame_button_->setEnabled(true);
+    // No schedule_optimization() here: `set_base_image` emits
+    // documentChanged, which is already connected to it. Calling it
+    // again would convert the picture twice and restart the debounce
+    // the first call had just started.
+}
+
+void TransmitPanel::dragEnterEvent(QDragEnterEvent* event) {
+    // Accept only a single local file. Multiple would be ambiguous --
+    // one picture goes out at a time -- and a remote URL would mean
+    // fetching, which this panel has no business doing.
+    const QMimeData* mime = event->mimeData();
+    if (!mime->hasUrls()) return;
+    const QList<QUrl> urls = mime->urls();
+    if (urls.size() != 1 || !urls.front().isLocalFile()) return;
+    event->acceptProposedAction();
+}
+
+void TransmitPanel::dropEvent(QDropEvent* event) {
+    const QList<QUrl> urls = event->mimeData()->urls();
+    if (urls.size() != 1 || !urls.front().isLocalFile()) return;
+    event->acceptProposedAction();
+
+    // Deferred, not called here. `load_image` can open the framing
+    // dialog or a message box, and a nested event loop inside
+    // `dropEvent` means this handler has not returned -- so the
+    // platform's drop handshake is unfinished and the *source*
+    // application stays blocked for as long as the operator spends
+    // choosing a crop. Returning first and loading on the next tick
+    // costs nothing and ends the drag properly.
+    const QString path = urls.front().toLocalFile();
+    QTimer::singleShot(0, this, [this, path] { load_image(path); });
+}
+
 void TransmitPanel::set_last_rx_image(const images::Picture& image) {
     editor_->set_last_rx(image);
+    // Only now is there anything for the button to insert. Before the
+    // first reception it added an item that rendered as nothing, which
+    // reads as a broken button rather than as "not yet".
+    add_rx_button_->setEnabled(true);
+    add_rx_button_->setToolTip(QString());
+}
+
+void TransmitPanel::set_color_swatch(const QColor& color) {
+    // The button said "Colour..." and nothing else, so the current
+    // colour was invisible -- the one thing a colour control has to
+    // show. A filled square on the button, drawn at the icon size the
+    // style asks for so it matches the platform's other buttons.
+    // Dragging a text item emits selectionChanged on every mouse move,
+    // so without this guard the whole rebuild -- parse, allocate, paint,
+    // setIcon, and the layout invalidation setIcon triggers -- runs at
+    // mouse-move rate on the app's most latency-sensitive path.
+    if (color == swatch_color_) return;
+    swatch_color_ = color;
+
+    const int size = style()->pixelMetric(QStyle::PM_SmallIconSize);
+    // Device pixels, like the waterfall's backing image: a logical-sized
+    // pixmap is upscaled on a HiDPI screen, giving a soft square with a
+    // half-resolution border.
+    const qreal dpr = devicePixelRatioF();
+    QPixmap swatch(static_cast<int>(std::lround(size * dpr)),
+                   static_cast<int>(std::lround(size * dpr)));
+    swatch.setDevicePixelRatio(dpr);
+    swatch.fill(color.isValid() ? color : Qt::transparent);
+    if (color.isValid()) {
+        QPainter painter(&swatch);
+        painter.setPen(palette().color(QPalette::WindowText));
+        painter.drawRect(0, 0, size - 1, size - 1);
+    }
+    color_button_->setIcon(QIcon(swatch));
 }
 
 // --- property editing -------------------------------------------------------
@@ -501,8 +828,16 @@ overlay::Item* TransmitPanel::editing_item() {
 }
 
 void TransmitPanel::on_selection(overlay::Item* item) {
+    // Shown only with a selection: under the canvas this row is height
+    // the picture could have had.
+    properties_->setVisible(item != nullptr);
     properties_->setEnabled(item != nullptr);
-    if (item == nullptr) return;
+    if (item == nullptr) {
+        // Otherwise the last item's colour stays painted on a disabled
+        // button, describing a selection that no longer exists.
+        set_color_swatch(QColor());
+        return;
+    }
 
     const bool is_text = std::holds_alternative<overlay::TextItem>(*item);
     loading_properties_ = true;
@@ -515,9 +850,11 @@ void TransmitPanel::on_selection(overlay::Item* item) {
         align_combo_->setCurrentIndex(std::max(
             0, align_combo_->findData(QString::fromStdString(text.align))));
         size_spin_->setValue(text.size);
+        set_color_swatch(QColor(QString::fromStdString(text.color)));
     } else {
         text_edit_->setPlainText(QString());
         size_spin_->setValue(std::get<overlay::ImageItem>(*item).width);
+        set_color_swatch(QColor());  // no colour on an image item
     }
     rotation_spin_->setValue(std::visit([](const auto& i) { return i.rotation; },
                                         *item));
@@ -525,6 +862,20 @@ void TransmitPanel::on_selection(overlay::Item* item) {
 }
 
 // --- transmitting -----------------------------------------------------------
+
+void TransmitPanel::resizeEvent(QResizeEvent* event) {
+    QWidget::resizeEvent(event);
+    place_banner();
+}
+
+void TransmitPanel::place_banner() {
+    if (banner_ == nullptr || editor_ == nullptr) return;
+    const QRect over = editor_->geometry();
+    const int wanted = banner_->heightForWidth(over.width());
+    banner_->setGeometry(over.x(), over.y(), over.width(),
+                         std::max(banner_->sizeHint().height(), wanted));
+    banner_->raise();
+}
 
 bool TransmitPanel::transmitting() const { return running_.load(); }
 
@@ -546,6 +897,9 @@ void TransmitPanel::send() {
     }
     if (thread_.joinable()) thread_.join();
 
+    // A fresh attempt clears the previous one's error; the log keeps it.
+    banner_->clear();
+
     // Optimization, if it is on, must be entirely finished before the
     // radio is keyed -- so Send shortens its deadline and then waits,
     // on a timer rather than by blocking. `Speculative::ready()` is
@@ -557,6 +911,7 @@ void TransmitPanel::send() {
             send_picture_ = *image;
             awaiting_optimizer_ = true;
             send_button_->setEnabled(false);
+            set_picture_controls_enabled(false);
             status_->setText(tr("Refining picture..."));
             progress_->setRange(0, 0);
             wait_timer_->start();
@@ -607,10 +962,12 @@ void TransmitPanel::begin_transmit(const images::Picture& picture,
         });
 
     send_button_->setEnabled(false);
+    set_picture_controls_enabled(false);
     cancel_button_->setEnabled(true);
     // The level is captured in tx_config above, so moving the slider now
     // would change the reading without changing the transmission.
     level_slider_->setEnabled(false);
+    last_logged_phase_ = -1;
     running_.store(true);
     emit transmitStarted();
 
@@ -634,7 +991,37 @@ void TransmitPanel::cancel() {
 
 void TransmitPanel::on_state(int phase, double progress, const QString& message) {
     const auto tx_phase = static_cast<tx::TxPhase>(phase);
-    status_->setText(message.isEmpty()
+    // This slot fires on every playback progress tick; the log gets a
+    // line only when the phase changes. Keying and unkeying are the
+    // lines the on-air PTT shakedown will want timestamps for.
+    if (phase != last_logged_phase_) {
+        last_logged_phase_ = phase;
+        switch (tx_phase) {
+            case tx::TxPhase::Keying:
+            case tx::TxPhase::Sending:
+            case tx::TxPhase::Unkeying:
+            case tx::TxPhase::Done:
+            case tx::TxPhase::Cancelled:
+                app_->log_event("tx", log::Severity::Info,
+                                message.isEmpty()
+                                    ? QString::fromLatin1(tx::phase_name(tx_phase))
+                                    : message);
+                break;
+            case tx::TxPhase::Failed:
+                // The text arrives through on_error too; the phase line
+                // marks *when* the sequence gave up.
+                app_->log_event("tx", log::Severity::Error,
+                                tr("transmit failed"));
+                break;
+            default:
+                break;  // Idle/Encoding/Modulating: routine, not events
+        }
+    }
+    // Failed carries the exception text as its message; the banner and
+    // the log have it in full, and a single-line label given a long
+    // error would force the send bar's minimum width out. The label is
+    // the progress tier: short phase words only.
+    status_->setText(message.isEmpty() || tx_phase == tx::TxPhase::Failed
                          ? QString::fromLatin1(tx::phase_name(tx_phase))
                          : message);
     if (tx_phase == tx::TxPhase::Sending) {
@@ -649,7 +1036,17 @@ void TransmitPanel::on_state(int phase, double progress, const QString& message)
     }
 }
 
-void TransmitPanel::on_error(const QString& message) { status_->setText(message); }
+void TransmitPanel::on_error(const QString& message) {
+    // Sticky (the banner) plus durable (the log): "PTT OFF FAILED --
+    // unkey it manually" must survive the "Sent" that follows it on
+    // the status label. The label itself gets nothing: it cannot wrap,
+    // so a long error there inflates the send bar's minimum width --
+    // rendered proof: a 700 px gui-shot request came back 1204 px wide
+    // with the PTT message in the label.
+    place_banner();
+    banner_->show_error(message);
+    app_->log_event("tx", log::Severity::Error, message);
+}
 
 void TransmitPanel::on_finished(bool ok) {
     if (thread_.joinable()) thread_.join();
@@ -664,11 +1061,21 @@ void TransmitPanel::on_finished(bool ok) {
         schedule_optimization();
     }
     send_button_->setEnabled(true);
+    set_picture_controls_enabled(true);
     cancel_button_->setEnabled(false);
     level_slider_->setEnabled(true);
     progress_->setRange(0, 100);
     progress_->setValue(ok ? 100 : 0);
-    if (ok) status_->setText(tr("Sent"));
+    if (ok) {
+        status_->setText(tr("Sent"));
+    } else if (static_cast<tx::TxPhase>(last_logged_phase_) ==
+               tx::TxPhase::Failed) {
+        // A failed send previously wrote no terminal status at all --
+        // whatever text happened to be there stood. A cancelled send
+        // also lands here with ok=false, and its "cancelled" text is
+        // already correct, so only a genuine failure is relabelled.
+        status_->setText(tr("Failed"));
+    }
     emit transmitFinished();
 }
 

--- a/native/gui/tx_panel.hpp
+++ b/native/gui/tx_panel.hpp
@@ -16,13 +16,17 @@
 #include <string>
 #include <thread>
 
+#include "images/images.hpp"
 #include "images/types.hpp"
 #include "optimize/speculative.hpp"
 #include "overlay/model.hpp"
 #include "tx/engine.hpp"
 
+class QColor;
 class QComboBox;
 class QDoubleSpinBox;
+class QDragEnterEvent;
+class QDropEvent;
 class QGroupBox;
 class QLabel;
 class QPlainTextEdit;
@@ -34,6 +38,7 @@ class QTimer;
 namespace sstvae::gui {
 
 class AppState;
+class ErrorBanner;
 class OverlayEditor;
 
 // The output level is stored as a peak amplitude (`transmit.level`,
@@ -58,6 +63,11 @@ public:
     ~TransmitPanel() override;
 
     bool transmitting() const;
+    // The 4:3 canvas. Read by tests and by the screenshot tool.
+    QWidget* picture_area() const;
+    // Everything below the canvas, as one widget, so the container can
+    // hold it to the same height as the receive pane's strip.
+    QWidget* control_strip() const;
 
 public slots:
     void send();
@@ -72,6 +82,10 @@ public slots:
     void cancel();
     void choose_image();
     void load_image(const QString& path);
+    // Re-open the framing dialog for the picture already loaded. The
+    // original is kept, so this starts from the source rather than
+    // cropping what the last framing produced.
+    void choose_framing();
     // The receive panel's newest complete picture, for a "last_rx" inset.
     void set_last_rx_image(const images::Picture& image);
 
@@ -88,6 +102,15 @@ signals:
     void errorOccurred(const QString& message);
     void sendFinished(bool ok);
 
+protected:
+    // A dropped picture file loads exactly as a chosen one does.
+    void dragEnterEvent(QDragEnterEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
+
+protected:
+    // Only to keep the error banner sitting over the top of the picture.
+    void resizeEvent(QResizeEvent* event) override;
+
 private slots:
     void on_optimizer_progress();
     void on_state(int phase, double progress, const QString& message);
@@ -99,13 +122,23 @@ private slots:
 
 private:
     void build_ui();
+    // Keeps the floating error banner across the top of the picture.
+    void place_banner();
+    // Paint the current text colour onto the Colour button.
+    void set_color_swatch(const QColor& color);
+    // True while the picture is committed to a send in progress.
+    bool picture_locked() const;
+    void set_picture_controls_enabled(bool on);
+    // Push `framing_` through `images::fit` into the editor, and
+    // relabel the picture honestly.
+    void apply_framing();
     // Everything from "the operator pressed Send" onwards, once any
     // optimization has settled. Split out because Send may have to wait
     // for the optimizer first, and that wait must not block the GUI.
     void begin_transmit(const images::Picture& picture,
                         std::vector<double> latents);
     void rebuild_optimizer();
-    QWidget* build_side_panel();
+    QWidget* build_tool_row();
     QGroupBox* build_properties(QWidget* parent);
     QWidget* build_send_bar();
     void update_level_label();
@@ -113,17 +146,30 @@ private:
 
     AppState* app_ = nullptr;
     OverlayEditor* editor_ = nullptr;
+    ErrorBanner* banner_ = nullptr;
 
     QPushButton* choose_button_ = nullptr;
+    QPushButton* frame_button_ = nullptr;
     QLabel* image_label_ = nullptr;
     QPushButton* add_rx_button_ = nullptr;
 
+    // The picture as loaded, at its own size, plus how it is framed
+    // into the transmit canvas. Kept apart so re-framing starts from
+    // the source instead of compounding crops.
+    std::optional<images::Picture> source_;
+    QString source_path_;
+    images::Framing framing_;
+
+    QWidget* strip_ = nullptr;
     QGroupBox* properties_ = nullptr;
     QPlainTextEdit* text_edit_ = nullptr;
     QComboBox* align_combo_ = nullptr;
     QDoubleSpinBox* size_spin_ = nullptr;
     QDoubleSpinBox* rotation_spin_ = nullptr;
     QPushButton* color_button_ = nullptr;
+    // What the swatch currently shows, so a drag's per-mouse-move
+    // selectionChanged does not rebuild an identical icon.
+    QColor swatch_color_;
     // Set while the property widgets are being filled from an item, so
     // their change signals do not write straight back into it.
     bool loading_properties_ = false;
@@ -155,6 +201,14 @@ private:
     // An edit arrived while a send was in progress; re-arm once it is
     // over rather than moving the ground under it.
     bool restart_after_send_ = false;
+
+    // Edge detection for the log: `on_state` fires on every playback
+    // progress tick, so phase transitions are logged only when the
+    // phase actually changes.
+    int last_logged_phase_ = -1;
+    // The optimizer's finished result is logged once per run, not once
+    // per progress callback.
+    bool optimizer_result_logged_ = false;
 };
 
 }  // namespace sstvae::gui

--- a/native/gui/waterfall.cpp
+++ b/native/gui/waterfall.cpp
@@ -2,6 +2,7 @@
 
 #include <QColor>
 #include <QFontMetrics>
+#include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
 #include <QPen>
@@ -67,12 +68,17 @@ const std::array<Rgb, 256>& colormap() {
 }  // namespace
 
 Waterfall::Waterfall(QWidget* parent, int fps) : QWidget(parent) {
-    // Narrow minimum: the frequency axis is scaled to whatever width the
-    // splitter gives it, and demanding all the bins as pixels would stop
-    // the operator shrinking this column in favour of the picture.
+    // Narrow minimum: the frequency axis is scaled to whatever width it
+    // is given, and demanding all 384 bins as pixels would make this
+    // strip the floor under the whole receive pane -- and, since the
+    // two panes share a splitter whose minimum is the *sum* of theirs,
+    // under the window.
     setMinimumWidth(160);
-    setMinimumHeight(140);
-    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
+    setMinimumHeight(90);
+    // A strip across the top of the receive pane rather than a column
+    // down its side, so it takes the width it is given and does not
+    // fight the picture below it for height.
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
     auto* timer = new QTimer(this);
     connect(timer, &QTimer::timeout, this, &Waterfall::tick);
@@ -81,7 +87,12 @@ Waterfall::Waterfall(QWidget* parent, int fps) : QWidget(parent) {
 
 Waterfall::~Waterfall() = default;
 
-QSize Waterfall::sizeHint() const { return QSize(280, 600); }
+// Wide and shallow: history depth follows the height, so a strip holds
+// less of it than the old full-height column did -- about eight
+// seconds at 20 fps, which is the span that matters for "is someone
+// transmitting right now" and for setting soundcard gain. The splitter
+// above it makes that the operator's call rather than this number's.
+QSize Waterfall::sizeHint() const { return QSize(520, 160); }
 
 void Waterfall::set_ring(std::shared_ptr<rx::RingBuffer> ring) {
     ring_ = std::move(ring);
@@ -147,6 +158,7 @@ void Waterfall::tick() {
     // already been clipped somewhere upstream in the capture chain, so
     // this reports the soundcard's problem rather than ours.
     clipping_ = peak_ >= 0.99;
+    if (clipping_) clip_latched_ = true;
 
     ensure_image();
     const std::vector<double> reduced = dsp::reduce_to_width(
@@ -188,6 +200,24 @@ void Waterfall::paintEvent(QPaintEvent* event) {
     painter.drawImage(QPointF(0, 0), image_);
     draw_band_markers(painter);
     draw_level_meter(painter);
+    draw_disabled_scrim(painter);
+}
+
+void Waterfall::draw_disabled_scrim(QPainter& painter) {
+    // `setEnabled(false)` alone does nothing to a custom-painted widget:
+    // Qt greys the *standard* controls it draws itself, and a QLabel
+    // dims its pixmap, but a paintEvent that blits an image and strokes
+    // hard-coded colours renders pixel-identically either way. This
+    // widget is disabled exactly once -- while transmitting -- and the
+    // whole point of showing it then is that a paused receiver must not
+    // look like a wedged one, which is the state a frozen spectrum with
+    // no scrim is indistinguishable from.
+    if (isEnabled()) return;
+    painter.fillRect(rect(), QColor(0, 0, 0, 150));
+    painter.setPen(QColor(220, 220, 220, 220));
+    const QString label = tr("paused - transmitting");
+    const QRect box = rect();
+    painter.drawText(box, Qt::AlignCenter, label);
 }
 
 void Waterfall::draw_band_markers(QPainter& painter) {
@@ -203,14 +233,21 @@ void Waterfall::draw_band_markers(QPainter& painter) {
         painter.drawLine(x, 0, x, h);
     }
 
-    // The column is user-resizable, so the caption has to earn its
+    // The strip is user-resizable, so the caption has to earn its
     // place: drop it rather than let it run off the edge or overprint
     // the spectrum.
     const QString label = tr("SSTVAE %1-%2 Hz")
                               .arg(BAND_LO_HZ, 0, 'f', 0)
                               .arg(BAND_HI_HZ, 0, 'f', 0);
     const int label_x = static_cast<int>(BAND_LO_HZ * scale) + 4;
-    if (label_x + painter.fontMetrics().horizontalAdvance(label) < w - 12) {
+    // The latched CLIP marker shares this baseline at the right edge;
+    // when it is up, the caption yields early rather than overprinting
+    // it -- at 195-240 px both fit the old guard and neither is legible.
+    const int reserved =
+        clip_latched_
+            ? painter.fontMetrics().horizontalAdvance(tr("CLIP")) + 20
+            : 12;
+    if (label_x + painter.fontMetrics().horizontalAdvance(label) < w - reserved) {
         painter.setPen(QColor(0, 0, 0, 160));
         painter.drawText(label_x + 1, 15, label);  // shadow, for contrast
         painter.setPen(QColor(255, 255, 255, 220));
@@ -255,6 +292,34 @@ void Waterfall::draw_level_meter(QPainter& painter) {
         color = QColor(255, 190, 60);
     }
     painter.fillRect(x0, h - 2 - filled, bar_w, filled, color);
+
+    if (clip_latched_) {
+        // Latched, not momentary: stays until the meter is clicked, so
+        // clipping that happened while nobody was looking still gets
+        // reported. Same shadowed-text idiom as the band caption.
+        const QString label = tr("CLIP");
+        const int text_x =
+            x0 - painter.fontMetrics().horizontalAdvance(label) - 4;
+        painter.setPen(QColor(0, 0, 0, 160));
+        painter.drawText(text_x + 1, 15, label);
+        painter.setPen(QColor(255, 60, 60, 230));
+        painter.drawText(text_x, 14, label);
+    }
+}
+
+void Waterfall::clear_clip() {
+    clip_latched_ = false;
+    update();
+}
+
+void Waterfall::mousePressEvent(QMouseEvent* event) {
+    // A click on (or near) the meter clears the latch. The whole right
+    // edge counts -- an 8 px bar is not a precision target.
+    if (clip_latched_ && event->position().x() >= width() - 30) {
+        clear_clip();
+        return;
+    }
+    QWidget::mousePressEvent(event);
 }
 
 }  // namespace sstvae::gui

--- a/native/gui/waterfall.hpp
+++ b/native/gui/waterfall.hpp
@@ -16,13 +16,18 @@
 // single pixel per tick, and k > 1 would jump k pixels and hold k times
 // less history for the same pane.
 //
-// The frequency axis has the same problem in the same direction -- 384
-// bins squeezed into a ~280 px column -- so rows are reduced to the
-// widget's width when they are computed rather than by the painter; see
-// `dsp::reduce_to_width`.
+// The frequency axis has the same problem, and had it in the same
+// direction while this widget was a narrow column: 384 bins squeezed
+// into ~280 px. Rows are therefore reduced to the widget's width when
+// they are computed rather than by the painter (`dsp::reduce_to_width`,
+// peak-hold when shrinking so a one-bin carrier cannot be sampled
+// away). As a strip it is usually *wider* than 384 px and that function
+// interpolates instead -- the shrinking path still matters whenever the
+// pane is dragged narrow, which the splitter allows.
 //
-// History depth therefore follows the widget height: at ~20 fps a
-// 700-pixel pane holds a bit over half a minute.
+// History depth therefore follows the widget height: at ~20 fps the
+// default 160-pixel strip holds about eight seconds, and dragging the
+// splitter down buys more.
 //
 // Audio comes from the same RingBuffer the decoder reads, via `tail()`
 // -- a display-sized slice, never `snapshot()`. The decode loop already
@@ -58,9 +63,20 @@ public:
     void set_ring(std::shared_ptr<rx::RingBuffer> ring);
     void clear();
 
+    // The clip indicator latches: a peak at or over unity marks the
+    // display until the operator clicks the meter. The instantaneous
+    // red bar reverts as soon as the peak passes, which for a 20 fps
+    // meter means a clipped over could come and go entirely unseen.
+    // Latched state is what turns "was it clipping while I was away?"
+    // into a question with an answer -- which is also why replacing
+    // the ring does *not* clear it.
+    bool clip_latched() const { return clip_latched_; }
+    void clear_clip();
+
 protected:
     void paintEvent(QPaintEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
 
 private slots:
     // A slot rather than a plain member so a test can drive one frame
@@ -72,12 +88,14 @@ private:
     void ensure_image();
     void draw_band_markers(QPainter& painter);
     void draw_level_meter(QPainter& painter);
+    void draw_disabled_scrim(QPainter& painter);
 
     std::shared_ptr<rx::RingBuffer> ring_;
     // Exactly widget-sized; see the header comment.
     QImage image_;
     double peak_ = 0.0;
     bool clipping_ = false;
+    bool clip_latched_ = false;
 };
 
 }  // namespace sstvae::gui

--- a/native/tests/CMakeLists.txt
+++ b/native/tests/CMakeLists.txt
@@ -26,6 +26,18 @@ target_link_libraries(test_ringbuffer PRIVATE sstvae_core)
 target_include_directories(test_ringbuffer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME ringbuffer COMMAND test_ringbuffer)
 
+add_executable(test_framing test_framing.cpp)
+target_link_libraries(test_framing PRIVATE sstvae_core)
+target_include_directories(test_framing PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME framing COMMAND test_framing)
+set_tests_properties(framing PROPERTIES TIMEOUT 180)
+
+add_executable(test_log test_log.cpp)
+target_link_libraries(test_log PRIVATE sstvae_core)
+target_include_directories(test_log PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME log COMMAND test_log)
+set_tests_properties(log PROPERTIES TIMEOUT 120)
+
 # The decode loop's decisions, with a stub decoder in place of the
 # codec -- so the state machine is covered in every build, including
 # --no-codec.
@@ -176,6 +188,38 @@ if(TARGET sstvae_gui)
   sstvae_onnxruntime_copy_runtime(test_overlay_editor)
   add_test(NAME overlay_editor COMMAND test_overlay_editor)
   set_tests_properties(overlay_editor PROPERTIES TIMEOUT 300)
+
+  add_executable(test_crop_view test_crop_view.cpp)
+  target_link_libraries(test_crop_view PRIVATE sstvae_gui)
+  target_include_directories(test_crop_view PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  sstvae_hamlib_copy_runtime(test_crop_view)
+  sstvae_onnxruntime_copy_runtime(test_crop_view)
+  add_test(NAME crop_view COMMAND test_crop_view)
+  set_tests_properties(crop_view PROPERTIES TIMEOUT 300)
+
+  add_executable(test_log_pane test_log_pane.cpp)
+  target_link_libraries(test_log_pane PRIVATE sstvae_gui)
+  target_include_directories(test_log_pane PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  sstvae_hamlib_copy_runtime(test_log_pane)
+  sstvae_onnxruntime_copy_runtime(test_log_pane)
+  add_test(NAME log_pane COMMAND test_log_pane)
+  set_tests_properties(log_pane PROPERTIES TIMEOUT 300)
+
+  add_executable(test_picture_box test_picture_box.cpp)
+  target_link_libraries(test_picture_box PRIVATE sstvae_gui)
+  target_include_directories(test_picture_box PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  sstvae_hamlib_copy_runtime(test_picture_box)
+  sstvae_onnxruntime_copy_runtime(test_picture_box)
+  add_test(NAME picture_box COMMAND test_picture_box)
+  set_tests_properties(picture_box PROPERTIES TIMEOUT 300)
+
+  add_executable(test_pane_container test_pane_container.cpp)
+  target_link_libraries(test_pane_container PRIVATE sstvae_gui)
+  target_include_directories(test_pane_container PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  sstvae_hamlib_copy_runtime(test_pane_container)
+  sstvae_onnxruntime_copy_runtime(test_pane_container)
+  add_test(NAME pane_container COMMAND test_pane_container)
+  set_tests_properties(pane_container PROPERTIES TIMEOUT 300)
 
   add_executable(test_waterfall test_waterfall.cpp)
   target_link_libraries(test_waterfall PRIVATE sstvae_gui)

--- a/native/tests/test_crop_view.cpp
+++ b/native/tests/test_crop_view.cpp
@@ -1,0 +1,178 @@
+// The framing dialog's interaction arithmetic.
+//
+// Everything here has a right answer and none of it needs eyes, which
+// is the same line `test_overlay_editor.cpp` draws. The one that
+// matters most is the drag direction: `paintEvent` holds the picture
+// still and moves the crop window, so a drag to the right must select
+// a window further right. The first version of this widget had the
+// opposite sign -- taken from a comment describing a widget that pans
+// the picture instead -- so dragging right selected further left, and
+// nothing in the repository could see it.
+
+#include <QApplication>
+#include <QMouseEvent>
+#include <QWheelEvent>
+
+#include <cmath>
+
+#include "check.hpp"
+#include "crop_dialog.hpp"
+#include "images/images.hpp"
+
+namespace check = sstvae::check;
+using sstvae::gui::CropView;
+using sstvae::images::Framing;
+using sstvae::images::Picture;
+
+namespace {
+
+constexpr int W = 520;
+constexpr int H = 390;
+
+Picture flat(int width, int height) {
+    Picture p(width, height);
+    for (std::size_t i = 0; i < p.rgb.size(); ++i) {
+        p.rgb[i] = static_cast<std::uint8_t>(i % 251);
+    }
+    return p;
+}
+
+void drag(CropView& view, double from_x, double from_y, double dx, double dy) {
+    const QPointF from(from_x, from_y);
+    const QPointF to(from_x + dx, from_y + dy);
+    QMouseEvent press(QEvent::MouseButtonPress, from, view.mapToGlobal(from),
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(&view, &press);
+    QMouseEvent move(QEvent::MouseMove, to, view.mapToGlobal(to), Qt::NoButton,
+                     Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(&view, &move);
+    QMouseEvent release(QEvent::MouseButtonRelease, to, view.mapToGlobal(to),
+                        Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    QApplication::sendEvent(&view, &release);
+}
+
+void wheel(CropView& view, int delta, int times) {
+    for (int i = 0; i < times; ++i) {
+        QWheelEvent event(QPointF(W / 2.0, H / 2.0),
+                          view.mapToGlobal(QPointF(W / 2.0, H / 2.0)),
+                          QPoint(0, 0), QPoint(0, delta), Qt::NoButton,
+                          Qt::NoModifier, Qt::NoScrollPhase, false);
+        QApplication::sendEvent(&view, &event);
+    }
+}
+
+void test_drag_moves_the_window_with_the_pointer() {
+    CropView view;
+    view.resize(W, H);
+    view.set_source(flat(1600, 900));  // 16:9: room to pan horizontally
+    view.set_framing(Framing{});
+
+    const double start = view.framing().center_x;
+    drag(view, W / 2.0, H / 2.0, 40, 0);
+    check::is_true(view.framing().center_x > start,
+                   "crop/drag: dragging right selects further right");
+
+    const double after_right = view.framing().center_x;
+    drag(view, W / 2.0, H / 2.0, -40, 0);
+    check::is_true(view.framing().center_x < after_right,
+                   "crop/drag: dragging left comes back");
+}
+
+void test_drag_is_vertical_too_when_there_is_room() {
+    CropView view;
+    view.resize(W, H);
+    view.set_source(flat(900, 1600));  // portrait: room to pan vertically
+    view.set_framing(Framing{});
+
+    const double start = view.framing().center_y;
+    drag(view, W / 2.0, H / 2.0, 0, 30);
+    check::is_true(view.framing().center_y > start,
+                   "crop/drag: dragging down selects further down");
+}
+
+void test_drag_stops_at_the_edges() {
+    CropView view;
+    view.resize(W, H);
+    view.set_source(flat(1600, 900));
+    view.set_framing(Framing{});
+
+    // Far beyond the picture: the window must stop at the edge rather
+    // than hang over nothing, which `images::fit` would then clamp
+    // differently from what was previewed.
+    drag(view, W / 2.0, H / 2.0, 5000, 5000);
+    const Framing f = view.framing();
+    check::is_true(f.center_x <= 1.0 && f.center_x >= 0.0,
+                   "crop/drag: centre_x stays inside the picture");
+    check::is_true(f.center_y <= 1.0 && f.center_y >= 0.0,
+                   "crop/drag: centre_y stays inside the picture");
+    // A 16:9 source at zoom 1 has no vertical slack at all, so the
+    // vertical centre cannot have moved.
+    check::is_true(std::abs(f.center_y - 0.5) < 1e-9,
+                   "crop/drag: no vertical travel when there is no slack");
+}
+
+void test_a_trackpad_gesture_does_not_slam_the_zoom() {
+    CropView view;
+    view.resize(W, H);
+    view.set_source(flat(1600, 900));
+    view.set_framing(Framing{});
+
+    // Ten high-resolution events of 4 units each -- a third of one
+    // physical detent. Treating each event as a full notch ran this to
+    // the 4x ceiling; accumulating leaves it untouched.
+    wheel(view, 4, 10);
+    check::is_true(std::abs(view.framing().zoom - 1.0) < 1e-9,
+                   "crop/wheel: a third of a notch does not zoom");
+
+    // And a real notch does move it, once.
+    wheel(view, 120, 1);
+    check::is_true(view.framing().zoom > 1.0,
+                   "crop/wheel: one full notch zooms in");
+    check::is_true(view.framing().zoom < 1.2,
+                   "crop/wheel: by one step, not several");
+}
+
+void test_zoom_is_bounded() {
+    CropView view;
+    view.resize(W, H);
+    view.set_source(flat(1600, 900));
+    view.set_framing(Framing{});
+
+    wheel(view, 120, 200);
+    check::is_true(view.framing().zoom <= 4.0 + 1e-9,
+                   "crop/wheel: zoom stops at the ceiling");
+    wheel(view, -120, 400);
+    check::is_true(view.framing().zoom >= 1.0 - 1e-9,
+                   "crop/wheel: and never below cover");
+}
+
+void test_an_empty_source_is_harmless() {
+    // The dialog is never opened without a picture, but a widget that
+    // divides by a zero-sized source would be a crash rather than a
+    // wrong picture, so it is worth one assertion.
+    CropView view;
+    view.resize(W, H);
+    view.set_framing(Framing{});
+    drag(view, 10, 10, 20, 20);
+    wheel(view, 120, 1);
+    const Framing f = view.framing();
+    check::is_true(!std::isnan(f.center_x) && !std::isnan(f.center_y),
+                   "crop/empty: no NaN from a source-less view");
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    check::report_crashes_instead_of_prompting();
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    const QApplication app(argc, argv);
+
+    test_drag_moves_the_window_with_the_pointer();
+    test_drag_is_vertical_too_when_there_is_room();
+    test_drag_stops_at_the_edges();
+    test_a_trackpad_gesture_does_not_slam_the_zoom();
+    test_zoom_is_bounded();
+    test_an_empty_source_is_harmless();
+
+    return check::report("crop view");
+}

--- a/native/tests/test_framing.cpp
+++ b/native/tests/test_framing.cpp
@@ -1,0 +1,264 @@
+// `images::fit` with a Framing, and the contract that matters most:
+// adding framing must not change what the default call produces.
+//
+// The trap is one pixel wide. The old code cropped at
+// `(scaled - target) / 2` -- integer division, i.e. truncation -- and
+// the natural rewrite `lround(center * scaled - target / 2.0)` agrees
+// for an even `scaled` and disagrees by one for an odd one. Every
+// odd-intermediate picture would then shift a pixel, silently, for no
+// reason the operator asked for.
+//
+// **The oracle has to be the old formula, reimplemented here.**
+// Comparing `fit(img)` against `fit(img, Framing{})` proves nothing:
+// the first delegates to the second, so it compares the function to
+// itself and passes however wrong both are. (Verified -- that first
+// draft passed with the `lround` mutation in place.) Nor can Python be
+// the oracle: `tests/test_native_parity.py` deliberately does not
+// compare `fit_image` on anything that needs resampling, because PIL's
+// LANCZOS and stb's filter differ by design. So the reference below
+// resamples through the *same* `images::resize`, which isolates the
+// one thing under test -- the crop offset.
+
+#include "images/images.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "check.hpp"
+#include "images/types.hpp"
+
+namespace check = sstvae::check;
+using sstvae::images::Framing;
+using sstvae::images::Picture;
+
+namespace {
+
+// A deterministic, non-uniform picture: every pixel encodes its own
+// position, so a crop that lands one pixel out is visible as a
+// mismatch rather than hidden by flat colour.
+Picture ramp(int width, int height) {
+    Picture p(width, height);
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            const std::size_t i = (static_cast<std::size_t>(y) * width + x) * 3;
+            p.rgb[i] = static_cast<std::uint8_t>(x % 256);
+            p.rgb[i + 1] = static_cast<std::uint8_t>(y % 256);
+            p.rgb[i + 2] = static_cast<std::uint8_t>((x + y) % 256);
+        }
+    }
+    return p;
+}
+
+// The algorithm as it stood before framing existed, written out.
+// Independent of the code under test except for `resize`, which is
+// shared on purpose so the resampler cancels and only the crop offset
+// is being compared.
+Picture reference_fit(const Picture& img) {
+    const int W = sstvae::images::IMG_W;
+    const int H = sstvae::images::IMG_H;
+    if (img.width == W && img.height == H) return img;
+    const double scale = std::max(static_cast<double>(W) / img.width,
+                                  static_cast<double>(H) / img.height);
+    const int sw = std::max(W, static_cast<int>(std::lround(img.width * scale)));
+    const int sh = std::max(H, static_cast<int>(std::lround(img.height * scale)));
+    const Picture scaled = sstvae::images::resize(img, sw, sh);
+    Picture out(W, H);
+    const int left = (sw - W) / 2;  // the original integer division
+    const int top = (sh - H) / 2;
+    for (int y = 0; y < H; ++y) {
+        const std::uint8_t* src =
+            scaled.rgb.data() + (static_cast<std::size_t>(y + top) * sw + left) * 3;
+        std::copy(src, src + static_cast<std::size_t>(W) * 3,
+                  out.rgb.begin() + static_cast<std::size_t>(y) * W * 3);
+    }
+    return out;
+}
+
+void test_default_framing_matches_the_old_algorithm() {
+    // Sizes chosen so both parities of the scaled intermediate appear --
+    // that is where truncation and rounding disagree. 1920x1080 scales
+    // to 853 wide (odd); 800x600 to 640 (even).
+    const std::vector<std::pair<int, int>> sizes = {
+        {640, 480},  {1920, 1080}, {800, 600},  {481, 640},
+        {1001, 700}, {333, 250},   {1279, 721}, {320, 240},
+    };
+    int odd_seen = 0;
+    for (const auto& [w, h] : sizes) {
+        const Picture src = ramp(w, h);
+        const Picture want = reference_fit(src);
+        const std::string label = std::to_string(w) + "x" + std::to_string(h);
+
+        // Record that the sample actually exercises the odd case; a
+        // suite that only ever saw even intermediates would pass with
+        // the bug present.
+        const double scale =
+            std::max(static_cast<double>(sstvae::images::IMG_W) / w,
+                     static_cast<double>(sstvae::images::IMG_H) / h);
+        const int sw = std::max(sstvae::images::IMG_W,
+                                static_cast<int>(std::lround(w * scale)));
+        if (sw % 2 == 1) ++odd_seen;
+
+        for (const Picture& got :
+             {sstvae::images::fit(src), sstvae::images::fit(src, Framing{})}) {
+            check::equal(got.width, want.width, "framing/default: width " + label);
+            check::equal(got.height, want.height, "framing/default: height " + label);
+            check::is_true(got.rgb == want.rgb,
+                           "framing/default: byte-identical to the old "
+                           "algorithm for " +
+                               label);
+        }
+    }
+    check::is_true(odd_seen > 0,
+                   "framing/default: the sample includes an odd scaled width, "
+                   "which is the case that can regress");
+}
+
+// Which source pixel ended up at the output's top-left corner.
+//
+// This is the oracle the framing tests needed. `ramp` encodes a pixel's
+// own x in red and y in green, so on a geometry where the cover scale
+// is exactly 1 -- and `resize` then returns the source untouched -- the
+// output's corner pixel *names the crop offset*. Inequality assertions
+// cannot do this: two real mutants (a mirrored pan axis, and zoom
+// applied to width only) both passed a suite built out of `a != b`.
+struct Corner {
+    int x;
+    int y;
+};
+Corner corner_source_of(const Picture& out) {
+    return {out.rgb[0], out.rgb[1]};
+}
+
+void test_panning_selects_the_named_columns() {
+    // 1280x480: the cover scale is max(640/1280, 480/480) = 1.0
+    // exactly, so no resampling happens and the crop is a pure
+    // sub-rectangle whose offset the corner pixel reports.
+    const Picture src = ramp(1280, 480);
+
+    struct Case {
+        double center_x;
+        int want_left;
+        const char* what;
+    };
+    // left = clamp(floor(center*1280 - 320), 0, 640)
+    const Case cases[] = {
+        {0.0, 0, "hard left"},
+        {0.25, 0, "quarter, clamped to the left edge"},
+        {0.5, 320, "centre"},
+        {0.75, 640, "three quarters, clamped to the right edge"},
+        {1.0, 640, "hard right"},
+    };
+    for (const Case& c : cases) {
+        Framing f;
+        f.center_x = c.center_x;
+        const Picture out = sstvae::images::fit(src, f);
+        const Corner got = corner_source_of(out);
+        check::equal(got.x, c.want_left % 256,
+                     std::string("framing/pan: ") + c.what +
+                         " starts at source column " +
+                         std::to_string(c.want_left));
+        check::equal(got.y, 0, std::string("framing/pan: ") + c.what +
+                                   " starts at source row 0");
+    }
+
+    // Directional, stated separately so a mirrored axis is unmistakable
+    // rather than merely "different".
+    Framing left;
+    left.center_x = 0.0;
+    Framing right;
+    right.center_x = 1.0;
+    check::is_true(corner_source_of(sstvae::images::fit(src, left)).x <
+                       corner_source_of(sstvae::images::fit(src, right)).x,
+                   "framing/pan: a smaller centre selects a smaller column");
+}
+
+void test_zoom_crops_both_axes_equally() {
+    // 1280x960 is 4:3, so the cover scale is 0.5 and zoom 2 makes it
+    // exactly 1.0 -- again no resampling. The window is then the middle
+    // 640x480 of the source, and both offsets are checkable.
+    const Picture src = ramp(1280, 960);
+    Framing zoomed;
+    zoomed.zoom = 2.0;
+    const Picture out = sstvae::images::fit(src, zoomed);
+
+    const Corner got = corner_source_of(out);
+    check::equal(got.x, 320 % 256, "framing/zoom: left offset is 320");
+    check::equal(got.y, 240 % 256, "framing/zoom: top offset is 240");
+
+    // The whole sub-rectangle, not only its corner: this is what fails
+    // if zoom is applied to one axis and not the other, since the
+    // squashed intermediate changes every row.
+    Picture want(sstvae::images::IMG_W, sstvae::images::IMG_H);
+    for (int y = 0; y < sstvae::images::IMG_H; ++y) {
+        const std::uint8_t* row =
+            src.rgb.data() +
+            ((static_cast<std::size_t>(y) + 240) * 1280 + 320) * 3;
+        std::copy(row, row + static_cast<std::size_t>(sstvae::images::IMG_W) * 3,
+                  want.rgb.begin() +
+                      static_cast<std::size_t>(y) * sstvae::images::IMG_W * 3);
+    }
+    check::is_true(out.rgb == want.rgb,
+                   "framing/zoom: the output is exactly the centre 640x480 "
+                   "of a 2x-zoomed 1280x960 source");
+
+    // Below 1 would expose edges with nothing behind them.
+    Framing under;
+    under.zoom = 0.25;
+    check::is_true(
+        sstvae::images::fit(src, under).rgb ==
+            sstvae::images::fit(src, Framing{}).rgb,
+        "framing/zoom: below 1 is clamped to cover");
+}
+
+void test_out_of_range_centres_are_clamped() {
+    const Picture src = ramp(1280, 480);
+    Framing far;
+    far.center_x = 5.0;
+    far.center_y = -3.0;
+    const Picture out = sstvae::images::fit(src, far);
+    check::equal(out.width, sstvae::images::IMG_W, "framing/clamp: right size");
+    // Named offsets rather than a comparison against another call of
+    // the same function: the rightmost legal window starts at column
+    // 640, and the vertical has no room at all so it starts at row 0.
+    const Corner got = corner_source_of(out);
+    check::equal(got.x, 640 % 256,
+                 "framing/clamp: a far-right centre lands on column 640");
+    check::equal(got.y, 0, "framing/clamp: a negative centre lands on row 0");
+}
+
+void test_identity_shortcut_respects_framing() {
+    // A 640x480 source with the default framing is returned untouched
+    // (the parity path). With a zoom it must NOT be -- an operator who
+    // zoomed an already-4:3 picture meant it.
+    const Picture src = ramp(sstvae::images::IMG_W, sstvae::images::IMG_H);
+    check::is_true(sstvae::images::fit(src, Framing{}).rgb == src.rgb,
+                   "framing/identity: default framing returns the original");
+    Framing zoomed;
+    zoomed.zoom = 1.5;
+    check::is_true(sstvae::images::fit(src, zoomed).rgb != src.rgb,
+                   "framing/identity: a zoom is honoured on a 4:3 source");
+}
+
+}  // namespace
+
+int main() {
+    check::report_crashes_instead_of_prompting();
+    check::Watchdog watchdog(120.0, "framing");
+
+    check::current_step.store("default_matches_bare");
+    test_default_framing_matches_the_old_algorithm();
+    check::current_step.store("pan");
+    test_panning_selects_the_named_columns();
+    check::current_step.store("zoom");
+    test_zoom_crops_both_axes_equally();
+    check::current_step.store("clamp");
+    test_out_of_range_centres_are_clamped();
+    check::current_step.store("identity");
+    test_identity_shortcut_respects_framing();
+
+    return check::report("framing");
+}

--- a/native/tests/test_log.cpp
+++ b/native/tests/test_log.cpp
@@ -1,0 +1,170 @@
+// The status log: bounding, sinks, formatting, and file rotation.
+//
+// The rotation test uses a tiny max_bytes so it exercises the shift
+// chain (.log -> .1 -> .2) rather than needing a megabyte of lines.
+
+#include "log/log.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+
+namespace fs = std::filesystem;
+namespace check = sstvae::check;
+using sstvae::log::Entry;
+using sstvae::log::FileWriter;
+using sstvae::log::format_entry;
+using sstvae::log::Severity;
+using sstvae::log::StatusLog;
+
+namespace {
+
+std::string read_all(const fs::path& p) {
+    std::ifstream in(p);
+    return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+
+// Portable and unique without getpid(); same idiom as test_checkpoint.
+fs::path make_temp_dir() {
+    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    const fs::path dir =
+        fs::temp_directory_path() / ("sstvae-log-" + std::to_string(stamp));
+    fs::create_directories(dir);
+    return dir;
+}
+
+void test_append_and_snapshot() {
+    StatusLog log(10);
+    log.append("rig", Severity::Info, "Rig: 14.2300 MHz");
+    log.append("tx", Severity::Error, "PTT OFF FAILED");
+    const auto entries = log.snapshot();
+    check::equal(entries.size(), std::size_t{2}, "two entries retained");
+    check::equal(entries[0].source, std::string("rig"), "source kept");
+    check::equal(entries[1].text, std::string("PTT OFF FAILED"), "text kept");
+    check::is_true(entries[0].ms > 0, "wall-clock stamp set");
+    check::is_true(entries[0].ms <= entries[1].ms, "entries in order");
+}
+
+void test_bounded() {
+    StatusLog log(3);
+    for (int i = 0; i < 10; ++i) {
+        log.append("app", Severity::Info, "line " + std::to_string(i));
+    }
+    const auto entries = log.snapshot();
+    check::equal(entries.size(), std::size_t{3}, "bounded to max_entries");
+    check::equal(entries.front().text, std::string("line 7"), "oldest dropped");
+    check::equal(entries.back().text, std::string("line 9"), "newest kept");
+}
+
+void test_sink_sees_every_entry() {
+    StatusLog log(2);  // smaller than the number of appends
+    std::vector<std::string> seen;
+    log.add_sink([&](const Entry& e) { seen.push_back(e.text); });
+    for (int i = 0; i < 5; ++i) {
+        log.append("rx", Severity::Info, std::to_string(i));
+    }
+    check::equal(seen.size(), std::size_t{5},
+                 "sink not bounded by the in-memory cap");
+}
+
+void test_format() {
+    Entry e;
+    e.ms = 1000;  // epoch + 1 s, any zone: the fields we assert are stable
+    e.source = "rig";
+    e.severity = Severity::Error;
+    e.text = "no response";
+    const std::string line = format_entry(e);
+    check::is_true(line.find("rig") != std::string::npos, "source in line");
+    check::is_true(line.find("ERROR") != std::string::npos, "severity in line");
+    check::is_true(line.find("no response") != std::string::npos, "text in line");
+    check::is_true(line.find("1970-") != std::string::npos ||
+                       line.find("1969-") != std::string::npos,
+                   "date rendered from the stamp");
+}
+
+void test_file_rotation(const fs::path& dir) {
+    const fs::path path = dir / "sstvae.log";
+    FileWriter writer(path, /*max_bytes=*/64, /*rotations=*/2);
+    check::is_true(writer.error().empty(), "writer opens cleanly");
+
+    Entry e;
+    e.ms = 0;
+    e.source = "app";
+    e.severity = Severity::Info;
+    for (int i = 0; i < 12; ++i) {
+        e.text = "rotation filler line " + std::to_string(i);
+        writer.write(e);
+    }
+    check::is_true(fs::exists(path), "live file exists");
+    check::is_true(fs::exists(path.string() + ".1"), "first rotation exists");
+    check::is_true(fs::exists(path.string() + ".2"), "second rotation exists");
+    check::is_true(!fs::exists(path.string() + ".3"),
+                   "nothing beyond the configured rotations");
+    // The newest line survives in the live file or the newest rotation;
+    // rotation must never *lose* it.
+    const std::string joined =
+        read_all(path) + read_all(path.string() + ".1");
+    check::is_true(joined.find("line 11") != std::string::npos,
+                   "newest line not lost to rotation");
+    check::is_true(writer.error().empty(), "no error after rotating");
+}
+
+void test_missing_parent_is_created(const fs::path& dir) {
+    // A fresh install has no config directory yet; the writer creates
+    // it rather than silently producing no file for the first session.
+    FileWriter writer(dir / "fresh-subdir" / "sstvae.log");
+    check::is_true(writer.error().empty(),
+                   "a missing parent directory is created");
+    Entry e;
+    e.source = "app";
+    e.text = "first line";
+    writer.write(e);
+    check::is_true(fs::exists(dir / "fresh-subdir" / "sstvae.log"),
+                   "and the file lands in it");
+}
+
+void test_file_failure_is_loud(const fs::path& dir) {
+    // A parent that cannot be a directory, because it is a file: the
+    // open fails, error() says so, and write() is a no-op rather than
+    // a crash.
+    std::ofstream(dir / "blocker").put('\n');
+    FileWriter writer(dir / "blocker" / "sstvae.log");
+    check::is_true(!writer.error().empty(), "open failure reported");
+    Entry e;
+    e.source = "app";
+    e.text = "dropped";
+    writer.write(e);  // must not throw
+}
+
+}  // namespace
+
+int main() {
+    check::report_crashes_instead_of_prompting();
+    check::Watchdog watchdog(60.0, "log");
+
+    check::current_step.store("append_and_snapshot");
+    test_append_and_snapshot();
+    check::current_step.store("bounded");
+    test_bounded();
+    check::current_step.store("sink");
+    test_sink_sees_every_entry();
+    check::current_step.store("format");
+    test_format();
+
+    const fs::path dir = make_temp_dir();
+    check::current_step.store("rotation");
+    test_file_rotation(dir);
+    check::current_step.store("missing_parent");
+    test_missing_parent_is_created(dir);
+    check::current_step.store("failure_is_loud");
+    test_file_failure_is_loud(dir);
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+
+    return check::report("log");
+}

--- a/native/tests/test_log_pane.cpp
+++ b/native/tests/test_log_pane.cpp
@@ -1,0 +1,138 @@
+// The log pane and the error banner, in the parts with a right answer.
+//
+// What needs eyes stays with sstvae-gui-shot; what does not: the pane
+// backfills from the log's snapshot (startup entries logged before the
+// pane existed must appear), the filter re-renders from the log rather
+// than hiding blocks, error lines render bold, appends follow the tail
+// without dragging the view right, and the banner is hidden until an
+// error arrives and stays until cleared.
+
+#include <QApplication>
+#include <QComboBox>
+#include <QPlainTextEdit>
+#include <QScrollBar>
+#include <QTextBlock>
+
+#include <string>
+
+#include "banner.hpp"
+#include "check.hpp"
+#include "log/log.hpp"
+#include "log_pane.hpp"
+
+namespace check = sstvae::check;
+using sstvae::gui::ErrorBanner;
+using sstvae::gui::LogPane;
+using sstvae::log::Severity;
+using sstvae::log::StatusLog;
+
+namespace {
+
+QPlainTextEdit* text_of(LogPane& pane) {
+    auto* text = pane.findChild<QPlainTextEdit*>();
+    check::is_true(text != nullptr, "pane has a text view");
+    return text;
+}
+
+void test_backfill_from_snapshot() {
+    StatusLog log;
+    log.append("app", Severity::Warning, "config: bad key");
+    log.append("rig", Severity::Info, "Rig: 14.2300 MHz");
+
+    // Entries logged *before* the pane existed -- the startup case.
+    LogPane pane(&log);
+    const QString shown = text_of(pane)->toPlainText();
+    check::is_true(shown.contains("config: bad key"),
+                   "pane/backfill: startup entries appear");
+    check::is_true(shown.contains("14.2300"),
+                   "pane/backfill: all of them");
+}
+
+void test_append_and_filter() {
+    StatusLog log;
+    log.append("rig", Severity::Info, "rig line");
+    LogPane pane(&log);
+
+    // Live append through the slot, as AppState::logEntry delivers it.
+    log.append("tx", Severity::Error, "tx error line");
+    // By value: `snapshot()` returns a vector, so binding a
+    // reference to its `back()` leaves one dangling at the end of
+    // the full expression -- GCC's -Wdangling-reference is right.
+    const auto entry = log.snapshot().back();
+    pane.append(entry.ms, "tx", static_cast<int>(Severity::Error),
+                "tx error line");
+    QPlainTextEdit* text = text_of(pane);
+    check::is_true(text->toPlainText().contains("tx error line"),
+                   "pane/append: live entries appear");
+
+    // The error line is bold; the info line is not.
+    const QTextBlock last = text->document()->lastBlock();
+    check::is_true(last.begin().fragment().charFormat().fontWeight() ==
+                       QFont::Bold,
+                   "pane/append: error lines are bold");
+
+    // Filtering to another source re-renders from the log.
+    auto* filter = pane.findChild<QComboBox*>();
+    check::is_true(filter != nullptr, "pane has a filter");
+    filter->setCurrentText(QStringLiteral("rig"));
+    check::is_true(!text->toPlainText().contains("tx error line"),
+                   "pane/filter: other sources drop out");
+    check::is_true(text->toPlainText().contains("rig line"),
+                   "pane/filter: the wanted source stays");
+    filter->setCurrentText(QStringLiteral("All"));
+    check::is_true(text->toPlainText().contains("tx error line"),
+                   "pane/filter: All restores everything");
+}
+
+void test_follow_never_scrolls_right() {
+    StatusLog log;
+    LogPane pane(&log);
+    pane.resize(400, 160);
+    pane.show();
+    QPlainTextEdit* text = text_of(pane);
+
+    const std::string long_text(300, 'x');
+    for (int i = 0; i < 8; ++i) {
+        log.append("rx", Severity::Info, long_text);
+        const auto entry = log.snapshot().back();
+        pane.append(entry.ms, "rx", static_cast<int>(Severity::Info),
+                    QString::fromStdString(long_text));
+    }
+    check::equal(text->horizontalScrollBar()->value(), 0,
+                 "pane/follow: long lines never drag the view right");
+}
+
+void test_banner_lifecycle() {
+    ErrorBanner banner;
+    check::is_true(banner.isHidden(), "banner/initial: hidden");
+    check::is_true(banner.message().isEmpty(), "banner/initial: empty");
+
+    banner.show_error(QStringLiteral("PTT OFF FAILED"));
+    check::is_true(!banner.isHidden(), "banner/error: shown");
+    check::equal(banner.message().toStdString(), std::string("PTT OFF FAILED"),
+                 "banner/error: carries the message");
+
+    // A later error replaces, never appends.
+    banner.show_error(QStringLiteral("second"));
+    check::equal(banner.message().toStdString(), std::string("second"),
+                 "banner/error: newest message wins");
+
+    banner.clear();
+    check::is_true(banner.isHidden(), "banner/clear: hidden again");
+    check::is_true(banner.message().isEmpty(), "banner/clear: and empty");
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    check::report_crashes_instead_of_prompting();
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    const QApplication app(argc, argv);
+
+    test_backfill_from_snapshot();
+    test_append_and_filter();
+    test_follow_never_scrolls_right();
+    test_banner_lifecycle();
+
+    return check::report("log pane + banner");
+}

--- a/native/tests/test_overlay_editor.cpp
+++ b/native/tests/test_overlay_editor.cpp
@@ -9,12 +9,18 @@
 // like a working editor until an item will not go where you put it.
 
 #include <QApplication>
+#include <QKeyEvent>
 #include <QMouseEvent>
+#include <QLayout>
+#include <QVBoxLayout>
+#include <QWidget>
 
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <memory>
 #include <string>
+#include <variant>
 
 #include "check.hpp"
 #include "images/types.hpp"
@@ -68,6 +74,12 @@ void move_to(gui::OverlayEditor& editor, QPoint at) {
 void release(gui::OverlayEditor& editor, QPoint at) {
     QMouseEvent event(QEvent::MouseButtonRelease, QPointF(at), QPointF(at),
                       Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    QApplication::sendEvent(&editor, &event);
+}
+
+void key(gui::OverlayEditor& editor, int code,
+         Qt::KeyboardModifiers mods = Qt::NoModifier) {
+    QKeyEvent event(QEvent::KeyPress, code, mods);
     QApplication::sendEvent(&editor, &event);
 }
 
@@ -219,6 +231,128 @@ void test_the_composite_is_the_renderer_s_output() {
 
 }  // namespace
 
+
+void test_arrows_nudge_by_a_fixed_fraction() {
+    // The nudge exists because a mouse cannot do it: positions are
+    // normalized, so the smallest drag is one widget pixel -- a
+    // different distance at every window size. A key step has to be a
+    // fixed fraction of the canvas, and it has to move the axis it
+    // names in the direction it names.
+    std::unique_ptr<gui::OverlayEditor> editor(make_editor());
+    editor->add_text("N0CALL");
+    overlay::Item* item = editor->selected_item();
+    check::is_true(item != nullptr, "nudge: an added item is selected");
+
+    const double x0 = std::visit([](const auto& i) { return i.x; }, *item);
+    const double y0 = std::visit([](const auto& i) { return i.y; }, *item);
+
+    constexpr double FINE = 1.0 / 640.0;
+    const auto ix = [&] { return std::visit([](const auto& i) { return i.x; }, *item); };
+    const auto iy = [&] { return std::visit([](const auto& i) { return i.y; }, *item); };
+
+    key(*editor, Qt::Key_Right);
+    check::is_true(std::abs(ix() - (x0 + FINE)) <= 1e-9,
+                   "nudge: right moves +x by one fine step");
+    check::is_true(std::abs(iy() - y0) <= 1e-9, "nudge: right leaves y alone");
+
+    key(*editor, Qt::Key_Left);
+    check::is_true(std::abs(ix() - x0) <= 1e-9, "nudge: left comes back");
+
+    key(*editor, Qt::Key_Down);
+    check::is_true(std::abs(iy() - (y0 + FINE)) <= 1e-9, "nudge: down moves +y");
+    key(*editor, Qt::Key_Up);
+    check::is_true(std::abs(iy() - y0) <= 1e-9, "nudge: up comes back");
+
+    // Shift is the coarse step, and it is bigger -- not merely
+    // different, which an inequality assertion would also accept.
+    constexpr double COARSE = 1.0 / 64.0;
+    key(*editor, Qt::Key_Right, Qt::ShiftModifier);
+    check::is_true(std::abs(ix() - (x0 + COARSE)) <= 1e-9,
+                   "nudge: shift takes the coarse step");
+}
+
+void test_delete_removes_the_selection() {
+    std::unique_ptr<gui::OverlayEditor> editor(make_editor());
+    editor->add_text("N0CALL");
+    check::equal(static_cast<int>(editor->doc().items.size()), 1,
+                 "delete: one item to begin with");
+    key(*editor, Qt::Key_Delete);
+    check::equal(static_cast<int>(editor->doc().items.size()), 0,
+                 "delete: the key removes it");
+    check::is_true(editor->selected_item() == nullptr,
+                   "delete: and clears the selection");
+
+    // With nothing selected the key must fall through rather than be
+    // swallowed, or a shortcut elsewhere in the window stops working.
+    key(*editor, Qt::Key_Delete);
+    check::equal(static_cast<int>(editor->doc().items.size()), 0,
+                 "delete: harmless with an empty document");
+}
+
+void test_an_added_item_can_be_nudged_without_clicking_first() {
+    // The flow the feature is for: Add text, then line it up. The
+    // button that added it has the focus, so unless the editor takes
+    // focus the keys are dead exactly here.
+    std::unique_ptr<gui::OverlayEditor> editor(make_editor());
+    editor->add_text("N0CALL");
+    check::is_true(editor->hasFocus() || editor->focusPolicy() != Qt::ClickFocus,
+                   "nudge: the editor is reachable by keyboard after an add");
+}
+
+// The editor must not pin a window height to its own width.
+//
+// It used to: `setFixedHeight(width * 3/4)` in `resizeEvent`, which is
+// a hard *minimum*, so widening the transmit pane raised a floor under
+// the whole window that narrowing it never lowered. Measured before the
+// fix, through `sstvae-gui-shot --transmit`: the panel's minimum height
+// went 611 px at 545 wide, 925 at 1348, **1274 at 1900**. Bounded while
+// a splitter kept the pane narrow; unbounded once a tab hands it the
+// entire window. The identical construct in the receive preview is
+// guarded by `test_picture_box.cpp` -- this is the other copy.
+//
+// Nothing is lost by capping instead: `canvas_rect()` letterboxes in
+// both directions, so a pane too short for 4:3 draws a smaller centred
+// canvas and the handles follow it, because they come from that same
+// rectangle.
+void test_it_pins_no_window_height() {
+    QWidget container;
+    auto* layout = new QVBoxLayout(&container);
+    layout->setContentsMargins(0, 0, 0, 0);
+    auto* editor = new gui::OverlayEditor(&container);
+    layout->addWidget(editor);
+    container.resize(3000, 2000);
+    container.show();
+
+    int previous = 0;
+    for (const int w : {545, 900, 1348, 1900}) {
+        // Twice: the cap is derived from the width, so Qt clamps the
+        // incoming geometry against the previous one and the new cap
+        // applies on the pass `updateGeometry` asks for.
+        for (int pass = 0; pass < 2; ++pass) {
+            container.setGeometry(0, 0, w, 400);
+            QCoreApplication::processEvents();
+        }
+        const int floor = container.minimumSizeHint().height();
+        if (previous != 0) {
+            check::equal(floor, previous,
+                         "the minimum height does not follow the editor's width");
+        }
+        previous = floor;
+
+        // **And the constraint the hint cannot see.** `minimumSizeHint`
+        // never consults `heightForWidth`; what Qt actually applies when
+        // it lays a widget out is `minimumHeightForWidth(width)`. The
+        // first version of this test checked only the hint above, went
+        // green, and shipped a window that grew off the bottom of the
+        // screen -- because `hasHeightForWidth` was still set on the
+        // editor, a `QSplitter` hid it and a `QTabWidget` passed it
+        // straight through to the window.
+        check::is_true(!container.layout()->hasHeightForWidth() ||
+                           container.layout()->minimumHeightForWidth(w) <= floor,
+                       "and neither does minimumHeightForWidth");
+    }
+}
+
 int main(int argc, char** argv) {
     check::report_crashes_instead_of_prompting();
     qputenv("QT_QPA_PLATFORM", "offscreen");
@@ -231,6 +365,10 @@ int main(int argc, char** argv) {
     test_normalized_coordinates_survive_a_resize();
     test_removing_clears_the_selection();
     test_the_composite_is_the_renderer_s_output();
+    test_arrows_nudge_by_a_fixed_fraction();
+    test_delete_removes_the_selection();
+    test_an_added_item_can_be_nudged_without_clicking_first();
+    test_it_pins_no_window_height();
 
     return check::report("overlay editor");
 }

--- a/native/tests/test_pane_container.cpp
+++ b/native/tests/test_pane_container.cpp
@@ -1,0 +1,329 @@
+// The receive/transmit layout switch.
+//
+// Four claims, each of which fails invisibly if it is wrong:
+//
+//   1. The panels survive a mode switch. They are not toys -- the real
+//      ones own a decode thread and a transmit thread -- so a container
+//      that deletes its children when it is replaced would crash a long
+//      way from here, at exit or at the next callback.
+//   2. They come back *visible*. Reparenting through a null parent sets
+//      Qt's explicit-hidden flag, and a widget hidden that way stays
+//      hidden when it is added to a visible layout. The window would
+//      look empty and nothing would have failed.
+//   3. Tabs really are narrower. This is the entire justification for
+//      the feature: a QSplitter's minimum is the sum of its children's,
+//      a QTabWidget's is the max. If it did not hold, "small screen
+//      mode" would be a menu entry that changed nothing.
+//   4. "auto" resolves against the screen and honours an explicit
+//      setting. The dangerous case is a screen we could not measure --
+//      it must not read as "tiny".
+//
+// Deliberately built from two plain widgets rather than the real
+// panels: the switch is container logic, and pulling in AppState would
+// start a model load and open the rig.
+
+#include <QApplication>
+#include <QLabel>
+#include <QPushButton>
+#include <QSize>
+#include <QSizePolicy>
+#include <QPointer>
+#include <QSize>
+#include <QSizePolicy>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <string>
+
+#include "check.hpp"
+#include "flow_layout.hpp"
+#include "pane_container.hpp"
+
+using namespace sstvae;
+using gui::PaneLayout;
+
+namespace {
+
+// A pane with a real minimum width, since that is what the third claim
+// above is about. A bare QWidget has a minimum of zero and both layouts
+// would agree on nothing.
+QWidget* pane(int minimum_width) {
+    auto* w = new QWidget;
+    auto* layout = new QVBoxLayout(w);
+    auto* label = new QLabel(QStringLiteral("x"));
+    label->setMinimumWidth(minimum_width);
+    layout->addWidget(label);
+    return w;
+}
+
+void test_panels_survive_and_stay_visible() {
+    auto* first = pane(200);
+    auto* second = pane(200);
+    QPointer<QWidget> first_alive(first);
+    QPointer<QWidget> second_alive(second);
+
+    gui::PaneContainer container(first, QStringLiteral("Receive"), second,
+                                 QStringLiteral("Transmit"));
+    container.resize(900, 500);
+    container.show();
+
+    check::equal(static_cast<int>(container.mode()),
+                 static_cast<int>(PaneLayout::Split), "starts side by side");
+
+    // Switch both ways twice: a container that leaks or deletes on one
+    // direction only would pass a single switch.
+    for (int round = 0; round < 2; ++round) {
+        container.set_mode(PaneLayout::Tabs);
+        check::is_true(!first_alive.isNull() && !second_alive.isNull(),
+                       "panels survive the switch to tabs");
+        check::is_true(first->isVisible(), "the current tab's panel is visible");
+        // The second tab is *correctly* hidden -- that is what a tab
+        // widget is -- so what is checked is that it is still owned and
+        // becomes visible when selected, not that it is on screen.
+        check::is_true(second->parentWidget() != nullptr,
+                       "the background tab's panel is still parented");
+
+        container.set_mode(PaneLayout::Split);
+        check::is_true(!first_alive.isNull() && !second_alive.isNull(),
+                       "panels survive the switch back to side by side");
+        check::is_true(first->isVisible() && second->isVisible(),
+                       "both panels are visible side by side");
+    }
+}
+
+void test_tabs_are_narrower_than_side_by_side() {
+    // Equal minimums, so the arithmetic is unambiguous: the sum is
+    // twice the max, and any result between them would mean the layout
+    // is not doing what the whole feature assumes.
+    auto* first = pane(300);
+    auto* second = pane(300);
+    gui::PaneContainer container(first, QStringLiteral("Receive"), second,
+                                 QStringLiteral("Transmit"));
+
+    const int split_min = container.minimumSizeHint().width();
+    container.set_mode(PaneLayout::Tabs);
+    const int tabs_min = container.minimumSizeHint().width();
+
+    // Not "smaller by some tolerance" -- the claim is structural. Tabs
+    // hold one pane's minimum where the splitter holds two, so the gap
+    // has to be about a whole pane. Checked loosely (chrome, handle and
+    // group-box margins differ between the two) but not so loosely that
+    // a few pixels would pass.
+    check::is_true(tabs_min < split_min,
+                   "tabs have a smaller minimum width than side by side");
+    check::is_true(tabs_min < split_min * 3 / 4,
+                   "the saving is about a pane, not a margin");
+}
+
+void test_resolve_layout() {
+    // An explicit setting wins over the screen, in both directions:
+    // wanting both halves on a small panel is allowed, and so is
+    // wanting tabs on a large one.
+    check::equal(static_cast<int>(gui::resolve_layout("split", QSize(800, 1200), QSize(1015, 700))),
+                 static_cast<int>(PaneLayout::Split),
+                 "an explicit 'split' is honoured on a screen too small for it");
+    check::equal(static_cast<int>(gui::resolve_layout("tabs", QSize(3840, 1200), QSize(1015, 700))),
+                 static_cast<int>(PaneLayout::Tabs),
+                 "an explicit 'tabs' is honoured on a large screen");
+
+    check::equal(static_cast<int>(gui::resolve_layout("auto", QSize(1920, 1200), QSize(1015, 700))),
+                 static_cast<int>(PaneLayout::Split), "auto: it fits");
+    check::equal(static_cast<int>(gui::resolve_layout("auto", QSize(800, 1200), QSize(1015, 700))),
+                 static_cast<int>(PaneLayout::Tabs), "auto: it does not fit");
+    // Exactly the available width is a fit: a maximised window is a
+    // legitimate way to run this app, and availableGeometry has already
+    // taken the panels and docks off.
+    check::equal(static_cast<int>(gui::resolve_layout("auto", QSize(1015, 1200), QSize(1015, 700))),
+                 static_cast<int>(PaneLayout::Split), "auto: exactly fits");
+
+    // **Height is a constraint too**, and this is what that adds: a
+    // screen wide enough for side by side but too short for it must
+    // still choose tabs. Before this, only width was compared -- fine
+    // while the split layout's height floor was fixed, and wrong once
+    // wrapping made that floor rise as the window narrows.
+    check::equal(static_cast<int>(gui::resolve_layout("auto", QSize(1920, 600),
+                                                     QSize(1015, 800))),
+                 static_cast<int>(PaneLayout::Tabs),
+                 "auto: wide enough but too short still picks tabs");
+    check::equal(static_cast<int>(gui::resolve_layout("auto", QSize(1920, 900),
+                                                     QSize(1015, 800))),
+                 static_cast<int>(PaneLayout::Split),
+                 "auto: room in both axes stays side by side");
+    // An unmeasurable screen is an unanswered question in either axis.
+    check::equal(static_cast<int>(gui::resolve_layout("auto", QSize(1920, 0),
+                                                     QSize(1015, 800))),
+                 static_cast<int>(PaneLayout::Split),
+                 "auto: an unmeasurable height falls to side by side");
+
+    // The failure that must not read as "small screen". A screen we
+    // could not measure is an unanswered question, and answering it
+    // with the fallback layout would quietly demote every operator
+    // whose platform did not report a geometry.
+    check::equal(static_cast<int>(gui::resolve_layout("auto", QSize(0, 1200), QSize(1015, 700))),
+                 static_cast<int>(PaneLayout::Split),
+                 "auto: an unmeasurable screen falls to side by side");
+}
+
+// A stand-in pane: a picture that takes the room, over a control strip
+// of a given height. The two real panes differ only in how tall their
+// strips are, which is exactly what this reproduces.
+struct Pane {
+    QWidget* root;
+    QWidget* picture;
+    QWidget* strip;
+};
+
+Pane make_pane(int strip_rows) {
+    auto* root = new QWidget;
+    auto* layout = new QVBoxLayout(root);
+    layout->setContentsMargins(0, 0, 0, 0);
+    auto* picture = new QWidget(root);
+    picture->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    picture->setMinimumSize(80, 60);
+    layout->addWidget(picture, 1);
+    auto* strip = new QWidget(root);
+    auto* strip_layout = new QVBoxLayout(strip);
+    strip_layout->setContentsMargins(0, 0, 0, 0);
+    for (int i = 0; i < strip_rows; ++i) {
+        // **A wrapping row of real buttons, not a fixed-height label.**
+        // The first version of this fixture used labels of a fixed
+        // height, so the strips could not wrap and the test passed
+        // without ever exercising the case that broke: at narrow widths
+        // the two strips reflow to *different* row counts, and a single
+        // measurement of their heights is then wrong. Different button
+        // counts per row make the two sides wrap at different widths,
+        // which is exactly the real panes' situation.
+        auto* row = new QWidget(strip);
+        auto* flow = new gui::FlowLayout(row);
+        for (int b = 0; b < 3 + i * 2; ++b) {
+            auto* button = new QPushButton(QStringLiteral("button %1").arg(b), row);
+            flow->addWidget(button);
+        }
+        strip_layout->addWidget(row);
+    }
+    layout->addWidget(strip);
+    return {root, picture, strip};
+}
+
+// **The property the whole layout exists to provide**, and the one that
+// had no test while two bugs hid behind it: the two pictures are the
+// same size.
+//
+// It is asserted on *unequal* panes -- three control rows against one --
+// because equal-by-accident is exactly what a fixture of two identical
+// panes would prove. The real panes differ the same way: the composer
+// carries tools, properties and a send bar where the monitor carries a
+// status line, a card and its buttons.
+void test_the_two_pictures_are_the_same_size() {
+    Pane rx = make_pane(1);
+    Pane tx = make_pane(3);
+
+    gui::PaneContainer container(rx.root, QStringLiteral("Receive"), tx.root,
+                                 QStringLiteral("Transmit"));
+    container.set_control_strips(rx.strip, tx.strip);
+    container.show();
+
+    // Deliberately spanning the widths where the rows wrap differently:
+    // 760 and 900 are narrow enough that the two strips take different
+    // numbers of lines, which is where a single-pass measurement failed.
+    for (const QSize size : {QSize(760, 900), QSize(900, 1100), QSize(1200, 700),
+                             QSize(1600, 900), QSize(2000, 620)}) {
+        for (int pass = 0; pass < 2; ++pass) {
+            container.setGeometry(0, 0, size.width(), size.height());
+            QCoreApplication::processEvents();
+        }
+        const std::string at = " at " + std::to_string(size.width()) + "x" +
+                               std::to_string(size.height());
+        check::equal(rx.strip->height(), tx.strip->height(),
+                     "the two control strips are the same height" + at);
+        check::equal(rx.picture->width(), tx.picture->width(),
+                     "the two pictures are the same width" + at);
+        check::equal(rx.picture->height(), tx.picture->height(),
+                     "the two pictures are the same height" + at);
+        // Not merely equal -- *large*. Shrinking both to a postage stamp
+        // would satisfy every assertion above, and is precisely the
+        // failure the previous implementation shipped.
+        check::is_true(rx.picture->height() > size.height() / 3,
+                       "and the picture uses the room it was given" + at);
+    }
+}
+
+// Equal sizes must survive the layout switch, which is where the last
+// implementation lost them: the mode change did not re-run the sizing,
+// so a picture kept the size it had while sharing the window.
+void test_sizes_survive_a_mode_round_trip() {
+    Pane rx = make_pane(1);
+    Pane tx = make_pane(3);
+    gui::PaneContainer container(rx.root, QStringLiteral("Receive"), tx.root,
+                                 QStringLiteral("Transmit"));
+    container.set_control_strips(rx.strip, tx.strip);
+    container.show();
+    for (int pass = 0; pass < 2; ++pass) {
+        container.setGeometry(0, 0, 1400, 800);
+        QCoreApplication::processEvents();
+    }
+    const QSize before = rx.picture->size();
+
+    container.set_mode(PaneLayout::Tabs);
+    QCoreApplication::processEvents();
+    container.set_mode(PaneLayout::Split);
+    for (int pass = 0; pass < 2; ++pass) {
+        container.setGeometry(0, 0, 1400, 800);
+        QCoreApplication::processEvents();
+    }
+
+    check::equal(rx.picture->width(), before.width(),
+                 "a round trip through tabs leaves the picture's width alone");
+    check::equal(rx.picture->height(), before.height(),
+                 "and its height");
+    check::equal(rx.picture->height(), tx.picture->height(),
+                 "and the two are still equal afterwards");
+}
+
+// **A widget that must not pin the window's width still has to be
+// visible.** `QSizePolicy::Ignored` is how several progress-tier
+// surfaces avoid setting a width floor -- and `QWidgetItem::sizeHint()`
+// answers zero for an Ignored axis, which a layout with stretch to give
+// can interpret sensibly and this one cannot. Laid out literally, the
+// transmit status label and the send progress bar were 0 px wide: the
+// refiner's running "+x.x dB" report simply stopped appearing, and an
+// operator noticed before any test did.
+void test_ignored_width_widgets_are_still_laid_out() {
+    QWidget host;
+    auto* flow = new gui::FlowLayout(&host);
+    auto* normal = new QPushButton(QStringLiteral("Send"), &host);
+    auto* ignored = new QLabel(QStringLiteral("Refining picture... +3.2 dB est."), &host);
+    ignored->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    flow->addWidget(normal);
+    flow->addWidget(ignored);
+    host.resize(900, 80);
+    host.show();
+    QCoreApplication::processEvents();
+
+    check::is_true(ignored->width() > 0,
+                   "an Ignored-width widget is given a real width");
+    check::is_true(ignored->width() >= ignored->sizeHint().width() / 2,
+                   "and enough of one to read its text");
+    // ...while still not raising the floor, which is the reason it was
+    // marked Ignored in the first place. The layout's minimum must come
+    // from the *other* item.
+    check::is_true(flow->minimumSize().width() <= normal->sizeHint().width() + 4,
+                   "and it still does not pin the layout's minimum width");
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    check::report_crashes_instead_of_prompting();
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    const QApplication app(argc, argv);
+
+    test_panels_survive_and_stay_visible();
+    test_tabs_are_narrower_than_side_by_side();
+    test_resolve_layout();
+    test_the_two_pictures_are_the_same_size();
+    test_sizes_survive_a_mode_round_trip();
+    test_ignored_width_widgets_are_still_laid_out();
+
+    return check::report("pane container");
+}

--- a/native/tests/test_picture_box.cpp
+++ b/native/tests/test_picture_box.cpp
@@ -1,0 +1,197 @@
+// The received-picture box.
+//
+// The bug this exists for has now been shipped twice in different
+// shapes, and both times it looked like a working preview:
+//
+//   1. **The ratchet.** `setFixedHeight(width * 3/4)` makes the box's
+//      *minimum* height follow its width, so widening the pane raises a
+//      floor under the whole window that narrowing it never lowers.
+//      Invisible at split-pane widths; at a full-window tab it demanded
+//      a 1405 px window. So the first and most important assertion here
+//      is that the minimum does not move at any width.
+//   2. **The aspect.** Two earlier attempts (`heightForWidth`, and
+//      pinning from the panel's stale `resizeEvent`) produced a 2.5:1
+//      box and a 460x90 strip. Both still contained a correctly
+//      letterboxed picture, so only the *box* geometry says which one
+//      you have.
+//
+// Neither has an oracle in a screenshot -- a wrong box is still a box
+// -- which is why the geometry is checked arithmetically here.
+
+#include <QApplication>
+#include <QLabel>
+#include <QPixmap>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <cmath>
+
+#include "check.hpp"
+#include "images/images.hpp"
+#include "picture_box.hpp"
+
+using namespace sstvae;
+
+namespace {
+
+constexpr double ASPECT =
+    static_cast<double>(images::IMG_W) / static_cast<double>(images::IMG_H);
+
+// A box inside a shown parent, so a resize is delivered and is not
+// clipped by the screen.
+//
+// Both halves earned themselves. `resize()` on a widget that has never
+// been shown *posts* the QResizeEvent rather than sending it, so the
+// first draft of this file measured a box still at its default 100x30 --
+// the ratchet test in particular went green having computed nothing,
+// which is the one thing a regression test cannot afford. And a
+// *top-level* box is clamped to the platform screen, so an 800x600
+// request arrived as 800x399 and read as a geometry bug in the widget.
+struct Host {
+    QWidget parent;
+    gui::PictureBox box{QStringLiteral("nothing yet"), &parent};
+
+    Host() {
+        parent.resize(3000, 2000);
+        parent.show();
+    }
+
+    gui::PictureBox& sized(int w, int h) {
+        // **Twice, deliberately.** The box's height cap is derived from
+        // its width, so Qt clamps an incoming geometry against the
+        // *previous* cap and the new one only applies on the next pass.
+        // In the application a layout supplies that pass (the widget
+        // calls `updateGeometry`); here nothing else would, so the
+        // second call stands in for it. Asserting after one pass would
+        // be asserting that a two-pass settle is a one-pass settle.
+        for (int pass = 0; pass < 2; ++pass) {
+            box.setGeometry(0, 0, w, h);
+            QCoreApplication::processEvents();
+        }
+        check::equal(box.width(), w, "the resize was delivered");
+        return box;
+    }
+};
+
+// Within a pixel of 4:3, since the rectangle is integral.
+bool is_four_by_three(const QRect& r) {
+    if (r.height() <= 0) return false;
+    const double got = static_cast<double>(r.width()) / r.height();
+    return std::abs(got - ASPECT) < 0.02;
+}
+
+void test_the_minimum_never_follows_the_width() {
+    // **Measured through a layout, on the parent.** `minimumSizeHint()`
+    // is a constant here, so asserting it against itself is a
+    // tautology no implementation could fail -- and the thing that
+    // actually hurt was never the hint but the *effective* minimum a
+    // `setFixedHeight` installs, which propagates into whatever
+    // contains the box and from there into the window. So the box goes
+    // in a layout and the assertion is on the container.
+    QWidget container;
+    auto* layout = new QVBoxLayout(&container);
+    layout->setContentsMargins(0, 0, 0, 0);
+    auto* box = new gui::PictureBox(QStringLiteral("nothing yet"), &container);
+    layout->addWidget(box);
+    container.resize(3000, 2000);
+    container.show();
+
+    // Widths spanning a narrow split pane through a full-window tab on
+    // a large monitor. The 1400 case is the one that demanded a 1405 px
+    // window before this was geometry rather than a fixed height.
+    int previous = 0;
+    for (const int w : {200, 500, 1000, 1400, 2400}) {
+        for (int pass = 0; pass < 2; ++pass) {
+            container.setGeometry(0, 0, w, 400);
+            QCoreApplication::processEvents();
+        }
+        const int floor = container.minimumSizeHint().height();
+        check::is_true(floor <= gui::PictureBox::MIN_H,
+                       "the container's minimum height stays at the box's floor");
+        if (previous != 0) {
+            check::equal(floor, previous,
+                         "and does not grow as the box gets wider");
+        }
+        previous = floor;
+    }
+}
+
+void test_it_stays_four_by_three_in_both_directions() {
+    Host host;
+    gui::PictureBox& box = host.sized(800, 600);
+
+    check::is_true(is_four_by_three(box.picture_rect()),
+                   "width-limited: the picture box is 4:3");
+    check::equal(box.picture_rect().width(), 800,
+                 "width-limited: it uses the full width");
+
+    // Height-limited -- the case a tab creates, and the one the old
+    // fixed-height code could not produce at all because it simply
+    // forced the window taller instead.
+    host.sized(1400, 400);
+    const QRect tall = box.picture_rect();
+    check::is_true(is_four_by_three(tall), "height-limited: the picture box is 4:3");
+    check::equal(tall.height(), 400, "height-limited: it uses the full height");
+    check::is_true(tall.width() < 1400, "height-limited: and it narrows to suit");
+
+    // Centred, not pinned to a corner: a dropped offset leaves a
+    // picture that is the right shape in the wrong place.
+    check::equal(tall.x(), (1400 - tall.width()) / 2, "the picture is centred");
+}
+
+void test_it_asks_for_four_by_three_and_imposes_nothing() {
+    Host host;
+    gui::PictureBox& box = host.sized(800, 600);
+    // The hint is what a layout gives it when there is room, which is
+    // what keeps a roomy pane showing a full-width picture.
+    check::equal(box.sizeHint().height(), 800 * images::IMG_H / images::IMG_W,
+                 "it asks for 4:3");
+    // **And imposes nothing.** It used to cap its own height at 4:3,
+    // which was safe on its own and became a problem the moment a
+    // second cap existed: two caps on one property meant whichever
+    // resizeEvent ran last decided the size, and the two panes came out
+    // 523 px against 480. The box now fills whatever it is given and
+    // centres a 4:3 rectangle inside, so the only thing deciding its
+    // size is the layout.
+    check::equal(box.maximumHeight(), QWIDGETSIZE_MAX,
+                 "and caps nothing, so the layout is the only authority");
+    check::equal(box.minimumSizeHint().height(), gui::PictureBox::MIN_H,
+                 "with a floor that does not follow the width");
+}
+
+void test_a_picture_is_scaled_into_the_box() {
+    Host host;
+    gui::PictureBox& box = host.sized(800, 600);
+    QPixmap picture(images::IMG_W, images::IMG_H);
+    picture.fill(Qt::red);
+    box.set_picture(picture);
+    // Setting a picture must not change the geometry -- a preview that
+    // resized itself around its content would undo everything above.
+    check::is_true(is_four_by_three(box.picture_rect()),
+                   "the box keeps its shape once a picture is in it");
+    check::equal(box.picture_rect().width(), 800,
+                 "and still fills the width it was given");
+    // The picture is actually *in* there and scaled to the rectangle --
+    // without this the whole file would pass on a box that draws
+    // nothing, which is what a `rescale()` reading the wrong size gives
+    // you.
+    const QPixmap shown = box.findChild<QLabel*>()->pixmap();
+    check::is_true(!shown.isNull(), "the picture is displayed");
+    check::equal(shown.width(), box.picture_rect().width(),
+                 "scaled to the box, not left at its own size");
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    check::report_crashes_instead_of_prompting();
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    const QApplication app(argc, argv);
+
+    test_the_minimum_never_follows_the_width();
+    test_it_stays_four_by_three_in_both_directions();
+    test_it_asks_for_four_by_three_and_imposes_nothing();
+    test_a_picture_is_scaled_into_the_box();
+
+    return check::report("picture box");
+}

--- a/native/tests/test_rig.cpp
+++ b/native/tests/test_rig.cpp
@@ -147,7 +147,7 @@ struct Published {
         };
     }
     rig::OnStatus status_fn() {
-        return [this](const std::string& text) {
+        return [this](const std::string& text, bool /*error*/) {
             {
                 std::lock_guard<std::mutex> lock(m);
                 statuses.push_back(text);

--- a/native/tests/test_rig_hamlib.cpp
+++ b/native/tests/test_rig_hamlib.cpp
@@ -156,7 +156,7 @@ void test_the_controller_drives_a_real_backend() {
             }
             cv.notify_all();
         },
-        [&](const std::string& text) {
+        [&](const std::string& text, bool /*error*/) {
             std::lock_guard<std::mutex> lock(m);
             statuses.push_back(text);
         });

--- a/native/tests/test_waterfall.cpp
+++ b/native/tests/test_waterfall.cpp
@@ -10,6 +10,7 @@
 
 #include <QApplication>
 #include <QImage>
+#include <QMouseEvent>
 
 #include <algorithm>
 #include <cmath>
@@ -178,6 +179,75 @@ void test_a_resize_keeps_the_history() {
                  "waterfall/resize: and the image follows the widget");
 }
 
+void test_clipping_latches_until_cleared() {
+    gui::Waterfall widget;
+    widget.resize(W, H);
+
+    // A full-scale tone: peak >= 0.99, which is the clip threshold.
+    auto loud = std::make_shared<rx::RingBuffer>(2.0);
+    std::vector<double> block(dsp::WATERFALL_NFFT * 2);
+    for (std::size_t i = 0; i < block.size(); ++i) {
+        block[i] = std::sin(2.0 * std::numbers::pi * TONE_HZ *
+                            static_cast<double>(i) / config::FS);
+    }
+    loud->write(block);
+    widget.set_ring(loud);
+    QMetaObject::invokeMethod(&widget, "tick", Qt::DirectConnection);
+    check::is_true(widget.clip_latched(), "waterfall/clip: a clip latches");
+
+    // The signal drops back to a healthy level; the latch must hold --
+    // a momentary indicator is exactly what this replaces.
+    widget.set_ring(ring_with_tone(TONE_HZ));
+    QMetaObject::invokeMethod(&widget, "tick", Qt::DirectConnection);
+    check::is_true(widget.clip_latched(),
+                   "waterfall/clip: still latched after the peak passes");
+
+    // A click on the meter clears it.
+    QMouseEvent click(QEvent::MouseButtonPress, QPointF(W - 5, 10),
+                      widget.mapToGlobal(QPointF(W - 5, 10)), Qt::LeftButton,
+                      Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(&widget, &click);
+    check::is_true(!widget.clip_latched(),
+                   "waterfall/clip: a click on the meter clears the latch");
+}
+
+void test_disabled_looks_different() {
+    // `setEnabled(false)` is a no-op on a custom-painted widget: Qt
+    // greys the controls it draws itself and dims a QLabel's pixmap,
+    // but a paintEvent that blits an image and strokes hard-coded
+    // colours renders pixel-identically either way. This widget is
+    // disabled exactly once -- during transmit -- and the entire point
+    // of leaving it on screen then is that a paused receiver must not
+    // look like a wedged one. So "disabled renders differently" is the
+    // assertion, not "setEnabled was called".
+    gui::Waterfall widget;
+    widget.resize(W, H);
+    widget.set_ring(ring_with_tone(TONE_HZ));
+    for (int i = 0; i < 4; ++i) {
+        QMetaObject::invokeMethod(&widget, "tick", Qt::DirectConnection);
+    }
+    const QImage enabled = shot(widget);
+
+    widget.setEnabled(false);
+    const QImage disabled = shot(widget);
+
+    check::is_true(enabled != disabled,
+                   "waterfall/disabled: renders differently from enabled");
+    // And specifically darker, which is what a scrim means -- a change
+    // that merely moved pixels around would pass the check above.
+    const auto mean = [](const QImage& image) {
+        double total = 0.0;
+        for (int y = 0; y < image.height(); ++y) {
+            for (int x = 0; x < image.width(); ++x) {
+                total += brightness(image, x, y);
+            }
+        }
+        return total / (image.width() * image.height());
+    };
+    check::is_true(mean(disabled) < mean(enabled),
+                   "waterfall/disabled: and is dimmed rather than merely changed");
+}
+
 void test_clear_blanks_it() {
     gui::Waterfall widget;
     widget.resize(W, H);
@@ -203,6 +273,8 @@ int main(int argc, char** argv) {
     test_a_tone_paints_where_its_frequency_says();
     test_history_scrolls_downward();
     test_a_resize_keeps_the_history();
+    test_clipping_latches_until_cleared();
+    test_disabled_looks_different();
     test_clear_blanks_it();
 
     return check::report("waterfall widget");

--- a/tests/test_native_settings.py
+++ b/tests/test_native_settings.py
@@ -104,6 +104,12 @@ NON_DEFAULT = {
         "level": 0.72,
         "optimize": True,
     },
+    "ui": {
+        # Neither is a default: the default layout is "auto" and the
+        # default waterfall height is 0 ("never dragged").
+        "layout": "tabs",
+        "waterfall_height": 140,
+    },
     "version": 2,
 }
 


### PR DESCRIPTION
Written with Claude Code. UI Enhancements for SSTVAE 73 de KM8V:

The desktop app's main window, reworked around one idea: the received picture is the thing you cannot ask for again, so it should never be the smaller of the two.

**Layout.** Receive and transmit sit side by side, locked to the same width, each a 4:3 picture over a control strip -- and the two strips are held to one height, which is what makes the two pictures identical rather than merely similar. The spectrum spans the whole window above both, where it has the width to resolve anything. Measured equal at every window size from 800 to 1960 px.

Getting there turned up a class of bug worth naming, because it appears three times in Qt and is invisible each time: **a widget must never let its minimum follow its own width.** `setFixedHeight(width * 3/4)` is a hard minimum, so a wide pane raises a window floor that narrowing never lowers; `hasHeightForWidth` is the same thing where `minimumSizeHint()` cannot see it, which a QSplitter hides and a QTabWidget passes straight to the window. Both are gone, both are mutation-tested, and `sstvae-gui-shot --panes` now reports `minimumHeightForWidth` because that is the number a size hint will not show you.

**A tabbed layout** for screens too small for both panes (`ui.layout`, View > Layout). Resolved once at startup against the screen in both axes, because the height floor moves with the width; chosen by hand it stays chosen. The window also refuses to open larger than the screen -- without that, View > Layout goes off the edge with everything else and the fallback cannot be reached from inside the app.

**Control rows wrap** rather than being crushed. A QHBoxLayout has one line and no way to report that it cannot fit, so at the minimum width the window accepted, its own buttons were clipped mid-word.

**A status log dock and three tiers of error reporting.** Errors are sticky and logged, state gets its own indicators, progress keeps the labels that may overwrite each other. The rule that produced it: "PTT OFF FAILED -- unkey it manually" was provably destroyed by the "Sent" that followed it a second later, on the same label.

**A framing dialog** for pictures that are not 4:3, so the operator chooses what is sent instead of accepting a centre crop.

Also fixes an audio-layer defect this uncovered: one callback carried both "opened at 96000 Hz, resampled to 8000 Hz" -- information, and the normal case -- and genuine capture failures. Split, so the notice no longer raises a banner and a device disappearing mid-reception still does.

ctest 23/23, pytest 281, pytest --native 281, layering/includes/config checks clean, no compiler warnings from the new code.