### PR TITLE
Add "Download All Models" button to settings dialog

### DIFF
--- a/native/gui/main_window.cpp
+++ b/native/gui/main_window.cpp
@@ -619,6 +619,14 @@ void MainWindow::open_settings() {
                                   ok ? log::Severity::Info : log::Severity::Error,
                                   tr("rig test: %1").arg(message));
             });
+    // The message box the dialog itself shows is dismissed by hand; the
+    // log keeps what it said, same as the rig test above.
+    connect(&dialog, &SettingsDialog::modelDownloadFinished, state_,
+            [this](bool ok, const QString& message) {
+                state_->log_event("app",
+                                  ok ? log::Severity::Info : log::Severity::Error,
+                                  tr("download all models:\n%1").arg(message));
+            });
     if (dialog.exec() != QDialog::Accepted) return;
 
     // The sequence is the window's, not the dialog's: apply, save,

--- a/native/gui/settings_dialog.cpp
+++ b/native/gui/settings_dialog.cpp
@@ -18,6 +18,7 @@
 #include <QPushButton>
 #include <QScrollArea>
 #include <QSizePolicy>
+#include <QStringList>
 #include <QTabWidget>
 #include <QThread>
 #include <QVBoxLayout>
@@ -139,6 +140,21 @@ QWidget* scrolling(QWidget* page) {
     return area;
 }
 
+// One artifact "Download All" fetches, with the label its report uses.
+struct ModelPart {
+    std::string_view part;
+    const char* label;
+};
+
+const std::vector<ModelPart>& model_parts() {
+    static const std::vector<ModelPart> parts = {
+        {"encoder", "Encoder"},
+        {"decoder", "Decoder"},
+        {checkpoint::GRAD_PART, "Refinement gradient graph"},
+    };
+    return parts;
+}
+
 }  // namespace
 
 SettingsDialog::SettingsDialog(const settings::Config& config, QWidget* parent)
@@ -176,6 +192,8 @@ SettingsDialog::SettingsDialog(const settings::Config& config, QWidget* parent)
 
     connect(this, &SettingsDialog::rigTestFinished, this,
             &SettingsDialog::on_rig_test_finished, Qt::QueuedConnection);
+    connect(this, &SettingsDialog::modelDownloadFinished, this,
+            &SettingsDialog::on_model_download_finished, Qt::QueuedConnection);
 }
 
 SettingsDialog::~SettingsDialog() = default;
@@ -229,6 +247,27 @@ QWidget* SettingsDialog::model_tab() {
     precision_note_ = note(QString(), page);
     form->addRow(QString(), precision_note_);
     sync_precision_enabled();
+
+    // Centred and set apart, like the rig tab's test buttons: everything
+    // else on this tab takes effect on OK, but this one does something --
+    // real network I/O -- the moment it is pressed.
+    download_all_ = new QPushButton(tr("Download All Models"), page);
+    connect(download_all_, &QPushButton::clicked, this,
+            &SettingsDialog::download_all_models);
+    auto* download_row = new QWidget(page);
+    auto* download_layout = new QHBoxLayout(download_row);
+    download_layout->setContentsMargins(0, 14, 0, 0);
+    download_layout->addStretch(1);
+    download_layout->addWidget(download_all_);
+    download_layout->addStretch(1);
+    form->addRow(download_row);
+    form->addRow(note(tr("Fetches the encoder, decoder and refinement gradient "
+                         "graph now, so a complete set is cached before going "
+                         "somewhere with no connection. Otherwise each is only "
+                         "fetched the first time it is actually needed -- the "
+                         "encoder on the first Send, the gradient graph on the "
+                         "first refined transmission."),
+                      page));
     return page;
 }
 
@@ -255,6 +294,62 @@ void SettingsDialog::sync_precision_enabled() {
                            suffix != QLatin1String("pt") &&
                            suffix != QLatin1String("ckpt"));
     precision_note_->setText(text);
