### PR TITLE
native: emit compile_commands.json for clangd

### DIFF
--- a/native/.clangd
+++ b/native/.clangd
@@ -1,0 +1,9 @@
+# Scoped to native/ (the only C++ tree) rather than the repo root,
+# since the Python side has no compilation database to offer.
+#
+# native/CMakeLists.txt sets CMAKE_EXPORT_COMPILE_COMMANDS, so any of
+# the build directories tools/build_native.sh creates will do; `build`
+# matches its default. Point elsewhere with a local override if you
+# configure to a different directory (e.g. native/build-sanitize).
+CompileFlags:
+  CompilationDatabase: build

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -19,6 +19,14 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# clangd reads this to get the real include paths and defines for every
+# target (Qt, onnxruntime, pybind11/Python.h, the bundled Hamlib
+# headers); without it clangd falls back to guessed flags and reports
+# most of the tree as undefined. .clangd points at the directory this
+# lands in. Every generator CMake supports here (Ninja, Makefiles) can
+# emit it; the root .gitignore already excludes the resulting file.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # The oldest macOS this is built to run on. Decision 2 in
 # docs/native-app.md sets a conservative hardware floor, and Qt 6.8
 # supports back to 12; stated explicitly so it is a choice rather than


### PR DESCRIPTION
## Summary

- `native/CMakeLists.txt` never set `CMAKE_EXPORT_COMPILE_COMMANDS`, so clangd had no compilation database for the C++ tree. With no include paths or defines for any target — Qt, onnxruntime, pybind11/Python.h, bundled Hamlib headers — it fell back to guessed flags and reported most of `native/` as a wall of undefined-symbol errors.
- The root `.gitignore` already excludes `compile_commands.json` and `.cache/`, so the generated file and clangd's index were anticipated; only the CMake setting that actually produces the file was missing.
- Added `native/.clangd`, scoped to the C++ tree (the Python side has no compilation database to offer), pointing `CompilationDatabase` at `build` — the directory `tools/build_native.sh` configures into by default.

## Test plan

- [x] `cmake -S native -B <dir> -G Ninja ...` and confirmed `compile_commands.json` is generated with real `-I`/`-isystem` flags for every source file.
- [x] `tools/build_native.sh --no-codec -DSSTVAE_BUILD_PYMODULE=OFF -DSSTVAE_BUILD_QTAUDIO=OFF -DSSTVAE_BUILD_OVERLAY=OFF -DSSTVAE_BUILD_GUI=OFF -DSSTVAE_BUILD_RIG=OFF` completed a full build and produced `native/build/compile_commands.json` (35 entries) at the path `.clangd` expects.


---
_Generated by [Claude Code](https://claude.ai/code/session_0131NcBJJ5eb1ZjqE6K8dB9s)_