+}
+
+void SettingsDialog::set_download_busy(bool busy) {
+    download_all_->setEnabled(!busy);
+    download_all_->setText(busy ? tr("Downloading...") : tr("Download All Models"));
+}
+
+void SettingsDialog::download_all_models() {
+    // On a worker thread, for the same reason as the rig tests: a fetch
+    // of the published model is a real HTTP download, and the GUI
+    // thread must not block on the network any more than it blocks on
+    // the rig. The path/precision are read from the *pending* values in
+    // the dialog, not `config_`, so pointing the picker at a folder and
+    // pressing this button downloads nothing -- resolving those parts is
+    // pure local path arithmetic.
+    set_download_busy(true);
+    const std::string path = model_path_->text().trimmed().toStdString();
+    const std::string precision = precision_->currentData().toString().toStdString();
+
+    std::thread([this, path, precision] {
+        QStringList lines;
+        bool ok = true;
+        for (const ModelPart& part : model_parts()) {
+            const bool was_cached =
+                path.empty() &&
+                checkpoint::find_cached(checkpoint::onnx_filename(part.part, precision))
+                    .has_value();
+            try {
+                checkpoint::resolve_onnx(part.part, path, precision);
+                if (path.empty()) {
+                    lines << tr("%1: %2").arg(
+                        QString::fromUtf8(part.label),
+                        was_cached ? tr("already cached") : tr("downloaded"));
+                } else {
+                    lines << tr("%1: ready").arg(QString::fromUtf8(part.label));
+                }
+            } catch (const std::exception& e) {
+                ok = false;
+                lines << tr("%1: FAILED\n%2").arg(QString::fromUtf8(part.label),
+                                                   QString::fromUtf8(e.what()));
+            }
+        }
+        emit modelDownloadFinished(ok, lines.join(QStringLiteral("\n\n")));
+    }).detach();
+}
+
+void SettingsDialog::on_model_download_finished(bool ok, const QString& message) {
+    set_download_busy(false);
+    if (ok) {
+        QMessageBox::information(
+            this, tr("Models"), tr("All model artifacts are ready.\n\n%1").arg(message));
+    } else {
+        QMessageBox::warning(
+            this, tr("Models"),
+            tr("Some artifacts could not be fetched.\n\n%1").arg(message));
+    }
 }
 
 // --- audio ------------------------------------------------------------------

--- a/native/gui/settings_dialog.hpp
+++ b/native/gui/settings_dialog.hpp
@@ -51,12 +51,18 @@ private slots:
     void test_cat();
     void test_ptt();
     void on_rig_test_finished(bool ok, const QString& message);
+    void download_all_models();
+    void on_model_download_finished(bool ok, const QString& message);
 
 signals:
     // Emitted from the worker thread the rig test runs on; queued, so
     // the message box opens on the GUI thread. Nothing on the GUI
     // thread may block on the rig, not even for a test button.
     void rigTestFinished(bool ok, const QString& message);
+    // Emitted from the worker thread that fetches the model artifacts;
+    // queued for the same reason -- a download is real network I/O, and
+    // the GUI thread must not wait on it.
+    void modelDownloadFinished(bool ok, const QString& message);
 
 private:
     QWidget* model_tab();
@@ -72,6 +78,7 @@ private:
     settings::RigConfig pending_rig() const;
     int rig_model_number() const;
     void set_rig_test_busy(bool busy);
+    void set_download_busy(bool busy);
 
     settings::Config config_;
 
@@ -79,6 +86,7 @@ private:
     QLineEdit* model_path_ = nullptr;
     QComboBox* precision_ = nullptr;
     QLabel* precision_note_ = nullptr;
+    QPushButton* download_all_ = nullptr;
 
     // Audio
     QComboBox* input_device_ = nullptr;


### PR DESCRIPTION
## Summary
Adds a "Download All Models" button to the model settings tab that allows users to pre-cache all model artifacts (encoder, decoder, and refinement gradient graph) before going offline. This prevents delays when these models are first needed during transmission.

## Key Changes
- Added `ModelPart` struct and `model_parts()` function to define the three downloadable model artifacts with their display labels
- Implemented `download_all_models()` slot that runs model fetching on a worker thread to avoid blocking the GUI
- Added `set_download_busy()` helper to disable the button and update its text during downloads
- Added `on_model_download_finished()` slot to handle download completion and display results via message box
- Added `modelDownloadFinished` signal emitted from the worker thread (queued connection) with success status and detailed message
- Created centered "Download All Models" button in the model tab UI with explanatory note about when models are normally fetched
- Connected the signal in `MainWindow::open_settings()` to log download results to the app's event log
- Added `#include <QStringList>` for string list handling in the download results

## Implementation Details
- Downloads run on a detached worker thread (similar to the existing rig test functionality) to prevent GUI blocking on network I/O
- Uses pending dialog values (model path and precision) rather than the saved config, so users can preview downloads without committing settings
- Tracks whether each artifact was already cached vs. newly downloaded and reports status per artifact
- Gracefully handles download failures with detailed error messages in a warning dialog
- Button is disabled during downloads and shows "Downloading..." text for user feedback

https://claude.ai/code/session_01DdLsZsDPpThYmhREFJLtGC