### PR TITLE
Blind acquisition: streaming accumulator, correctness fixes, and beacon multi-repetition combining

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -63,6 +63,69 @@ typical 300–2700 Hz SSB filter, which limits the centre to roughly
 900–2100 Hz — exactly the range measured above. Beyond that the
 transmitter's own filtering, not the modem, is the limit.
 
+## ~~Blind acquisition: does longer integration reach weaker signals?~~ — no, and multi-timescale is implemented
+
+**Closed 2026-08-06.** `sync.BlindAccumulator` (the incremental,
+block-decomposed replacement for `acquire_blind`'s one-shot search — see
+`docs/native-app.md`'s history for why it exists) was built on the
+assumption that a longer integration window lets it detect weaker
+signals, the same way more samples lower a radiometer's noise floor.
+**Measured, that assumption is wrong for this detector.**
+
+`result()`'s score is peak-bin-sum / median-of-other-bins-sum, both sums
+of matched-filter *power* across periods. Both grow roughly
+proportionally with the number of periods folded in, so the ratio
+converges to a value set by the signal's *per-period* SNR — a ceiling
+integration doesn't push through, unlike coherent (voltage) integration
+or a radiometer's magnitude averaging. Measured (mode C frame data,
+`mpp` fading, one-shot `acquire_blind` with a growing search window from
+~10% to 100% of the real 95 s transmission):
+
+| SNR | window length dependence |
+|---|---|
+| −6 dB | passes at every length from ~10 s to 95 s, 8/8 seeds, score flat (4.2–5.4) |
+| −7 dB | mostly flat too; **one seed of eight missed at a 10 s window and caught at 95 s** |
+| −10 dB | fails at every length up to and including the full 95 s, no exceptions, no seed rescued |
+
+So a signal below the floor cannot be rescued by any amount of
+integration. What longer integration *does* buy is **reliability near
+the floor**: a signal whose true ratio sits just above threshold can
+read below it on a short, noisy sample and get missed, and integrating
+over more of it converges the estimate and catches it — the −7 dB
+result above. That benefit runs out once the window covers the
+transmission's own duration; audio *older* than the transmission is
+pure dilution (already documented on `BlindAccumulator` itself), not
+more signal to integrate.
+
+**That reframes, but doesn't remove, the original motivation**
+(Andrew: "we want ~90 s for mode C without giving up on mode A's own
+36 s"). The right lever isn't a longer window in general, it's matching
+each mode's own duration — long enough to get mode C's full reliability
+benefit, short enough that mode A isn't sitting diluted behind 60+
+irrelevant seconds a mode-C-tuned window would still weight
+non-negligibly. Implemented: `BlindAccumulator.window_s` now accepts
+several decay timescales run in parallel off the *same* shared, expensive
+per-block matched-filter result (only the cheap decay-and-fold step
+repeats per timescale, so N timescales cost barely more than one);
+`result()` reports whichever timescale's score is highest.
+`rx/engine.py`/`engine.cpp` pass one timescale per `config.MODES`, each
+capped at that mode's own `duration_s` by (the now-repurposed)
+`blind_search_seconds` — default above every mode's duration, so nothing
+is capped unless deliberately lowered. Ported to C++ and cross-checked
+against the Python reference via `pytest --native`
+(`tests/test_blind_acquisition.py::test_blind_accumulator_multi_timescale_picks_the_better_one`).
+
+**Caveats on the measurement.** Single-digit-to-low-double-digit seed
+counts per cell, same order as the acquisition-near-threshold sweeps
+this file warns about elsewhere ("40–80% success rate... any sweep with
+single-digit trials per cell will invent a pattern") — the −6 dB / −10 dB
+rows are each other's sanity check (comfortably-above and clearly-below
+the floor, both flat, in opposite directions), which is stronger
+evidence than either alone, but the exact floor location and the exact
+size of the near-floor benefit were not swept at the 25-seed rigor that
+section demands. Good enough to justify the multi-timescale design;
+not a citable number for where the floor sits.
+
 ## ~~Improve acquisition at large frequency offsets~~ — did not reproduce
 
 **Withdrawn 2026-07-26. There is no offset effect; the original result

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -81,6 +81,12 @@ if(SSTVAE_SANITIZE)
   endif()
   add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer -g)
   add_link_options(-fsanitize=address,undefined)
+  # A named, project-wide define rather than a compiler-detection macro
+  # like __SANITIZE_ADDRESS__: a test that wants to trade trial count
+  # for runtime under instrumentation is answering "is this the
+  # sanitizer build", not "did the compiler happen to define ASan's own
+  # macro" -- see test_beacon.cpp's use of it.
+  add_compile_definitions(SSTVAE_SANITIZE_BUILD)
 endif()
 
 # --- core -------------------------------------------------------------------

--- a/native/bindings/module/module.cpp
+++ b/native/bindings/module/module.cpp
@@ -408,10 +408,11 @@ PYBIND11_MODULE(sstvae_native, m) {
     // keeping this core free of any knowledge of that Python type.
     py::class_<sstvae::sync::BlindAccumulator>(sync, "BlindAccumulator")
         .def(py::init<double, double, int, double, std::optional<int>,
-                      std::optional<double>>(),
+                      std::vector<std::optional<double>>>(),
              py::arg("max_offset_hz") = 55.0, py::arg("bin_step_hz") = 1.7,
              py::arg("min_periods") = 8, py::arg("threshold") = 4.0,
-             py::arg("block_samples") = py::none(), py::arg("window_s") = 25.0)
+             py::arg("block_samples") = py::none(),
+             py::arg("window_s") = std::vector<std::optional<double>>{25.0})
         .def("push",
              [](sstvae::sync::BlindAccumulator& self, CArray z,
                 std::int64_t start_sample) {

--- a/native/bindings/module/module.cpp
+++ b/native/bindings/module/module.cpp
@@ -334,11 +334,23 @@ PYBIND11_MODULE(sstvae_native, m) {
               },
               py::arg("x"), py::arg("search_s") = py::none());
     modem.def("demodulate_blind",
-              [](DArray x, std::optional<std::pair<double, double>> search_s) {
+              [](DArray x, std::optional<std::pair<double, double>> search_s,
+                 std::optional<std::tuple<std::int64_t, double, double>> acquisition) {
                   std::span<const double> in(
                       x.data(), static_cast<std::size_t>(x.size()));
                   const sstvae::modem::Modem md;
-                  const auto r = md.demodulate_blind(in, search_s);
+                  std::optional<sstvae::sync::BlindAcquisition> acq;
+                  // Same (frame_start, freq_offset, metric) tuple shape
+                  // acquire_blind/BlindAccumulator.result return above --
+                  // a caller (rx/engine.py) that already located the
+                  // signal via its own persistent accumulator passes
+                  // that straight through rather than making this run
+                  // acquire_blind again from scratch.
+                  if (acquisition)
+                      acq = sstvae::sync::BlindAcquisition{
+                          std::get<0>(*acquisition), std::get<1>(*acquisition),
+                          std::get<2>(*acquisition)};
+                  const auto r = md.demodulate_blind(in, search_s, acq);
                   py::dict out;
                   out["latents"] = to_numpy(r.latents);
                   out["weights"] = to_numpy(r.weights);
@@ -358,7 +370,8 @@ PYBIND11_MODULE(sstvae_native, m) {
                       out["beacon"] = py::none();
                   return out;
               },
-              py::arg("x"), py::arg("search_s") = py::none());
+              py::arg("x"), py::arg("search_s") = py::none(),
+              py::arg("acquisition") = py::none());
 
     py::module_ sync = m.def_submodule("sync");
     // SyncError is raised through to Python as the reference's own

--- a/native/bindings/module/module.cpp
+++ b/native/bindings/module/module.cpp
@@ -403,6 +403,27 @@ PYBIND11_MODULE(sstvae_native, m) {
              py::arg("bin_step_hz") = 1.7, py::arg("min_periods") = 8,
              py::arg("threshold") = 4.0, py::arg("search") = py::none());
 
+    // result() returns a plain tuple, like acquire_blind above -- the
+    // conftest adapter wraps it into the reference's BlindAcquisition,
+    // keeping this core free of any knowledge of that Python type.
+    py::class_<sstvae::sync::BlindAccumulator>(sync, "BlindAccumulator")
+        .def(py::init<double, double, int, double, std::optional<int>,
+                      std::optional<double>>(),
+             py::arg("max_offset_hz") = 55.0, py::arg("bin_step_hz") = 1.7,
+             py::arg("min_periods") = 8, py::arg("threshold") = 4.0,
+             py::arg("block_samples") = py::none(), py::arg("window_s") = 25.0)
+        .def("push",
+             [](sstvae::sync::BlindAccumulator& self, CArray z,
+                std::int64_t start_sample) {
+                 std::span<const cdouble> in(z.data(), static_cast<std::size_t>(z.size()));
+                 self.push(in, start_sample);
+             },
+             py::arg("z"), py::arg("start_sample"))
+        .def("result", [](const sstvae::sync::BlindAccumulator& self) {
+            const auto a = self.result();
+            return py::make_tuple(a.frame_start, a.freq_offset, a.metric);
+        });
+
     py::module_ dsp = m.def_submodule("dsp");
     dsp.def("to_baseband",
             [](DArray x) {

--- a/native/core/audio/audio.cpp
+++ b/native/core/audio/audio.cpp
@@ -126,7 +126,7 @@ std::vector<double> StreamResampler::operator()(std::span<const double> chunk) {
     if (n == 0) return {};
 
     const std::vector<double> y = dsp::resample_poly(
-        std::span<const double>(buf_.data(), 2 * pad_ + n), up_, down_);
+        std::span<const double>(buf_.data(), 2 * pad_ + n), up_, down_, &filter_taps_);
     const std::size_t skip = pad_ * static_cast<std::size_t>(up_) / d;
     const std::size_t take = n * static_cast<std::size_t>(up_) / d;
 

--- a/native/core/audio/audio.hpp
+++ b/native/core/audio/audio.hpp
@@ -88,6 +88,10 @@ private:
     int down_;
     std::size_t pad_;
     std::vector<double> buf_;
+    // dsp::resample_poly's filter_cache slot: designed on this instance's
+    // first operator() call and reused on every later one, since up_/
+    // down_ never change -- see resample_poly's doc comment.
+    std::optional<std::vector<double>> filter_taps_;
 };
 
 // The device sample formats we can convert, named as QtMultimedia names

--- a/native/core/beacon/beacon.cpp
+++ b/native/core/beacon/beacon.cpp
@@ -206,16 +206,400 @@ std::optional<std::pair<int, std::string>> decode_payload(
 
 }  // namespace
 
+std::optional<BeaconResult> decode_single_repetition(
+    std::int64_t chip_offset, std::span<const double> coded_chips) {
+    const auto result = decode_payload(coded_chips);
+    if (!result) return std::nullopt;
+    return BeaconResult{chip_offset, result->first, result->second};
+}
+
+// --- multi-repetition combining ----------------------------------------------
+//
+// Port of sstvae/modem/beacon.py's module docstring section of the same
+// name -- read that for the full reasoning; this is a condensed version
+// alongside the code it explains.
+//
+// The superframe repeats continuously through the whole transmission
+// (~5.2 s apart -- up to ~18 times in a mode C transmission), but
+// decode() above only looks at whichever single repetition's own
+// Golay+CRC decode happens to succeed, discarding every other
+// repetition's evidence. Two things are exactly known about every
+// repetition within one transmission: the callsign is identical, and
+// the frame counter is an exact, predictable function of chip position
+// once any one repetition's value is known (chip_stream() lays
+// superframes back to back with no gaps, and the decoder's own chip
+// array indexes frames uniformly).
+//
+// decode_combined below uses both, in three tiers:
+//
+// - Chunks entirely inside the callsign field are identical, chip for
+//   chip, in every repetition, so their *signs* can simply be summed
+//   across repetitions before a single Golay decode -- genuine coherent
+//   combining, the cheap case. Sign, not raw magnitude: under fading,
+//   the per-frame channel estimate the equalizer divides by can itself
+//   sit near a fade null, amplifying that frame's noise into an
+//   enormous, essentially random magnitude, so a single such repetition
+//   dominates a raw sum and wrecks it (measured in the Python
+//   reference: raw summing recovered 6/12 bits -- chance -- where sign
+//   summing recovered 12/12).
+// - The chunk carrying the counter can't be summed that way (a
+//   genuinely different value is correct at every repetition), so
+//   search_counter_chunk instead evaluates every hypothesis by
+//   regenerating each repetition's expected codeword and summing its
+//   sign-correlation, combining evidence across repetitions before
+//   choosing -- voting on independent per-repetition decodes was tried
+//   first and measured useless at the SNRs this needs to help with (18
+//   repetitions, 18 different guesses, no repeat at all).
+// - The chunk mixing leftover callsign bits with the per-repetition CRC
+//   has the same problem but no simple shift predicts it (CRC depends
+//   on the whole payload) -- search_crc_mixed_chunk brute-forces its
+//   free bits and asks payload_bits what the CRC-inclusive chunk should
+//   look like for each hypothesis at each repetition's own counter.
+//
+// The final verification is the part that is easy to get wrong: it
+// must check only chunks that were never used to build the hypothesis
+// (the CRC/padding-only chunks) via a *bit-exact* independent decode,
+// not a correlation over the whole superframe -- a correlation lets the
+// chunks the search already fit dominate the score, which measures
+// curve-fit quality rather than correctness, and was measured to
+// produce a confident, fully wrong BeaconResult on 40 of 40 pure-noise
+// trials before this was caught.
+
+namespace {
+
+std::pair<int, int> chunk_bit_range(int chunk_idx) {
+    return {chunk_idx * 12, (chunk_idx + 1) * 12};
+}
+
+// np.sign: 0.0 at exactly zero, not +1 -- matters here because summed
+// signs feed straight into a Golay decode via golay::signs_table()
+// lookups, so a stray +1 bias at an exact-zero chip (vanishingly likely
+// on real noise, but reachable from a deliberately constructed test
+// vector) would be a real, if tiny, divergence from the Python
+// reference rather than a harmless rounding difference.
+double sign(double x) { return x > 0.0 ? 1.0 : (x < 0.0 ? -1.0 : 0.0); }
+
+std::vector<int> decode_chunk_bits(std::span<const double> chip_slice) {
+    std::vector<int> out;
+    append_int_bits(out, golay::decode_soft(chip_slice), 12);
+    return out;
+}
+
+// Candidate anchor phases (mod SUPERFRAME_LEN) for the combining
+// fallback, found by folding the sync-word correlation across every
+// period instead of trusting any single repetition's own (noisy,
+// 13-chip) peak -- the same "fold across periods" idea BlindAccumulator
+// uses for the pilot, applied here to the Barker-13 word.
+std::vector<std::int64_t> folded_sync_phases(std::span<const double> chips,
+                                             int max_candidates = 4) {
+    if (chips.size() < static_cast<std::size_t>(SYNC_LEN + SUPERFRAME_LEN)) return {};
+    const std::size_t n_out = chips.size() - static_cast<std::size_t>(SYNC_LEN) + 1;
+    std::vector<double> corr(n_out);
+    for (std::size_t k = 0; k < n_out; ++k) {
+        double c = 0.0;
+        for (int j = 0; j < SYNC_LEN; ++j)
+            c += chips[k + static_cast<std::size_t>(j)] *
+                 static_cast<double>(config::BEACON_SYNC[static_cast<std::size_t>(j)]);
+        corr[k] = c;
+    }
+    std::vector<double> folded(static_cast<std::size_t>(SUPERFRAME_LEN), 0.0);
+    for (std::size_t k = 0; k < n_out; ++k)
+        folded[k % static_cast<std::size_t>(SUPERFRAME_LEN)] += corr[k];
+
+    std::vector<std::size_t> order(folded.size());
+    std::iota(order.begin(), order.end(), 0);
+    std::stable_sort(order.begin(), order.end(), [&folded](std::size_t a, std::size_t b) {
+        return folded[a] > folded[b];
+    });
+    std::vector<std::int64_t> out;
+    const std::size_t limit = std::min(order.size(), static_cast<std::size_t>(max_candidates));
+    for (std::size_t i = 0; i < limit; ++i) out.push_back(static_cast<std::int64_t>(order[i]));
+    return out;
+}
+
+// Every chip offset spaced an exact multiple of SUPERFRAME_LEN from
+// `anchor_off` that has a full superframe's worth of chips available.
+// Checks each direction's fit explicitly rather than assuming the
+// anchor's own position fits -- it doesn't always, e.g. an anchor near
+// the very end of a short buffer.
+std::vector<std::int64_t> repetition_grid(std::int64_t n_chips, std::int64_t anchor_off) {
+    const auto fits = [n_chips](std::int64_t pos) {
+        return pos >= 0 && pos + SYNC_LEN + CODED_LEN <= n_chips;
+    };
+    std::vector<std::int64_t> grid;
+    if (fits(anchor_off)) grid.push_back(anchor_off);
+    for (std::int64_t k = 1; fits(anchor_off + k * SUPERFRAME_LEN); ++k)
+        grid.push_back(anchor_off + k * SUPERFRAME_LEN);
+    for (std::int64_t k = -1; fits(anchor_off + k * SUPERFRAME_LEN); --k)
+        grid.push_back(anchor_off + k * SUPERFRAME_LEN);
+    std::sort(grid.begin(), grid.end());
+    return grid;
+}
+
+// Joint search over the chunk carrying the counter's own low bit 0 --
+// see the file-level comment above for why voting can't be used here.
+// Evaluates every possible value of this chunk's remaining
+// `12 - n_counter_bits` bits at the anchor, regenerates what each
+// repetition's own counter-shifted 12-bit value and Golay codeword
+// would be for that hypothesis, and scores each hypothesis by summing
+// its predicted codeword's sign-correlation against every repetition's
+// actual chips. Returns (counter_at_anchor, extra_bits_value).
+std::optional<std::pair<int, int>> search_counter_chunk(
+    std::span<const double> chips, const std::vector<std::int64_t>& grid,
+    std::int64_t anchor_off, int chunk_idx, int n_counter_bits) {
+    const int clo = chunk_idx * 24;
+    const std::int64_t anchor_frame = anchor_off / CHIPS_PER_FRAME;
+    const std::size_t n_grid = grid.size();
+
+    std::vector<double> received(n_grid * 24);
+    std::vector<std::int64_t> frame_deltas(n_grid);
+    for (std::size_t g = 0; g < n_grid; ++g) {
+        const std::int64_t pos = grid[g];
+        frame_deltas[g] = pos / CHIPS_PER_FRAME - anchor_frame;
+        for (int c = 0; c < 24; ++c)
+            received[g * 24 + static_cast<std::size_t>(c)] =
+                sign(chips[static_cast<std::size_t>(pos + SYNC_LEN + clo + c)]);
+    }
+
+    const int n_extra = 12 - n_counter_bits;
+    const int n_counters = 1 << n_counter_bits;
+    const int counter_mask = n_counters - 1;
+    const std::span<const double> signs = golay::signs_table();
+
+    double best_score = -1e300;
+    std::optional<std::pair<int, int>> best;
+    for (int extra = 0; extra < (1 << n_extra); ++extra) {
+        for (int counter = 0; counter < n_counters; ++counter) {
+            double score = 0.0;
+            for (std::size_t g = 0; g < n_grid; ++g) {
+                const int counter_val = (counter + static_cast<int>(frame_deltas[g])) &
+                                        counter_mask;
+                const int data12 = (counter_val << n_extra) | extra;
+                const double* row = signs.data() +
+                                    static_cast<std::size_t>(data12) * golay::N_BITS;
+                for (int c = 0; c < 24; ++c)
+                    score += row[c] * received[g * 24 + static_cast<std::size_t>(c)];
+            }
+            if (score > best_score) {
+                best_score = score;
+                best = std::make_pair(counter, extra);
+            }
+        }
+    }
+    return best;
+}
+
+// Joint search for a chunk mixing still-unknown callsign bits with the
+// per-repetition CRC (chunk 4 in the current layout) -- see the
+// file-level comment above. Brute-forces only this chunk's free
+// (non-CRC) bits and, for each hypothesis, derives the exact expected
+// per-repetition chunk content from payload_bits itself. Returns the
+// chunk's free-bit fragment (`n_free` bits, MSB first), or nullopt if
+// the chunk isn't shaped as assumed (free callsign bits followed by CRC
+// bits, no counter overlap).
+std::optional<std::vector<int>> search_crc_mixed_chunk(
+    std::span<const double> chips, const std::vector<std::int64_t>& grid,
+    std::int64_t anchor_off, int chunk_idx, int frame_index,
+    const std::vector<int>& known_callsign_bits) {
+    const auto [blo, bhi] = chunk_bit_range(chunk_idx);
+    const int callsign_lo = BEACON_COUNTER_BITS;
+    const int callsign_hi = callsign_lo + config::BEACON_CALLSIGN_BITS;
+    const int free_lo = std::max(blo, callsign_lo);
+    const int free_hi = std::min(bhi, callsign_hi);
+    const int n_free = free_hi - free_lo;
+    if (free_lo != blo || n_free + (bhi - callsign_hi) != 12) return std::nullopt;
+
+    const std::int64_t anchor_frame = anchor_off / CHIPS_PER_FRAME;
+    const int clo = chunk_idx * 24;
+    const std::size_t n_grid = grid.size();
+    std::vector<double> received(n_grid * 24);
+    std::vector<std::int64_t> frame_deltas(n_grid);
+    for (std::size_t g = 0; g < n_grid; ++g) {
+        const std::int64_t pos = grid[g];
+        frame_deltas[g] = pos / CHIPS_PER_FRAME - anchor_frame;
+        for (int c = 0; c < 24; ++c)
+            received[g * 24 + static_cast<std::size_t>(c)] =
+                sign(chips[static_cast<std::size_t>(pos + SYNC_LEN + clo + c)]);
+    }
+    const std::span<const double> signs = golay::signs_table();
+
+    double best_score = -1e300;
+    std::optional<std::vector<int>> best_frag;
+    for (int free_val = 0; free_val < (1 << n_free); ++free_val) {
+        std::vector<int> frag;
+        append_int_bits(frag, free_val, n_free);
+        std::vector<int> trial = known_callsign_bits;
+        std::copy(frag.begin(), frag.end(), trial.begin() + (free_lo - callsign_lo));
+        std::vector<int> codes;
+        for (int i = 0; i < config::BEACON_CALLSIGN_BITS; i += BEACON_CALLSIGN_CHAR_BITS)
+            codes.push_back(bits_to_int(std::span<const int>(trial).subspan(
+                static_cast<std::size_t>(i), BEACON_CALLSIGN_CHAR_BITS)));
+        const std::string callsign = codes_to_callsign(codes);
+
+        double score = 0.0;
+        for (std::size_t g = 0; g < n_grid; ++g) {
+            const std::int64_t fi = frame_index + frame_deltas[g];
+            if (fi < 0 || fi > MAX_FRAME_COUNTER) continue;
+            std::vector<int> payload = payload_bits(static_cast<int>(fi), callsign);
+            std::vector<int> chunk_bits(payload.begin() +
+                                            std::min<std::ptrdiff_t>(blo, static_cast<std::ptrdiff_t>(payload.size())),
+                                        payload.begin() +
+                                            std::min<std::ptrdiff_t>(bhi, static_cast<std::ptrdiff_t>(payload.size())));
+            chunk_bits.resize(12, 0);
+            const int data12 = bits_to_int(chunk_bits);
+            const double* row = signs.data() + static_cast<std::size_t>(data12) * golay::N_BITS;
+            for (int c = 0; c < 24; ++c)
+                score += row[c] * received[g * 24 + static_cast<std::size_t>(c)];
+        }
+        if (score > best_score) {
+            best_score = score;
+            best_frag = frag;
+        }
+    }
+    return best_frag;
+}
+
+std::optional<BeaconResult> decode_combined(std::span<const double> chips,
+                                            std::int64_t anchor_off) {
+    const std::int64_t n = static_cast<std::int64_t>(chips.size());
+    const std::vector<std::int64_t> grid = repetition_grid(n, anchor_off);
+    if (grid.size() < 3) return std::nullopt;  // too few repetitions for this to mean anything
+
+    const int counter_lo = 0;
+    const int callsign_lo = BEACON_COUNTER_BITS;
+    const int callsign_hi = BEACON_COUNTER_BITS + config::BEACON_CALLSIGN_BITS;
+
+    std::vector<int> invariant_chunks, variant_chunks;
+    for (int c = 0; c < N_CHUNKS; ++c) {
+        const auto [clo_bit, chi_bit] = chunk_bit_range(c);
+        if (callsign_lo <= clo_bit && chi_bit <= callsign_hi)
+            invariant_chunks.push_back(c);
+        else if (clo_bit < callsign_hi)
+            variant_chunks.push_back(c);
+    }
+
+    std::vector<int> callsign_bits(static_cast<std::size_t>(config::BEACON_CALLSIGN_BITS), -1);
+
+    // Coherent case: sum this chunk's coded chips (by sign) across every
+    // repetition (identical by construction), decode once.
+    for (int c : invariant_chunks) {
+        const int clo = c * 24;
+        std::vector<double> summed(24, 0.0);
+        for (std::int64_t pos : grid)
+            for (int j = 0; j < 24; ++j)
+                summed[static_cast<std::size_t>(j)] +=
+                    sign(chips[static_cast<std::size_t>(pos + SYNC_LEN + clo + j)]);
+        const std::vector<int> bits = decode_chunk_bits(summed);
+        const auto [blo, bhi] = chunk_bit_range(c);
+        std::copy(bits.begin(), bits.end(), callsign_bits.begin() + (blo - callsign_lo));
+    }
+
+    // The chunk carrying the counter's own low bit can't be voted on --
+    // joint-search it.
+    const int counter_chunk = *std::find_if(
+        variant_chunks.begin(), variant_chunks.end(),
+        [counter_lo](int c) { return chunk_bit_range(c).first <= counter_lo; });
+    const auto result =
+        search_counter_chunk(chips, grid, anchor_off, counter_chunk, BEACON_COUNTER_BITS);
+    if (!result) return std::nullopt;
+    const auto [frame_index, extra_bits_value] = *result;
+    if (frame_index < 0 || frame_index > MAX_FRAME_COUNTER) return std::nullopt;
+    const int n_extra = 12 - BEACON_COUNTER_BITS;
+    {
+        const auto [blo, bhi] = chunk_bit_range(counter_chunk);
+        const int lo = std::max(blo, callsign_lo);
+        const int hi = std::min(bhi, callsign_hi);
+        if (lo < hi) {
+            std::vector<int> extra_bits;
+            append_int_bits(extra_bits, extra_bits_value, n_extra);
+            std::copy(extra_bits.begin() + (lo - (bhi - n_extra)), extra_bits.end(),
+                     callsign_bits.begin() + (lo - callsign_lo));
+        }
+    }
+
+    // Remaining variant chunks (the one mixing leftover callsign bits
+    // with the per-repetition CRC) can't be voted on either -- joint-
+    // search them too.
+    for (int c : variant_chunks) {
+        if (c == counter_chunk) continue;
+        const auto frag =
+            search_crc_mixed_chunk(chips, grid, anchor_off, c, frame_index, callsign_bits);
+        if (!frag) return std::nullopt;
+        const int lo = std::max(chunk_bit_range(c).first, callsign_lo);
+        std::copy(frag->begin(), frag->end(), callsign_bits.begin() + (lo - callsign_lo));
+    }
+
+    if (std::any_of(callsign_bits.begin(), callsign_bits.end(), [](int b) { return b < 0; }))
+        return std::nullopt;  // a fragment nobody resolved (shouldn't happen given the layout)
+
+    std::vector<int> codes;
+    for (int i = 0; i < config::BEACON_CALLSIGN_BITS; i += BEACON_CALLSIGN_CHAR_BITS)
+        codes.push_back(bits_to_int(std::span<const int>(callsign_bits)
+                                        .subspan(static_cast<std::size_t>(i),
+                                                BEACON_CALLSIGN_CHAR_BITS)));
+    const std::string callsign = codes_to_callsign(codes);
+
+    // Verification: only against chunks nothing above was searched
+    // against (the CRC/padding-only ones), and by bit-exact independent
+    // decode rather than a correlation threshold -- see the file-level
+    // comment for why either shortcut is wrong. If even one repetition's
+    // own plain Golay decode of every verify chunk matches exactly what
+    // payload_bits says it should be, accept.
+    std::vector<int> verify_chunks;
+    for (int c = 0; c < N_CHUNKS; ++c)
+        if (chunk_bit_range(c).first >= callsign_hi) verify_chunks.push_back(c);
+    if (verify_chunks.empty()) return std::nullopt;
+
+    bool verified = false;
+    for (std::int64_t pos : grid) {
+        const std::int64_t fi =
+            frame_index + (pos / CHIPS_PER_FRAME - anchor_off / CHIPS_PER_FRAME);
+        if (fi < 0 || fi > MAX_FRAME_COUNTER) continue;
+        const std::vector<int> payload = payload_bits(static_cast<int>(fi), callsign);
+        bool all_match = true;
+        for (int c : verify_chunks) {
+            const auto [blo, bhi] = chunk_bit_range(c);
+            std::vector<int> want(
+                payload.begin() + std::min<std::ptrdiff_t>(blo, static_cast<std::ptrdiff_t>(payload.size())),
+                payload.begin() + std::min<std::ptrdiff_t>(bhi, static_cast<std::ptrdiff_t>(payload.size())));
+            want.resize(12, 0);
+            const std::vector<int> got = decode_chunk_bits(
+                chips.subspan(static_cast<std::size_t>(pos + SYNC_LEN + c * 24), 24));
+            if (!std::equal(want.begin(), want.end(), got.begin())) {
+                all_match = false;
+                break;
+            }
+        }
+        if (all_match) {
+            verified = true;
+            break;
+        }
+    }
+    if (!verified) return std::nullopt;
+
+    return BeaconResult{anchor_off, frame_index, callsign};
+}
+
+}  // namespace
+
 std::optional<BeaconResult> decode(std::span<const double> chips,
                                    double threshold) {
-    for (std::int64_t off : find_sync(chips, threshold)) {
+    const std::vector<std::int64_t> candidates = find_sync(chips, threshold);
+    for (std::int64_t off : candidates) {
         const std::size_t end =
             static_cast<std::size_t>(off) + SYNC_LEN + CODED_LEN;
         if (end > chips.size()) continue;
-        const auto result = decode_payload(
-            chips.subspan(static_cast<std::size_t>(off) + SYNC_LEN, CODED_LEN));
-        if (result)
-            return BeaconResult{off, result->first, result->second};
+        const auto result = decode_single_repetition(
+            off, chips.subspan(static_cast<std::size_t>(off) + SYNC_LEN, CODED_LEN));
+        if (result) return result;
+    }
+    for (std::int64_t off : candidates) {
+        const auto result = decode_combined(chips, off);
+        if (result) return result;
+    }
+    for (std::int64_t off : folded_sync_phases(chips)) {
+        const auto result = decode_combined(chips, off);
+        if (result) return result;
     }
     return std::nullopt;
 }

--- a/native/core/beacon/beacon.hpp
+++ b/native/core/beacon/beacon.hpp
@@ -93,9 +93,23 @@ std::vector<std::int64_t> find_sync(std::span<const double> chips,
                                     double threshold = 0.6,
                                     int max_candidates = 8);
 
-// Find and decode one superframe anywhere in `chips`. Tries the
-// best-correlated candidates in order and returns the first whose CRC
-// checks out.
+// Decode exactly one repetition's SUPERFRAME_LEN-SYNC_LEN=CODED_LEN
+// coded chips (i.e. `chips[off+SYNC_LEN : off+SYNC_LEN+CODED_LEN]` for
+// some sync offset `off`), or nullopt if its CRC does not check out.
+// `decode()` tries this at every find_sync() candidate before falling
+// back to combining evidence across repetitions (see the .cpp); exposed
+// separately so a caller (or a test) that wants single-repetition
+// behaviour specifically doesn't have to reconstruct it.
+std::optional<BeaconResult> decode_single_repetition(
+    std::int64_t chip_offset, std::span<const double> coded_chips);
+
+// Find and decode one beacon superframe anywhere in `chips` (soft
+// values, any length >= SUPERFRAME_LEN). Tries the best-correlated sync
+// candidates in order and returns the first one whose CRC checks out;
+// falls back to combining evidence across every repetition in `chips`
+// if no single one decodes alone -- see the .cpp for why and how (port
+// of sstvae/modem/beacon.py's module docstring on multi-repetition
+// combining).
 std::optional<BeaconResult> decode(std::span<const double> chips,
                                    double threshold = 0.6);
 

--- a/native/core/dsp/dsp.cpp
+++ b/native/core/dsp/dsp.cpp
@@ -191,6 +191,18 @@ std::vector<cdouble> to_baseband(std::span<const double> x) {
     return out;
 }
 
+std::vector<cdouble> to_baseband_at(std::span<const double> x, std::int64_t start_sample) {
+    const Heterodyne& h = heterodyne();
+    // (step * start_sample) mod period, computed defensively for a
+    // negative start_sample even though the caller never passes one.
+    std::int64_t idx = (h.step * start_sample) % h.period;
+    if (idx < 0) idx += h.period;
+    const cdouble correction = h.table[static_cast<std::size_t>(idx)];
+    std::vector<cdouble> out = to_baseband(x);
+    for (cdouble& v : out) v *= correction;
+    return out;
+}
+
 double wrap_cycles(double cycles) { return cycles - std::floor(cycles); }
 
 std::vector<cdouble> freq_correct(std::span<const cdouble> z, double f_hz) {

--- a/native/core/dsp/dsp.cpp
+++ b/native/core/dsp/dsp.cpp
@@ -147,6 +147,33 @@ std::vector<T> convolve_same_impl(std::span<const T> a, std::span<const double> 
     return out;
 }
 
+// numpy.convolve(a, v, mode="same") for complex a / real v, via FFT
+// rather than the direct sum convolve_same_impl uses. Only sync_lowpass
+// wants this: its 129-tap kernel against a's full length (the whole
+// ring-buffer snapshot, not a bounded search window) made the direct sum
+// the single largest cost in a live decode-loop profile -- a poll-cycle
+// tax that scaled with total buffer duration rather than with anything
+// acquisition actually needs. Same offset arithmetic as
+// convolve_same_impl, just applied to the FFT-computed full convolution
+// instead of a materialized one.
+std::vector<cdouble> fftconvolve_same(std::span<const cdouble> a,
+                                       std::span<const double> v) {
+    const std::size_t full = a.size() + v.size() - 1;
+    const std::size_t n = next_fast_len(full, /*real=*/false);
+    std::vector<cdouble> pa(n, cdouble{}), pv(n, cdouble{});
+    std::copy(a.begin(), a.end(), pa.begin());
+    for (std::size_t i = 0; i < v.size(); ++i) pv[i] = cdouble{v[i], 0.0};
+    std::vector<cdouble> fa = fft(pa, true);
+    const std::vector<cdouble> fv = fft(pv, true);
+    for (std::size_t i = 0; i < n; ++i) fa[i] *= fv[i];
+    const std::vector<cdouble> conv = fft(fa, false);
+
+    const std::size_t offset = (v.size() - 1) / 2;
+    return std::vector<cdouble>(
+        conv.begin() + static_cast<std::ptrdiff_t>(offset),
+        conv.begin() + static_cast<std::ptrdiff_t>(offset + a.size()));
+}
+
 }  // namespace
 
 std::vector<cdouble> to_baseband(std::span<const double> x) {
@@ -306,7 +333,7 @@ std::vector<cdouble> convolve_same(std::span<const cdouble> a,
 
 std::vector<cdouble> sync_lowpass(std::span<const cdouble> z) {
     static const std::vector<double> taps = firwin_lowpass(129, 850.0);
-    return convolve_same(z, std::span<const double>(taps));
+    return fftconvolve_same(z, std::span<const double>(taps));
 }
 
 std::vector<cdouble> hilbert(std::span<const double> x) {

--- a/native/core/dsp/dsp.cpp
+++ b/native/core/dsp/dsp.cpp
@@ -6,6 +6,7 @@
 #include <numbers>
 #include <numeric>
 #include <stdexcept>
+#include <utility>
 
 #include "dsp/fft.hpp"
 
@@ -260,7 +261,8 @@ std::size_t upfirdn_out_len(std::size_t len_h, std::size_t len_x, int up, int do
     return (in_len - 1) / static_cast<std::size_t>(down) + 1;
 }
 
-std::vector<double> resample_poly(std::span<const double> x, int up, int down) {
+std::vector<double> resample_poly(std::span<const double> x, int up, int down,
+                                  std::optional<std::vector<double>>* filter_cache) {
     if (up <= 0 || down <= 0) throw std::invalid_argument("resample_poly: up/down must be positive");
     const int g = static_cast<int>(std::gcd(up, down));
     up /= g;
@@ -275,12 +277,22 @@ std::vector<double> resample_poly(std::span<const double> x, int up, int down) {
 
     // Filter design, exactly scipy's: cutoff 1/max(up,down) relative to
     // Nyquist, 10*max(up,down) taps either side, Kaiser(5.0).
+    //
+    // `slot` is the caller's filter_cache if one was given, or a local
+    // optional that only lives for this one call otherwise -- either
+    // way the design-and-populate logic below runs unchanged, and reads
+    // back through the same `h` reference.
     const int max_rate = std::max(up, down);
-    const double f_c = 1.0 / max_rate;
     const int half_len = 10 * max_rate;
-    const int numtaps = 2 * half_len + 1;
-    std::vector<double> h = firwin_band(numtaps, 0.0, f_c, kaiser(numtaps, 5.0));
-    for (double& v : h) v *= up;
+    std::optional<std::vector<double>> local_filter;
+    std::optional<std::vector<double>>& slot = filter_cache ? *filter_cache : local_filter;
+    if (!slot.has_value()) {
+        const int numtaps = 2 * half_len + 1;
+        std::vector<double> h = firwin_band(numtaps, 0.0, 1.0 / max_rate, kaiser(numtaps, 5.0));
+        for (double& v : h) v *= up;
+        slot = std::move(h);
+    }
+    const std::vector<double>& h = *slot;
 
     // Zero-pad the filter so the output samples land at the centre.
     const std::size_t n_pre_pad =

--- a/native/core/dsp/dsp.hpp
+++ b/native/core/dsp/dsp.hpp
@@ -29,6 +29,17 @@ using cdouble = std::complex<double>;
 // provides per-carrier noise selectivity. Sync filters its own copy.
 std::vector<cdouble> to_baseband(std::span<const double> x);
 
+// to_baseband(x), but as if `x` were a slice of a longer signal starting
+// at absolute sample index `start_sample` rather than at 0 -- i.e.
+// exactly to_baseband(full)[start_sample : start_sample + x.size()] for
+// whatever longer `full` array `x` actually came from. See
+// sstvae.modem.dsp.to_baseband_at's docstring: needed by any caller
+// that baseband-converts one long recording as a series of independent
+// chunks and carries state *across* them (sync::BlindAccumulator's live
+// caller in rx/engine.cpp), because to_baseband always treats its own
+// input's first sample as the heterodyne's local n=0.
+std::vector<cdouble> to_baseband_at(std::span<const double> x, std::int64_t start_sample);
+
 // Fractional part of a phase in cycles, in [0, 1). For arbitrary
 // frequencies the product cannot be made exact the way the integer
 // cases can, but reducing before exp() removes the large-argument error.

--- a/native/core/dsp/dsp.hpp
+++ b/native/core/dsp/dsp.hpp
@@ -10,6 +10,7 @@
 
 #include <complex>
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -56,7 +57,19 @@ std::vector<double> kaiser(int m, double beta);
 // that per-chunk resampling cost. This function is the whole-signal
 // form, correct for a file or a complete waveform and wrong for a
 // stream of blocks.
-std::vector<double> resample_poly(std::span<const double> x, int up, int down);
+//
+// The Kaiser-windowed sinc filter this designs depends only on (up,
+// down), not on `x`, so `filter_cache`, if given, is a slot this fills
+// in on first use and reuses on every later call with it -- for a
+// caller (StreamResampler) that resamples many chunks at one fixed
+// ratio and would otherwise redesign the same (up to ~8821-tap) filter
+// from scratch on every chunk. Owned entirely by the caller: no shared
+// state, no locking, no eviction policy -- the caller's own lifetime is
+// the cache's lifetime. Passing the same slot across two different
+// (up, down) ratios is a caller bug, same as reusing any other
+// single-purpose local for two things, and is not detected.
+std::vector<double> resample_poly(std::span<const double> x, int up, int down,
+                                  std::optional<std::vector<double>>* filter_cache = nullptr);
 
 // numpy.convolve(a, v, mode="same"): the centre len(a) samples of the
 // full convolution, for len(a) >= len(v).

--- a/native/core/dsp/fft.hpp
+++ b/native/core/dsp/fft.hpp
@@ -14,6 +14,28 @@
 #include <cstddef>
 #include <vector>
 
+// Cache a handful of FFT plans (twiddle factors) instead of rebuilding
+// one on every call. Must be defined before pocketfft_hdronly.h is
+// first included, which happens right below -- this is that header's
+// only include site in the codebase.
+//
+// Off (0) by default upstream. A live-decode-loop perf capture showed
+// 5.45% of total CPU time in `cfftp<double>::cfftp` -- the plan
+// *constructor*, not the transform itself -- because every FFT call
+// anywhere in the native code, including 67 back-to-back same-length
+// calls inside a single acquire_blind() invocation, was rebuilding its
+// twiddle-factor table from scratch. The cache is a thread-safe,
+// mutex-protected LRU keyed by transform length (pocketfft_hdronly.h's
+// own `get_plan`), so this only removes redundant setup work; the
+// transform math, and so every golden vector's tolerance, is unchanged.
+// Sized generously above the small, fixed set of distinct lengths this
+// codebase's hot paths actually use, not tuned to it exactly -- eviction
+// churn from an undersized cache would be worse than the memory a few
+// extra unused slots cost.
+#ifndef POCKETFFT_CACHE_SIZE
+#define POCKETFFT_CACHE_SIZE 16
+#endif
+
 #include "pocketfft_hdronly.h"
 
 namespace sstvae::dsp {

--- a/native/core/golay/golay.cpp
+++ b/native/core/golay/golay.cpp
@@ -100,4 +100,6 @@ int min_distance() {
     return best;
 }
 
+std::span<const double> signs_table() { return tables().signs; }
+
 }  // namespace sstvae::golay

--- a/native/core/golay/golay.hpp
+++ b/native/core/golay/golay.hpp
@@ -36,4 +36,12 @@ int decode_soft(std::span<const double> soft);
 // Minimum distance of the code (8). Used by tests.
 int min_distance();
 
+// Sign pattern (+1/-1, MSB first) for every message, N_MESSAGES rows of
+// N_BITS each, row-major -- message `m`'s row is exactly what
+// `decode_soft` correlates candidate soft values against. Exposed so a
+// caller searching many hypotheses (beacon::_search_counter_chunk) can
+// index straight into the precomputed table instead of re-deriving each
+// hypothesis's codeword via codeword_bits() one at a time.
+std::span<const double> signs_table();
+
 }  // namespace sstvae::golay

--- a/native/core/modem/modem.cpp
+++ b/native/core/modem/modem.cpp
@@ -446,10 +446,35 @@ BlindDemodResult Modem::demodulate_blind(
         p += FRAME_SAMPLES;
     }
 
+    // Blind demod always covers every frame the *whole current buffer*
+    // can hold, since the transmission's true length is unknown until
+    // the beacon resolves it -- unlike demodulate() above, which
+    // restricts this same computation to the header's known real frame
+    // count via `received`. Most of that range is often not the real
+    // transmission at all (silence or noise before it starts, or
+    // accumulating after it ends, while the caller waits to see whether
+    // a longer mode is still arriving) -- a straight median over the
+    // *whole* range describes "typical", which is the noise floor
+    // whenever noise frames are the numerical majority, and noise then
+    // reads as fully trustworthy (weight ~1) right alongside real
+    // frames instead of being down-weighted. Anchoring instead on
+    // frames within an order of magnitude of the strongest ones seen
+    // needs only a few genuinely real frames to set the right
+    // reference, regardless of how much silence surrounds them; a real
+    // (even faded) frame is never excluded by this on its own account,
+    // since a *minority* of low-|h| frames barely moves a median in the
+    // first place. Mirrors sstvae/modem/modem.py's demodulate_blind.
     std::vector<double> mags;
     mags.reserve(h_pilot.size());
     for (const cdouble& v : h_pilot) mags.push_back(std::abs(v));
-    const double med_h = median(mags);
+    const double peak_h = mags.empty()
+        ? 0.0
+        : *std::max_element(mags.begin(), mags.end());
+    std::vector<double> plausible_mags;
+    plausible_mags.reserve(mags.size());
+    for (double m : mags)
+        if (m > 0.1 * peak_h) plausible_mags.push_back(m);
+    const double med_h = plausible_mags.empty() ? 1.0 : median(plausible_mags);
     const double floor = std::max(0.05 * med_h, 1e-9);
 
     auto pilot_at = [&h_pilot, n_f](int i) {

--- a/native/core/modem/modem.cpp
+++ b/native/core/modem/modem.cpp
@@ -400,14 +400,20 @@ DemodResult Modem::demodulate(std::span<const double> x,
 
 BlindDemodResult Modem::demodulate_blind(
     std::span<const double> x,
-    std::optional<std::pair<double, double>> search_s) const {
+    std::optional<std::pair<double, double>> search_s,
+    std::optional<sync::BlindAcquisition> acquisition) const {
     std::vector<cdouble> z = dsp::to_baseband(x);
 
-    std::optional<sync::SearchWindow> search;
-    if (search_s)
-        search = sync::SearchWindow{static_cast<std::int64_t>(search_s->first * FS),
-                                    static_cast<std::int64_t>(search_s->second * FS)};
-    const sync::BlindAcquisition ba = sync::acquire_blind(z, 55.0, 1.7, 8, 4.0, search);
+    sync::BlindAcquisition ba{};
+    if (acquisition) {
+        ba = *acquisition;
+    } else {
+        std::optional<sync::SearchWindow> search;
+        if (search_s)
+            search = sync::SearchWindow{static_cast<std::int64_t>(search_s->first * FS),
+                                        static_cast<std::int64_t>(search_s->second * FS)};
+        ba = sync::acquire_blind(z, 55.0, 1.7, 8, 4.0, search);
+    }
     z = dsp::freq_correct(z, ba.freq_offset);
 
     const std::int64_t p0 = ba.frame_start - NCP;  // CP-start of local frame 0

--- a/native/core/modem/modem.hpp
+++ b/native/core/modem/modem.hpp
@@ -104,9 +104,17 @@ class Modem {
     //
     // No sample-clock drift tracking (that needs a preamble phase
     // reference); fine for the bounded windows this targets.
+    //
+    // `acquisition`, if given, skips the internal acquire_blind call and
+    // demodulates at that position instead -- for a caller (rx/engine.cpp)
+    // that already found it via a persistent sync::BlindAccumulator
+    // rather than a fresh bounded-window search. The rest is unaffected:
+    // it still demodulates every frame the whole of `x` can hold, using
+    // `acquisition` only to place frame 0.
     BlindDemodResult demodulate_blind(
         std::span<const double> x,
-        std::optional<std::pair<double, double>> search_s = std::nullopt) const;
+        std::optional<std::pair<double, double>> search_s = std::nullopt,
+        std::optional<sync::BlindAcquisition> acquisition = std::nullopt) const;
 
    private:
     std::vector<cdouble> pilot_;

--- a/native/core/rx/engine.cpp
+++ b/native/core/rx/engine.cpp
@@ -268,6 +268,19 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
     // the next one can make a brand-new reception look as though it has
     // already stalled, and end it early.
     std::optional<std::int64_t> tracked_reception_start;
+    // Blind acquisition's persistent search state: a BlindAccumulator
+    // folds in only the audio that is new since the last poll (see
+    // sync::BlindAccumulator), so unlike the preamble path it carries
+    // state across iterations of this loop instead of re-deriving
+    // everything from the current snapshot each time. blind_acc_pushed
+    // is the absolute (ring-buffer-coordinate) sample count already
+    // folded in; unset means "nothing pushed yet, or the last push's
+    // position fell out of the ring buffer's retained window" -- either
+    // way there is a gap push() cannot bridge contiguously, so the right
+    // response is a fresh accumulator over what is available now rather
+    // than guessing at what filled it.
+    std::optional<sync::BlindAccumulator> blind_acc;
+    std::optional<std::int64_t> blind_acc_pushed;
 
     while (!stop.is_set()) {
         if (stop.wait(config.poll_interval)) break;
@@ -321,23 +334,44 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
             progress_metric = r.frames_received;
             reception_start = found->start;
         } else {
-            // Bound where blind acquisition searches (the dominant CPU
-            // cost of this path) to the most recent slice of the buffer;
-            // the retrospective decode still covers everything once
-            // locked. Whole buffer if it is shorter than the window.
-            const auto blind_span =
-                static_cast<std::int64_t>(config.blind_search_seconds * FS);
-            const auto n = static_cast<std::int64_t>(samples.size());
-            const auto blind_search =
-                n <= blind_span ? std::nullopt : window_s(n - blind_span, n);
+            // Fold whatever is new since the last poll into the running
+            // accumulator -- O(new samples), not O(window) -- which is
+            // what lets this search as far back as
+            // config.blind_search_seconds of *decayed* history rather
+            // than a hard-bounded recent slice. The retrospective decode
+            // below still covers the whole current buffer once locked,
+            // exactly as before.
+            if (!blind_acc || !blind_acc_pushed || *blind_acc_pushed < buf_start) {
+                blind_acc.emplace(55.0, 1.7, 8, 4.0, std::nullopt,
+                                  config.blind_search_seconds);
+                blind_acc_pushed = buf_start;
+            }
+            const auto new_lo = *blind_acc_pushed - buf_start;
+            if (new_lo < static_cast<std::int64_t>(samples.size())) {
+                const std::vector<double> new_raw(
+                    samples.begin() + new_lo, samples.end());
+                const std::vector<std::complex<double>> new_chunk =
+                    dsp::to_baseband_at(new_raw, *blind_acc_pushed);
+                blind_acc->push(new_chunk, *blind_acc_pushed);
+                blind_acc_pushed = static_cast<std::int64_t>(total);
+            }
+
+            std::optional<sync::BlindAcquisition> ba;
+            try {
+                ba = blind_acc->result();
+            } catch (const sync::SyncError&) {
+                ba = std::nullopt;
+            }
 
             std::optional<modem::BlindDemodResult> rb;
-            try {
-                rb = modem.demodulate_blind(samples, blind_search);
-            } catch (const sync::SyncError&) {
-                rb = std::nullopt;
-            } catch (const std::exception&) {
-                rb = std::nullopt;
+            if (ba) {
+                try {
+                    rb = modem.demodulate_blind(samples, std::nullopt, ba);
+                } catch (const sync::SyncError&) {
+                    rb = std::nullopt;
+                } catch (const std::exception&) {
+                    rb = std::nullopt;
+                }
             }
 
             if (rb && rb->beacon && rb->frame0_start) {

--- a/native/core/rx/engine.cpp
+++ b/native/core/rx/engine.cpp
@@ -35,6 +35,12 @@ constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
 // Mode C, the longest -- the denominator for blind progress, where the
 // real mode is unknown.
 constexpr int kTotalCLatents = config::MODES[config::N_MODES - 1].n_latents;
+constexpr int kMaxModeFrames = config::MODES[config::N_MODES - 1].n_frames;
+
+// Weight a blind-path latent must clear to count as "confidently
+// received" for the stall-detection progress metric -- see its use
+// below. Matches the "good" cutoff tests already judge latents by.
+constexpr double kProgressWeightThreshold = 0.5;
 
 // How many finished receptions to remember. They only need to outlive
 // their own audio in the ring buffer; 50 is the reference's bound.
@@ -138,6 +144,20 @@ std::optional<FoundReception> find_new_reception(
 int count_nonzero(const std::vector<double>& v) {
     return static_cast<int>(std::count_if(v.begin(), v.end(),
                                           [](double w) { return w != 0.0; }));
+}
+
+// Confidently-received latents only, not a bare nonzero count:
+// demodulate_blind assigns *some* nonzero weight to essentially every
+// legal abs_frame slot its ever-growing search range touches, real
+// signal or not (just small for noise, after the med_h fix in
+// modem.cpp), so a nonzero count keeps climbing every poll purely from
+// the buffer growing -- independent of whether any new real data has
+// arrived -- until buffer growth has mapped the *entire* legal
+// abs_frame range. That read as "stuck receiving forever": the stall
+// detector below never saw a stable metric to end_grace against.
+int count_confident(const std::vector<double>& v) {
+    return static_cast<int>(std::count_if(
+        v.begin(), v.end(), [](double w) { return w > kProgressWeightThreshold; }));
 }
 
 void remember_finished(std::deque<std::int64_t>& finished, std::int64_t pos) {
@@ -392,7 +412,7 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
                 have_latents = true;
                 callsign = rb->callsign;
                 snr_db = rb->snr_db;
-                progress_metric = count_nonzero(weights_full);
+                progress_metric = count_confident(weights_full);
                 progress_frac = static_cast<double>(progress_metric) / kTotalCLatents;
             }
         }
@@ -437,11 +457,32 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
         bool done = false;
         if (n_frames_expected) {
             done = *frames_received >= *n_frames_expected;
-        } else if (progress_metric > 0 && progress_metric == last_progress_metric) {
-            if (!stable_since) stable_since = Clock::now();
-            done = seconds_since(*stable_since) >= config.end_grace;
         } else {
-            stable_since.reset();
+            // Deterministic backstop: the beacon already told us exactly
+            // where this transmission's frame 0 sits
+            // (current_reception_start, in the same "preamble start"
+            // coordinate the header path uses), so the latest a real
+            // frame of it can possibly still be arriving is mode C's own
+            // duration -- the longest mode -- after that point, fixed the
+            // moment current_reception_start is known. That is unlike
+            // "progress stopped changing" below, which rides on
+            // demodulate_blind's own noise floor and is not guaranteed to
+            // ever settle: a stuck reception was observed sitting in
+            // Receiving for many minutes, far past any mode's duration.
+            // Once the buffer holds audio past this deadline there is
+            // provably no more real signal left to arrive for this
+            // reception, done or not.
+            const std::int64_t deadline_abs = *current_reception_start + PREAMBLE_SAMPLES +
+                                              HEADER_SAMPLES +
+                                              static_cast<std::int64_t>(kMaxModeFrames) *
+                                                  FRAME_SAMPLES;
+            if (progress_metric > 0 && progress_metric == last_progress_metric) {
+                if (!stable_since) stable_since = Clock::now();
+                done = seconds_since(*stable_since) >= config.end_grace;
+            } else {
+                stable_since.reset();
+            }
+            done = done || static_cast<std::int64_t>(total) >= deadline_abs;
         }
         last_progress_metric = progress_metric;
 

--- a/native/core/rx/engine.cpp
+++ b/native/core/rx/engine.cpp
@@ -336,14 +336,17 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
         } else {
             // Fold whatever is new since the last poll into the running
             // accumulator -- O(new samples), not O(window) -- which is
-            // what lets this search as far back as
-            // config.blind_search_seconds of *decayed* history rather
-            // than a hard-bounded recent slice. The retrospective decode
-            // below still covers the whole current buffer once locked,
-            // exactly as before.
+            // what lets this run one decay timescale per mode (see
+            // RxConfig::blind_search_seconds) rather than a single
+            // one-size-fits-all window. The retrospective decode below
+            // still covers the whole current buffer once locked, exactly
+            // as before.
             if (!blind_acc || !blind_acc_pushed || *blind_acc_pushed < buf_start) {
-                blind_acc.emplace(55.0, 1.7, 8, 4.0, std::nullopt,
-                                  config.blind_search_seconds);
+                std::vector<std::optional<double>> timescales;
+                for (const auto& mode : config::MODES)
+                    timescales.push_back(
+                        std::min(mode.duration_s, config.blind_search_seconds));
+                blind_acc.emplace(55.0, 1.7, 8, 4.0, std::nullopt, std::move(timescales));
                 blind_acc_pushed = buf_start;
             }
             const auto new_lo = *blind_acc_pushed - buf_start;

--- a/native/core/rx/engine.hpp
+++ b/native/core/rx/engine.hpp
@@ -73,7 +73,15 @@ struct RxConfig {
     // Downscale saved pictures, e.g. {320, 240}. Unset = full size.
     std::optional<std::pair<int, int>> size;
     bool once = false;
-    double blind_search_seconds = 25.0;
+    // A cap, not a fixed timescale: sync::BlindAccumulator runs one
+    // decay timescale per mode (config::MODES), each capped at
+    // min(mode.duration_s, blind_search_seconds), so by default (above
+    // every mode's own duration) no mode's timescale is capped at all --
+    // see decode_loop. Only useful to *shrink* below a mode's own
+    // duration (a fast synthetic test's short buffer, e.g.); there is no
+    // reliability reason to raise it past the longest mode's duration,
+    // since there is no more real signal beyond that to integrate.
+    double blind_search_seconds = config::MODES[config::N_MODES - 1].duration_s;
 };
 
 // The `threading.Event` the reference stops on. Shared with the

--- a/native/core/rx/ringbuffer.hpp
+++ b/native/core/rx/ringbuffer.hpp
@@ -70,11 +70,21 @@ public:
     // Drop everything captured so far, keeping the sample counter
     // monotonic.
     //
-    // Used when resuming receive after transmitting: the buffer is full
-    // of our own sidetone and the decode loop would happily lock onto
-    // it and "receive" the picture we just sent. Leaving `total_written`
-    // alone keeps every absolute sample position the loop has recorded
-    // still meaningful.
+    // Not currently on the resume-after-transmit path: both callers that
+    // need to keep our own sidetone out of the decoder (the "start
+    // receiving" button and ReceivePanel::resume_after_transmit) instead
+    // discard the whole RingBuffer and construct a fresh one, which
+    // starts decode_loop over from scratch -- so blind_acc and every
+    // other loop-local accumulator get a clean slate too, not just the
+    // audio. That leaves total_written() restarting at 0 rather than
+    // staying monotonic through the gap, which is fine because nothing
+    // survives the restart that could still be indexing against the old
+    // count. This method stays as a lower-overhead primitive (no
+    // reallocation, counter stays meaningful) for a caller that wants to
+    // wipe the audio in place without restarting the loop -- but pairing
+    // it with such a resume would need its own explicit reset of
+    // blind_acc/blind_acc_pushed and the other decode_loop locals, since
+    // none of those are reachable from here.
     void clear();
 
     std::size_t capacity() const { return buf_.size(); }

--- a/native/core/sync/sync.cpp
+++ b/native/core/sync/sync.cpp
@@ -287,8 +287,9 @@ BlindAcquisition acquire_blind(std::span<const cdouble> z, double max_offset_hz,
 
 BlindAccumulator::BlindAccumulator(double max_offset_hz, double bin_step_hz, int min_periods,
                                    double threshold, std::optional<int> block_samples,
-                                   std::optional<double> window_s)
+                                   std::vector<std::optional<double>> window_s)
     : min_periods_(min_periods), threshold_(threshold) {
+    if (window_s.empty()) throw SyncError("BlindAccumulator: window_s must not be empty");
     const std::vector<cdouble> templ = ofdm::pilot_template();
     std::vector<cdouble> kernel(templ.size());
     for (std::size_t i = 0; i < templ.size(); ++i)
@@ -317,14 +318,24 @@ BlindAccumulator::BlindAccumulator(double max_offset_hz, double bin_step_hz, int
     std::copy(kernel.begin(), kernel.end(), pad_kernel.begin());
     kernel_f_ = dsp::fft(pad_kernel, true);
 
-    // Applied once per processed block, uniformly across every phase and
-    // CFO bin -- see the BlindAccumulator docstring in sync.py for why
-    // this is exponential decay rather than exact eviction.
-    decay_per_block_ =
-        window_s ? std::exp(-static_cast<double>(step_) / (*window_s * static_cast<double>(FS)))
-                 : 1.0;
+    // One decay factor per timescale, applied once per processed block,
+    // uniformly across every phase and CFO bin within that timescale --
+    // see the BlindAccumulator docstring in sync.py for why this is
+    // exponential decay rather than exact eviction, and why several
+    // timescales run in parallel off the same per-block matched-filter
+    // result rather than a single one.
+    n_scales_ = static_cast<int>(window_s.size());
+    decay_per_block_.resize(static_cast<std::size_t>(n_scales_));
+    for (int t = 0; t < n_scales_; ++t)
+        decay_per_block_[static_cast<std::size_t>(t)] =
+            window_s[static_cast<std::size_t>(t)]
+                ? std::exp(-static_cast<double>(step_) /
+                          (*window_s[static_cast<std::size_t>(t)] * static_cast<double>(FS)))
+                : 1.0;
 
-    folded_.assign(shift_bins_.size() * static_cast<std::size_t>(FRAME_SAMPLES), 0.0);
+    folded_.assign(static_cast<std::size_t>(n_scales_) * shift_bins_.size() *
+                       static_cast<std::size_t>(FRAME_SAMPLES),
+                   0.0);
 }
 
 void BlindAccumulator::push(std::span<const cdouble> z, std::int64_t start_sample) {
@@ -354,8 +365,18 @@ void BlindAccumulator::push(std::span<const cdouble> z, std::int64_t start_sampl
         const std::int64_t abs0 = buf_start_ + static_cast<std::int64_t>(pos);
         const int phase0 = static_cast<int>(((abs0 % FRAME_SAMPLES) + FRAME_SAMPLES) % FRAME_SAMPLES);
 
-        if (decay_per_block_ != 1.0)
-            for (double& v : folded_) v *= decay_per_block_;
+        // Decay every timescale's whole array first -- cheap
+        // (n_scales_ x n_bins_ x FRAME_SAMPLES scalars) next to the
+        // per-bin FFT below, which is why adding timescales barely
+        // moves push()'s cost.
+        const std::size_t scale_stride =
+            shift_bins_.size() * static_cast<std::size_t>(FRAME_SAMPLES);
+        for (int t = 0; t < n_scales_; ++t) {
+            const double d = decay_per_block_[static_cast<std::size_t>(t)];
+            if (d == 1.0) continue;
+            double* base = &folded_[static_cast<std::size_t>(t) * scale_stride];
+            for (std::size_t i = 0; i < scale_stride; ++i) base[i] *= d;
+        }
 
         for (std::size_t bi = 0; bi < shift_bins_.size(); ++bi) {
             const int shift = shift_bins_[bi];
@@ -368,11 +389,17 @@ void BlindAccumulator::push(std::span<const cdouble> z, std::int64_t start_sampl
                     block_f[static_cast<std::size_t>(src)] * kernel_f_[static_cast<std::size_t>(i)];
             }
             const std::vector<cdouble> mf = dsp::fft(shifted, false);
-            double* row = &folded_[bi * static_cast<std::size_t>(FRAME_SAMPLES)];
-            int phase = phase0;
-            for (int i = 0; i < step; ++i) {
-                row[phase] += std::norm(mf[static_cast<std::size_t>(m - 1 + i)]);
-                if (++phase == FRAME_SAMPLES) phase = 0;
+            // Every timescale folds in the same per-block matched-filter
+            // power -- only the decay each one already applied to its
+            // own history (above) differs.
+            for (int t = 0; t < n_scales_; ++t) {
+                double* row = &folded_[static_cast<std::size_t>(t) * scale_stride +
+                                       bi * static_cast<std::size_t>(FRAME_SAMPLES)];
+                int phase = phase0;
+                for (int i = 0; i < step; ++i) {
+                    row[phase] += std::norm(mf[static_cast<std::size_t>(m - 1 + i)]);
+                    if (++phase == FRAME_SAMPLES) phase = 0;
+                }
             }
         }
         n_valid_ += step;
@@ -387,26 +414,38 @@ BlindAcquisition BlindAccumulator::result() const {
     if (n_valid_ < static_cast<std::int64_t>(FRAME_SAMPLES) * min_periods_)
         throw SyncError("window too short for blind acquisition");
 
+    // Best (timescale, bin) pair -- reports whichever timescale's peak
+    // score is highest, not a fixed one, since which timescale that is
+    // depends on which mode (if any) is actually transmitting.
+    const std::size_t scale_stride =
+        shift_bins_.size() * static_cast<std::size_t>(FRAME_SAMPLES);
     bool have_best = false;
     double best_score = 0.0;
     std::size_t best_bin = 0;
-    for (std::size_t bi = 0; bi < shift_bins_.size(); ++bi) {
-        const std::span<const double> row(&folded_[bi * static_cast<std::size_t>(FRAME_SAMPLES)],
-                                          static_cast<std::size_t>(FRAME_SAMPLES));
-        const std::size_t peak = argmax(row);
-        const double score =
-            row[peak] / (median(std::vector<double>(row.begin(), row.end())) + 1e-12);
-        if (!have_best || score > best_score) {
-            have_best = true;
-            best_score = score;
-            best_bin = bi;
+    int best_scale = 0;
+    for (int t = 0; t < n_scales_; ++t) {
+        const double* scale_base = &folded_[static_cast<std::size_t>(t) * scale_stride];
+        for (std::size_t bi = 0; bi < shift_bins_.size(); ++bi) {
+            const std::span<const double> row(
+                scale_base + bi * static_cast<std::size_t>(FRAME_SAMPLES),
+                static_cast<std::size_t>(FRAME_SAMPLES));
+            const std::size_t peak = argmax(row);
+            const double score =
+                row[peak] / (median(std::vector<double>(row.begin(), row.end())) + 1e-12);
+            if (!have_best || score > best_score) {
+                have_best = true;
+                best_score = score;
+                best_bin = bi;
+                best_scale = t;
+            }
         }
     }
     if (best_score < threshold_)
         throw SyncError("no periodic pilot found (peak prominence " +
                         std::to_string(best_score) + ")");
 
-    const std::span<const double> row(&folded_[best_bin * static_cast<std::size_t>(FRAME_SAMPLES)],
+    const double* scale_base = &folded_[static_cast<std::size_t>(best_scale) * scale_stride];
+    const std::span<const double> row(scale_base + best_bin * static_cast<std::size_t>(FRAME_SAMPLES),
                                       static_cast<std::size_t>(FRAME_SAMPLES));
     const std::size_t phase = argmax(row);
 

--- a/native/core/sync/sync.cpp
+++ b/native/core/sync/sync.cpp
@@ -285,4 +285,132 @@ BlindAcquisition acquire_blind(std::span<const cdouble> z, double max_offset_hz,
                             best_score};
 }
 
+BlindAccumulator::BlindAccumulator(double max_offset_hz, double bin_step_hz, int min_periods,
+                                   double threshold, std::optional<int> block_samples,
+                                   std::optional<double> window_s)
+    : min_periods_(min_periods), threshold_(threshold) {
+    const std::vector<cdouble> templ = ofdm::pilot_template();
+    std::vector<cdouble> kernel(templ.size());
+    for (std::size_t i = 0; i < templ.size(); ++i)
+        kernel[i] = std::conj(templ[templ.size() - 1 - i]);
+    m_ = static_cast<int>(kernel.size());
+
+    const int min_block = static_cast<int>(std::ceil(static_cast<double>(FS) / bin_step_hz));
+    block_ = static_cast<int>(dsp::next_fast_len(
+        static_cast<std::size_t>(std::max(min_block, 4 * m_)), /*real=*/false));
+    step_ = block_ - (m_ - 1);
+    if (step_ <= 0) throw SyncError("block_samples too small for the pilot kernel");
+    if (block_samples) {
+        block_ = *block_samples;
+        step_ = block_ - (m_ - 1);
+    }
+    const double bin_hz = static_cast<double>(FS) / static_cast<double>(block_);
+
+    n_bins_ = static_cast<int>(std::ceil(max_offset_hz / bin_step_hz));
+    for (int k = -n_bins_; k <= n_bins_; ++k) {
+        const int shift = static_cast<int>(std::nearbyint(static_cast<double>(k) * bin_step_hz / bin_hz));
+        shift_bins_.push_back(shift);
+        freqs_.push_back(static_cast<double>(shift) * bin_hz);
+    }
+
+    std::vector<cdouble> pad_kernel(static_cast<std::size_t>(block_), cdouble{});
+    std::copy(kernel.begin(), kernel.end(), pad_kernel.begin());
+    kernel_f_ = dsp::fft(pad_kernel, true);
+
+    // Applied once per processed block, uniformly across every phase and
+    // CFO bin -- see the BlindAccumulator docstring in sync.py for why
+    // this is exponential decay rather than exact eviction.
+    decay_per_block_ =
+        window_s ? std::exp(-static_cast<double>(step_) / (*window_s * static_cast<double>(FS)))
+                 : 1.0;
+
+    folded_.assign(shift_bins_.size() * static_cast<std::size_t>(FRAME_SAMPLES), 0.0);
+}
+
+void BlindAccumulator::push(std::span<const cdouble> z, std::int64_t start_sample) {
+    if (buf_start_ < 0) {
+        buf_start_ = start_sample;
+    } else if (start_sample != buf_start_ + static_cast<std::int64_t>(buf_.size())) {
+        throw SyncError(
+            "BlindAccumulator::push: expected a contiguous continuation at sample " +
+            std::to_string(buf_start_ + static_cast<std::int64_t>(buf_.size())) + ", got " +
+            std::to_string(start_sample));
+    }
+    buf_.insert(buf_.end(), z.begin(), z.end());
+
+    const int B = block_, m = m_, step = step_;
+    std::vector<cdouble> shifted(static_cast<std::size_t>(B));
+    std::size_t pos = 0;
+    while (pos + static_cast<std::size_t>(B) <= buf_.size()) {
+        const std::vector<cdouble> block(
+            buf_.begin() + static_cast<std::ptrdiff_t>(pos),
+            buf_.begin() + static_cast<std::ptrdiff_t>(pos) + B);
+        const std::vector<cdouble> block_f = dsp::fft(block, true);
+
+        // Same convention as acquire_blind's p2[j]: mf[i] (0-indexed
+        // within the valid slice, i.e. mf_full[m-1+i]) is the matched
+        // filter's response for a pilot window starting at block-local
+        // index i, so no (m - 1) belongs in abs0.
+        const std::int64_t abs0 = buf_start_ + static_cast<std::int64_t>(pos);
+        const int phase0 = static_cast<int>(((abs0 % FRAME_SAMPLES) + FRAME_SAMPLES) % FRAME_SAMPLES);
+
+        if (decay_per_block_ != 1.0)
+            for (double& v : folded_) v *= decay_per_block_;
+
+        for (std::size_t bi = 0; bi < shift_bins_.size(); ++bi) {
+            const int shift = shift_bins_[bi];
+            // np.roll(block_f, -shift): out[i] = block_f[(i + shift) mod B]
+            for (int i = 0; i < B; ++i) {
+                long src = static_cast<long>(i) + shift;
+                src %= B;
+                if (src < 0) src += B;
+                shifted[static_cast<std::size_t>(i)] =
+                    block_f[static_cast<std::size_t>(src)] * kernel_f_[static_cast<std::size_t>(i)];
+            }
+            const std::vector<cdouble> mf = dsp::fft(shifted, false);
+            double* row = &folded_[bi * static_cast<std::size_t>(FRAME_SAMPLES)];
+            int phase = phase0;
+            for (int i = 0; i < step; ++i) {
+                row[phase] += std::norm(mf[static_cast<std::size_t>(m - 1 + i)]);
+                if (++phase == FRAME_SAMPLES) phase = 0;
+            }
+        }
+        n_valid_ += step;
+        pos += static_cast<std::size_t>(step);
+    }
+
+    buf_.erase(buf_.begin(), buf_.begin() + static_cast<std::ptrdiff_t>(pos));
+    buf_start_ += static_cast<std::int64_t>(pos);
+}
+
+BlindAcquisition BlindAccumulator::result() const {
+    if (n_valid_ < static_cast<std::int64_t>(FRAME_SAMPLES) * min_periods_)
+        throw SyncError("window too short for blind acquisition");
+
+    bool have_best = false;
+    double best_score = 0.0;
+    std::size_t best_bin = 0;
+    for (std::size_t bi = 0; bi < shift_bins_.size(); ++bi) {
+        const std::span<const double> row(&folded_[bi * static_cast<std::size_t>(FRAME_SAMPLES)],
+                                          static_cast<std::size_t>(FRAME_SAMPLES));
+        const std::size_t peak = argmax(row);
+        const double score =
+            row[peak] / (median(std::vector<double>(row.begin(), row.end())) + 1e-12);
+        if (!have_best || score > best_score) {
+            have_best = true;
+            best_score = score;
+            best_bin = bi;
+        }
+    }
+    if (best_score < threshold_)
+        throw SyncError("no periodic pilot found (peak prominence " +
+                        std::to_string(best_score) + ")");
+
+    const std::span<const double> row(&folded_[best_bin * static_cast<std::size_t>(FRAME_SAMPLES)],
+                                      static_cast<std::size_t>(FRAME_SAMPLES));
+    const std::size_t phase = argmax(row);
+
+    return BlindAcquisition{static_cast<std::int64_t>(phase), freqs_[best_bin], best_score};
+}
+
 }  // namespace sstvae::sync

--- a/native/core/sync/sync.hpp
+++ b/native/core/sync/sync.hpp
@@ -79,12 +79,17 @@ BlindAcquisition acquire_blind(std::span<const cdouble> z,
 // throws SyncError otherwise. result() throws SyncError exactly as
 // acquire_blind() does: too little data pushed yet, or no bin's peak
 // clears `threshold`.
+// `window_s` runs one decay timescale per entry in parallel, off the
+// same (shared, expensive) per-block matched-filter result -- see the
+// Python class's docstring for why a single timescale can't serve every
+// mode well. result() reports whichever timescale's peak score is
+// highest. A single-element vector (the default) is one timescale.
 class BlindAccumulator {
    public:
     explicit BlindAccumulator(double max_offset_hz = 55.0, double bin_step_hz = 1.7,
                               int min_periods = 8, double threshold = 4.0,
                               std::optional<int> block_samples = std::nullopt,
-                              std::optional<double> window_s = 25.0);
+                              std::vector<std::optional<double>> window_s = {25.0});
 
     void push(std::span<const cdouble> z, std::int64_t start_sample);
     BlindAcquisition result() const;
@@ -95,13 +100,14 @@ class BlindAccumulator {
     double threshold_;
     int block_;
     int step_;
-    double decay_per_block_;
+    std::vector<double> decay_per_block_;  // one per timescale
     std::vector<int> shift_bins_;
     std::vector<double> freqs_;
     std::vector<cdouble> kernel_f_;
 
     int n_bins_;
-    std::vector<double> folded_;  // n_bins_ x FRAME_SAMPLES, row-major
+    int n_scales_;
+    std::vector<double> folded_;  // n_scales_ x n_bins_ x FRAME_SAMPLES, row-major
     std::int64_t n_valid_ = 0;
     std::vector<cdouble> buf_;
     std::int64_t buf_start_ = -1;  // -1 until the first push()

--- a/native/core/sync/sync.hpp
+++ b/native/core/sync/sync.hpp
@@ -68,4 +68,43 @@ BlindAcquisition acquire_blind(std::span<const cdouble> z,
                                double threshold = 4.0,
                                std::optional<SearchWindow> search = std::nullopt);
 
+// Incremental counterpart to acquire_blind(). Port of
+// sstvae.modem.sync.BlindAccumulator -- see that class's docstring for
+// the full design rationale (block-wise overlap-save so push() costs
+// O(new samples) rather than O(window length); why the block-local
+// circular-shift CFO trick still folds to the correct energy; why
+// window_s is exponential decay rather than exact eviction).
+//
+// push() requires contiguous input (no gaps, no re-sent samples) and
+// throws SyncError otherwise. result() throws SyncError exactly as
+// acquire_blind() does: too little data pushed yet, or no bin's peak
+// clears `threshold`.
+class BlindAccumulator {
+   public:
+    explicit BlindAccumulator(double max_offset_hz = 55.0, double bin_step_hz = 1.7,
+                              int min_periods = 8, double threshold = 4.0,
+                              std::optional<int> block_samples = std::nullopt,
+                              std::optional<double> window_s = 25.0);
+
+    void push(std::span<const cdouble> z, std::int64_t start_sample);
+    BlindAcquisition result() const;
+
+   private:
+    int m_;
+    int min_periods_;
+    double threshold_;
+    int block_;
+    int step_;
+    double decay_per_block_;
+    std::vector<int> shift_bins_;
+    std::vector<double> freqs_;
+    std::vector<cdouble> kernel_f_;
+
+    int n_bins_;
+    std::vector<double> folded_;  // n_bins_ x FRAME_SAMPLES, row-major
+    std::int64_t n_valid_ = 0;
+    std::vector<cdouble> buf_;
+    std::int64_t buf_start_ = -1;  // -1 until the first push()
+};
+
 }  // namespace sstvae::sync

--- a/native/gui/rx_panel.cpp
+++ b/native/gui/rx_panel.cpp
@@ -233,6 +233,17 @@ bool ReceivePanel::start() {
 
     const settings::Config& config = app_->config();
     ring_ = std::make_shared<rx::RingBuffer>(config.receive.buffer_seconds);
+    // decode_loop's own locals (blind_acc included) already start clean
+    // just by being a fresh function call, but the Progress this panel
+    // *displays* lives here, not in the loop -- and stop() (called by
+    // both the Stop button and suspend_for_transmit) never touches it.
+    // Without this, stopping while a reception was in progress leaves
+    // shared_ holding a stale "Receiving" Progress -- old mode, old
+    // frame count, old callsign -- and the 500 ms status timer shows it
+    // immediately on the next Start, before the new loop has run a
+    // single poll. A fresh SharedState is the rest of what "start() is
+    // the one method that resets all receiver state" needs to be true.
+    shared_ = std::make_unique<rx::SharedState>();
     if (Waterfall* w = fall()) w->set_ring(ring_);
 
     try {

--- a/native/tests/CMakeLists.txt
+++ b/native/tests/CMakeLists.txt
@@ -37,6 +37,12 @@ target_include_directories(test_framing PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME framing COMMAND test_framing)
 set_tests_properties(framing PROPERTIES TIMEOUT 180)
 
+add_executable(test_beacon test_beacon.cpp)
+target_link_libraries(test_beacon PRIVATE sstvae_core)
+target_include_directories(test_beacon PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME beacon COMMAND test_beacon)
+set_tests_properties(beacon PROPERTIES TIMEOUT 240)
+
 add_executable(test_log test_log.cpp)
 target_link_libraries(test_log PRIVATE sstvae_core)
 target_include_directories(test_log PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/native/tests/test_beacon.cpp
+++ b/native/tests/test_beacon.cpp
@@ -105,7 +105,24 @@ void test_no_false_lock_on_long_pure_noise() {
     constexpr int kModeCFrames = 660;
     const std::size_t n_chips = static_cast<std::size_t>(kModeCFrames) * config::CHIPS_PER_FRAME;
 
+    // ASan+UBSan's instrumentation makes decode()'s search markedly
+    // slower -- measured 2.4 s/trial at this length under
+    // SSTVAE_SANITIZE against ~0.05 s/trial without it, roughly 50x, so
+    // 200 trials (the unsanitized run, ~10 s) becomes several minutes
+    // and blows past both this file's own watchdog (180 s) and the
+    // ctest TIMEOUT (240 s). The statistical claim -- 0 false locks in
+    // 200 trials -- is still checked at full strength and full speed by
+    // every unsanitized build (every local run, CI's `native` job, and
+    // ThreadSanitizer, which doesn't set SSTVAE_SANITIZE); a sanitizer
+    // run exists to catch a memory-safety bug in the same code path, not
+    // to re-derive that statistic, and a fifth of the trials is still
+    // plenty of distinct seeds for that. 20 trials measures at ~48 s
+    // here -- comfortable margin under both deadlines, not "just enough".
+#ifdef SSTVAE_SANITIZE_BUILD
+    constexpr int kTrials = 20;
+#else
     constexpr int kTrials = 200;
+#endif
     int false_locks = 0;
     for (int trial = 0; trial < kTrials; ++trial) {
         Rng rng(10000 + static_cast<std::uint64_t>(trial));

--- a/native/tests/test_beacon.cpp
+++ b/native/tests/test_beacon.cpp
@@ -1,0 +1,133 @@
+// beacon::decode's multi-repetition combining fallback -- ported from
+// sstvae/modem/beacon.py, and tested here rather than only via golden
+// vectors because it is genuinely new logic (a search, not a
+// mechanical translation), with the two properties that matter most
+// having no oracle in a golden corpus:
+//
+// - it can recover a superframe when no single repetition's own
+//   Golay+CRC decode survives the noise, by combining evidence across
+//   every repetition instead of trying them one at a time;
+// - it must never confidently return a fake BeaconResult on long pure
+//   noise, which the first version of this search did on every single
+//   trial (see beacon.cpp's file-level comment on the combining
+//   fallback for why, and how the final verification step avoids it).
+
+#include "beacon/beacon.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "config.hpp"
+
+namespace check = sstvae::check;
+using namespace sstvae;
+
+namespace {
+
+// Deterministic pseudo-random values, the same construction
+// test_modem_roundtrip.cpp uses: splitmix64 plus a sum of uniforms for
+// an approximately-Gaussian shape. Not numpy's generator and not
+// trying to be -- nothing here is compared against Python, only
+// against this file's own expectations.
+class Rng {
+public:
+    explicit Rng(std::uint64_t seed) : state_(seed) {}
+
+    double normal() {
+        double acc = 0.0;
+        for (int i = 0; i < 4; ++i) {
+            state_ += 0x9E3779B97F4A7C15ULL;
+            std::uint64_t z = state_;
+            z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+            z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+            z = z ^ (z >> 31);
+            acc += static_cast<double>(z >> 11) / 9007199254740992.0 - 0.5;
+        }
+        return acc * 1.7;  // ~unit variance, per the same construction elsewhere
+    }
+
+private:
+    std::uint64_t state_;
+};
+
+void test_combining_decodes_where_no_single_repetition_can() {
+    // Mode C's own frame count -- see sstvae/config.py's MODES["C"] --
+    // duplicated as a literal rather than pulled in via the modem
+    // headers, which this file otherwise has no reason to depend on.
+    constexpr int kModeCFrames = 660;
+    const std::vector<double> chips = beacon::chip_stream(0, kModeCFrames, "TEST");
+
+    Rng rng(6);
+    std::vector<double> noisy(chips.size());
+    for (std::size_t i = 0; i < chips.size(); ++i) noisy[i] = chips[i] + rng.normal();
+
+    // Confirm the noise is actually heavy enough that individual
+    // repetitions mostly fail on their own -- otherwise this would not
+    // be exercising combining at all, just re-testing decode_single_
+    // repetition under a new name.
+    const std::vector<std::int64_t> candidates =
+        beacon::find_sync(noisy, /*threshold=*/0.3, /*max_candidates=*/30);
+    int n_solo_ok = 0;
+    for (std::int64_t off : candidates) {
+        const std::size_t end = static_cast<std::size_t>(off) + beacon::SYNC_LEN + beacon::CODED_LEN;
+        if (end > noisy.size()) continue;
+        std::span<const double> coded(noisy.data() + off + beacon::SYNC_LEN, beacon::CODED_LEN);
+        if (beacon::decode_single_repetition(off, coded)) ++n_solo_ok;
+    }
+    check::is_true(n_solo_ok <= 2,
+                   "beacon/combining: noise scale should leave most individual "
+                   "repetitions undecodable on their own (got " +
+                       std::to_string(n_solo_ok) + " solo successes)");
+
+    const auto result = beacon::decode(noisy);
+    check::is_true(result.has_value(),
+                   "beacon/combining: should recover the superframe from combined "
+                   "evidence even though no single repetition can decode it alone");
+    if (result) {
+        check::equal(result->frame_index,
+                     static_cast<int>(result->chip_offset / config::CHIPS_PER_FRAME),
+                     "beacon/combining: frame_index matches chip_offset (chip_stream "
+                     "starts at frame 0)");
+        check::is_true(result->callsign == "TEST",
+                       "beacon/combining: recovered callsign is 'TEST', got '" +
+                           result->callsign + "'");
+    }
+}
+
+void test_no_false_lock_on_long_pure_noise() {
+    // Long enough to hold the same number of repetitions as the
+    // combining test above -- a short buffer never reaches the
+    // combining fallback at all (repetition_grid needs >= 3 positions),
+    // so it would not exercise the bug this guards against.
+    constexpr int kModeCFrames = 660;
+    const std::size_t n_chips = static_cast<std::size_t>(kModeCFrames) * config::CHIPS_PER_FRAME;
+
+    constexpr int kTrials = 200;
+    int false_locks = 0;
+    for (int trial = 0; trial < kTrials; ++trial) {
+        Rng rng(10000 + static_cast<std::uint64_t>(trial));
+        std::vector<double> junk(n_chips);
+        for (double& v : junk) v = rng.normal();
+        if (beacon::decode(junk)) ++false_locks;
+    }
+    check::equal(false_locks, 0,
+                 "beacon/combining: no false locks on " + std::to_string(kTrials) +
+                     " trials of long pure noise");
+}
+
+}  // namespace
+
+int main() {
+    check::report_crashes_instead_of_prompting();
+    check::Watchdog watchdog(180.0, "beacon");
+
+    check::current_step.store("combining_decodes_where_no_single_repetition_can");
+    test_combining_decodes_where_no_single_repetition_can();
+    check::current_step.store("no_false_lock_on_long_pure_noise");
+    test_no_false_lock_on_long_pure_noise();
+
+    return check::report("beacon");
+}

--- a/native/tests/test_golden.cpp
+++ b/native/tests/test_golden.cpp
@@ -200,8 +200,13 @@ void test_dsp() {
     check::close(dsp::hilbert(x_odd), load_c16(g("dsp/hilbert_odd")), 1e-11,
                  "dsp/hilbert at odd length (the other mask branch)");
 
+    // FFT-based here (pocketfft) against a direct-sum-equivalent Python
+    // reference (scipy.signal.fftconvolve, itself within 1e-15 of the
+    // np.convolve values the golden vector was generated from) -- same
+    // "FFT sums 4096 terms" cross-implementation spread as dsp/hilbert
+    // just above, hence the same bound.
     check::close(dsp::sync_lowpass(dsp::to_baseband(x)),
-                 load_c16(g("dsp/sync_lowpass")), 1e-13, "dsp/sync_lowpass");
+                 load_c16(g("dsp/sync_lowpass")), 1e-11, "dsp/sync_lowpass");
 
     const std::vector<double> papr = load_f8(g("dsp/papr_db"));
     check::close(std::vector<double>{dsp::papr_db(x)}, papr, 1e-11, "dsp/papr_db");

--- a/native/tests/test_rx_engine.cpp
+++ b/native/tests/test_rx_engine.cpp
@@ -78,6 +78,16 @@ std::vector<double> transmission(const std::string& callsign, std::uint64_t seed
 // something the loop invented.
 constexpr std::uint8_t kDecoderMark = 0x5A;
 
+// No preamble/header at all -- forces decode_loop past find_new_
+// reception (which needs one) and into the blind path on every poll,
+// mirroring `_frames_only` in tests/test_listen_state_machine.py.
+std::vector<double> frames_only(const std::string& callsign, std::uint64_t seed) {
+    const std::vector<double> full = transmission(callsign, seed);
+    const auto skip = static_cast<std::size_t>(
+        config::LEADIN_SAMPLES + config::PREAMBLE_SAMPLES + config::HEADER_SAMPLES);
+    return std::vector<double>(full.begin() + static_cast<std::ptrdiff_t>(skip), full.end());
+}
+
 // Everything a running loop and the test share.
 struct Harness {
     rx::RingBuffer ring;
@@ -339,6 +349,72 @@ void test_low_cpu_loop_receives() {
                    "rx/lowcpu: the decoder's picture");
 }
 
+void test_fresh_session_does_not_inherit_blind_evidence_from_a_prior_one() {
+    // The app's "start receiving" button and ReceivePanel::resume_after_
+    // transmit both work by discarding the whole RingBuffer and calling
+    // decode_loop again from scratch (see rx_panel.cpp's start() /
+    // resume_after_transmit(), and RingBuffer::clear()'s comment, which
+    // records that clear() is *not* how that path works), rather than
+    // clearing state in place. blind_acc is a plain local inside
+    // decode_loop, so a brand-new call gets a clean one for free -- but
+    // that is a property of scoping, not something pinned against a
+    // future change that keeps decode_loop (and its locals) running
+    // across a session boundary instead of restarting it, which is
+    // exactly the scenario an indeterminate gap in real captured audio
+    // (silence while transmitting, or whatever a fresh capture stream
+    // first hands back) has no way to signal to a *stale* accumulator.
+    //
+    // Session 1 gets a real, complete mode-A transmission (no preamble/
+    // header, to force the blind path) and is left to lock and finish,
+    // so it isn't just idling. Session 2 is a brand-new RingBuffer +
+    // SharedState + decode_loop call, exactly as start()/resume_after_
+    // transmit() produce, fed nothing but noise: it must never report a
+    // reception. If blind_acc's folded evidence ever leaked across that
+    // boundary, session 2 would begin already most of the way to
+    // session 1's lock rather than from nothing.
+    Harness h1(40.0);
+    h1.config.once = true;
+    write_all(h1.ring, frames_only("KC2G", 41));
+
+    rx::decode_loop(h1.ring, h1.decoder(), h1.state, h1.config, h1.stop, h1.sink());
+
+    check::equal(h1.received.size(), std::size_t{1},
+                 "rx/session-reset: session 1 should lock on and finish a real "
+                 "transmission -- otherwise this isn't exercising real "
+                 "blind-accumulator evidence");
+
+    // A brand-new session: fresh RingBuffer, fresh SharedState, fresh
+    // decode_loop call. Fed nothing but noise -- a fixed seed, so this
+    // is deterministic rather than a rare-false-lock flake.
+    Harness h2(10.0);
+    std::vector<double> noise(static_cast<std::size_t>(8.0 * config::FS));
+    std::uint64_t s = 4242;
+    for (double& v : noise) {
+        s += 0x9E3779B97F4A7C15ULL;
+        std::uint64_t z = s;
+        z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+        z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+        z = z ^ (z >> 31);
+        v = 0.2 * (static_cast<double>(z >> 11) / 9007199254740992.0 - 0.5);
+    }
+    write_all(h2.ring, noise);
+
+    std::thread loop([&] {
+        rx::decode_loop(h2.ring, h2.decoder(), h2.state, h2.config, h2.stop, h2.sink());
+    });
+    std::thread watcher([&] { h2.poll_watcher(); });
+
+    h2.until([&] { return h2.polls() >= 4; }, "rx/session-reset: four polls on session 2");
+    h2.stop.set();
+    loop.join();
+    watcher.join();
+
+    check::equal(h2.count(), std::size_t{0},
+                 "rx/session-reset: a fresh session fed only noise must not report "
+                 "a reception -- blind_acc leaked evidence across a session "
+                 "boundary");
+}
+
 void test_stop_interrupts_a_wait_in_progress() {
     // Shutting the receiver down must not cost a poll interval. If the
     // condition variable were replaced by a polled flag this would sit
@@ -368,6 +444,7 @@ int main() {
         test_low_cpu_loop_receives();
         test_a_finished_reception_is_not_rediscovered();
         test_two_transmissions_are_both_received();
+        test_fresh_session_does_not_inherit_blind_evidence_from_a_prior_one();
     } catch (const std::exception& e) {
         std::fprintf(stderr, "FATAL: %s\n", e.what());
         return 1;

--- a/sstvae/modem/beacon.py
+++ b/sstvae/modem/beacon.py
@@ -217,8 +217,11 @@ def find_sync(chips: np.ndarray, threshold: float = 0.6, max_candidates: int = 8
 def decode(chips: np.ndarray, threshold: float = 0.6) -> BeaconResult | None:
     """Find and decode one beacon superframe anywhere in `chips` (soft
     values, any length >= SUPERFRAME_LEN). Tries the best-correlated sync
-    candidates in order and returns the first one whose CRC checks out."""
-    for off in find_sync(chips, threshold=threshold):
+    candidates in order and returns the first one whose CRC checks out;
+    falls back to combining evidence across every repetition in `chips`
+    (see `_decode_combined`) if no single one decodes alone."""
+    candidates = find_sync(chips, threshold=threshold)
+    for off in candidates:
         end = off + SYNC_LEN + CODED_LEN
         if end > len(chips):
             continue
@@ -226,4 +229,400 @@ def decode(chips: np.ndarray, threshold: float = 0.6) -> BeaconResult | None:
         if result is not None:
             frame_index, callsign = result
             return BeaconResult(chip_offset=off, frame_index=frame_index, callsign=callsign)
+    for off in candidates:
+        result = _decode_combined(chips, off)
+        if result is not None:
+            return result
+    for off in _folded_sync_phases(chips):
+        result = _decode_combined(chips, off)
+        if result is not None:
+            return result
     return None
+
+
+# --- multi-repetition combining ----------------------------------------------
+#
+# The superframe repeats continuously through the whole transmission
+# (~5.2 s apart -- up to ~18 times in a mode C transmission), but
+# `decode()` above only ever looks at ONE of them: whichever sync
+# candidate's own single-shot Golay+CRC decode happens to succeed. That
+# throws away the other repetitions' evidence entirely, even though two
+# things are guaranteed about them within one transmission:
+#
+# - The callsign is the same in every repetition.
+# - The frame counter is not the same, but it is an *exact*, fully
+#   predictable function of chip position: `chip_stream()` lays
+#   superframes back-to-back with no gaps, and every decoder-side chip
+#   array indexes frames uniformly (`beacon_soft[f * CHIPS_PER_FRAME +
+#   ...]`), so knowing any one repetition's true counter value fixes
+#   every other repetition's counter exactly -- no estimation needed,
+#   just `(chip_delta // CHIPS_PER_FRAME)` arithmetic.
+#
+# `_decode_combined` is a limited (not fully maximum-likelihood) way to
+# use that, in three tiers of decreasing simplicity:
+#
+# - Chunks that fall entirely inside the callsign field are identical,
+#   chip for chip, in every repetition, so their *signs* (see below) can
+#   simply be summed across repetitions before Golay-decoding once --
+#   genuine coherent combining, and the cheap case.
+# - The chunk carrying the counter's own low bit varies by design (a
+#   different value is genuinely correct at every repetition), so it
+#   can't be summed the same way -- but the exact value at every
+#   repetition is a known function of one hypothesis for the anchor's
+#   own value, so `_search_counter_chunk` evaluates every hypothesis by
+#   regenerating each repetition's expected codeword and summing its
+#   correlation, combining evidence across repetitions *before*
+#   choosing rather than voting on independent per-repetition guesses.
+#   Voting was tried first and measured useless here: 18 repetitions,
+#   18 different guesses, no repeat at all, because at the SNRs this is
+#   meant to help with individual repetitions rarely decode correctly
+#   on their own.
+# - The chunk mixing leftover callsign bits with the per-repetition CRC
+#   has the same voting problem (CRC depends on the whole payload, not
+#   just a shift), but no simple arithmetic predicts it -- so
+#   `_search_crc_mixed_chunk` brute-forces its free bits and asks
+#   `_payload_bits` what the CRC-inclusive chunk *should* look like for
+#   each hypothesis at each repetition's own counter, same combine-
+#   before-choose principle applied through the actual encoder.
+#
+# Summing/correlating by *sign*, not raw chip value, throughout: under
+# fading, the per-frame channel estimate the equalizer divides by can
+# itself sit near a fade null, amplifying that frame's noise into an
+# enormous, essentially random magnitude rather than a merely noisy
+# one. A single such repetition then dominates a raw sum or a raw
+# dot-product and wrecks it (measured on one case: raw summing
+# recovered 6/12 bits -- chance -- where every individual repetition
+# also decoded at only ~7/12; summing signs instead recovered 12/12).
+# Equal-gain (sign) combining gives up some of coherent combining's
+# theoretical SNR gain in exchange for not being destroyed by exactly
+# the outliers fading produces routinely.
+#
+# A final correlation check against every repetition's full superframe
+# (sync word included) guards against returning a wrong assembly as if
+# it were a real decode.
+
+
+def _folded_sync_phases(chips: np.ndarray, max_candidates: int = 4) -> list[int]:
+    """Candidate anchor phases (mod SUPERFRAME_LEN) for the combining
+    fallback, found by folding the sync-word correlation across every
+    period instead of trusting any single repetition's own (noisy,
+    13-chip) peak -- the same "fold across periods" idea
+    BlindAccumulator uses for the pilot, applied here to the Barker-13
+    word. A single repetition's find_sync() candidate can be the wrong
+    phase under fading (any one 13-chip correlation has its own noise-
+    driven false peaks, and the strongest one isn't always the true
+    one); summing the same signed correlation across every repetition
+    in the buffer before picking a phase is far more robust, since a
+    real periodic sync word reinforces at one phase while noise at the
+    wrong phases mostly cancels."""
+    if len(chips) < SYNC_LEN + SUPERFRAME_LEN:
+        return []
+    corr = np.correlate(chips, SYNC, mode="valid")
+    folded = np.array([corr[p::SUPERFRAME_LEN].sum() for p in range(SUPERFRAME_LEN)])
+    order = np.argsort(-folded)[:max_candidates]
+    return [int(p) for p in order]
+
+
+def _chunk_bit_range(chunk_idx: int) -> tuple[int, int]:
+    return chunk_idx * 12, (chunk_idx + 1) * 12
+
+
+def _decode_chunk_bits(chip_slice: np.ndarray) -> np.ndarray:
+    return _int_to_bits(golay.decode_soft(chip_slice), 12)
+
+
+def _repetition_grid(n_chips: int, anchor_off: int) -> list[int]:
+    """Every chip offset spaced an exact multiple of SUPERFRAME_LEN from
+    `anchor_off` that has a full superframe's worth of chips available
+    -- the repetition positions are *known* exactly once the anchor is
+    fixed, so this doesn't depend on find_sync() having independently
+    flagged each one (weak repetitions it missed are included anyway).
+    Checks each direction's fit explicitly rather than assuming the
+    anchor's own position (k=0) fits -- it doesn't always, e.g. an
+    anchor near the very end of a short buffer."""
+    def fits(pos: int) -> bool:
+        return 0 <= pos and pos + SYNC_LEN + CODED_LEN <= n_chips
+
+    grid = [anchor_off] if fits(anchor_off) else []
+    k = 1
+    while fits(anchor_off + k * SUPERFRAME_LEN):
+        grid.append(anchor_off + k * SUPERFRAME_LEN)
+        k += 1
+    k = -1
+    while fits(anchor_off + k * SUPERFRAME_LEN):
+        grid.append(anchor_off + k * SUPERFRAME_LEN)
+        k -= 1
+    return sorted(grid)
+
+
+def _search_counter_chunk(
+    chips: np.ndarray, grid: list[int], anchor_off: int, chunk_idx: int, n_counter_bits: int
+) -> tuple[int, int] | None:
+    """Joint search over the chunk carrying the counter's low bit 0 --
+    the one chunk voting can't help, since a *different* 12-bit value
+    is genuinely correct at every repetition (counter, not callsign),
+    so independently hard-decoding each repetition and voting on the
+    (delta-normalized) results only works if a real plurality of
+    individual repetitions already decode correctly on their own. Under
+    fading, at exactly the SNRs where combining would matter most, they
+    routinely don't (measured: 18 repetitions, 18 different normalized
+    guesses, no repeat at all).
+
+    Instead this evaluates *every* possible value of this chunk's
+    remaining unknown bits (assumed to be `12 - n_counter_bits` extra
+    callsign bits after the counter, matching chunk 0's layout) at the
+    anchor, regenerates what each repetition's *own* counter-shifted
+    12-bit value and Golay codeword would be for that hypothesis (the
+    counter delta between repetitions is exact, see the module
+    docstring), and scores each hypothesis by summing its predicted
+    codeword's sign-correlation against every repetition's actual
+    chips -- combining evidence across repetitions *before* choosing,
+    the same principle as the coherent chunk combining above, just
+    applied to a field that varies (predictably) instead of one that
+    doesn't. Cheap: (2**n_counter_bits) * n_extra_hyp * n_grid * 24
+    multiply-adds, done once in the fallback path only.
+    """
+    clo, chi = chunk_idx * 24, (chunk_idx + 1) * 24
+    anchor_frame = anchor_off // CHIPS_PER_FRAME
+    received = np.array(
+        [np.sign(chips[pos + SYNC_LEN + clo : pos + SYNC_LEN + chi]) for pos in grid]
+    )  # (n_grid, 24)
+    frame_deltas = np.array([pos // CHIPS_PER_FRAME - anchor_frame for pos in grid])
+
+    n_extra = 12 - n_counter_bits
+    counter_mask = (1 << n_counter_bits) - 1
+    counters = np.arange(1 << n_counter_bits)
+    best_score, best = -np.inf, None
+    for extra in range(1 << n_extra):
+        counter_vals = (counters[:, None] + frame_deltas[None, :]) & counter_mask
+        data12 = (counter_vals << n_extra) | extra  # (2**n_counter_bits, n_grid)
+        signs = golay._SIGNS[data12]  # (2**n_counter_bits, n_grid, 24)
+        scores = np.einsum("hgc,gc->h", signs, received)
+        h = int(np.argmax(scores))
+        if scores[h] > best_score:
+            best_score = float(scores[h])
+            best = (int(counters[h]), extra)
+    return best
+
+
+def _search_crc_mixed_chunk(
+    chips: np.ndarray,
+    grid: list[int],
+    anchor_off: int,
+    chunk_idx: int,
+    frame_index: int,
+    known_callsign_bits: np.ndarray,
+) -> np.ndarray | None:
+    """Joint search for a chunk mixing still-unknown callsign bits with
+    the per-repetition CRC (chunk 4 in the current layout) -- unlike
+    the counter chunk, the part that varies per repetition here isn't a
+    simple shift, since CRC depends on the *whole* payload. So this
+    can't reuse _search_counter_chunk's trick directly: instead it
+    brute-forces only this chunk's free (non-CRC) bits, and for each
+    hypothesis derives the exact expected per-repetition chunk content
+    from `_payload_bits` itself (which already knows how to fold in a
+    candidate callsign and a repetition's own counter and compute the
+    CRC that goes with them) rather than voting on independent
+    per-repetition guesses -- which, like the counter, routinely don't
+    agree at the SNRs this is meant to help with. Returns the chunk's
+    free-bit fragment (aligned to its position within the chunk), or
+    None if the chunk isn't shaped as assumed (free callsign bits
+    followed by CRC bits, no counter overlap)."""
+    blo, bhi = _chunk_bit_range(chunk_idx)
+    callsign_lo = BEACON_COUNTER_BITS
+    callsign_hi = callsign_lo + BEACON_CALLSIGN_BITS
+    free_lo, free_hi = max(blo, callsign_lo), min(bhi, callsign_hi)
+    n_free = free_hi - free_lo
+    if free_lo != blo or n_free + (bhi - callsign_hi) != 12:
+        return None  # not "free callsign bits then CRC bits" -- bail rather than guess wrong
+
+    anchor_frame = anchor_off // CHIPS_PER_FRAME
+    clo, chi = chunk_idx * 24, (chunk_idx + 1) * 24
+    received = np.array(
+        [np.sign(chips[pos + SYNC_LEN + clo : pos + SYNC_LEN + chi]) for pos in grid]
+    )
+    frame_deltas = [pos // CHIPS_PER_FRAME - anchor_frame for pos in grid]
+
+    best_score, best_frag = -np.inf, None
+    for free_val in range(1 << n_free):
+        frag_bits = _int_to_bits(free_val, n_free)
+        trial = known_callsign_bits.copy()
+        trial[free_lo - callsign_lo : free_hi - callsign_lo] = frag_bits
+        codes = [
+            _bits_to_int(trial[i : i + BEACON_CALLSIGN_CHAR_BITS])
+            for i in range(0, BEACON_CALLSIGN_BITS, BEACON_CALLSIGN_CHAR_BITS)
+        ]
+        callsign = codes_to_callsign(np.array(codes))
+        score = 0.0
+        for k, pos in enumerate(grid):
+            fi = frame_index + frame_deltas[k]
+            if not (0 <= fi <= MAX_FRAME_COUNTER):
+                continue
+            payload = _payload_bits(fi, callsign)
+            chunk_bits = payload[blo:bhi]
+            if len(chunk_bits) < 12:  # padding-only tail, zeros
+                chunk_bits = np.concatenate(
+                    [chunk_bits, np.zeros(12 - len(chunk_bits), dtype=np.int64)]
+                )
+            data12 = _bits_to_int(chunk_bits)
+            score += float(golay._SIGNS[data12] @ received[k])
+        if score > best_score:
+            best_score = score
+            best_frag = frag_bits
+    return best_frag
+
+
+def _decode_combined(chips: np.ndarray, anchor_off: int) -> BeaconResult | None:
+    n = len(chips)
+    grid = _repetition_grid(n, anchor_off)
+    if len(grid) < 3:  # too few repetitions for voting to mean anything
+        return None
+
+    counter_lo = 0
+    callsign_lo = BEACON_COUNTER_BITS
+    callsign_hi = BEACON_COUNTER_BITS + BEACON_CALLSIGN_BITS
+
+    invariant_chunks = [
+        c for c in range(N_CHUNKS)
+        if callsign_lo <= _chunk_bit_range(c)[0] and _chunk_bit_range(c)[1] <= callsign_hi
+    ]
+    variant_chunks = [
+        c for c in range(N_CHUNKS)
+        if c not in invariant_chunks and _chunk_bit_range(c)[0] < callsign_hi
+    ]
+
+    callsign_bits = np.full(BEACON_CALLSIGN_BITS, -1, dtype=np.int64)
+
+    # Coherent case: sum this chunk's coded chips across every
+    # repetition (identical by construction), decode once. Sums the
+    # *sign* of each repetition's chips, not the raw values: under
+    # fading, the per-frame channel estimate the equalizer divides by
+    # can itself be near a fade null, which amplifies that frame's
+    # noise into an enormous, essentially random magnitude rather than
+    # a merely noisy one -- a single such repetition then dominates a
+    # raw sum and wrecks it (measured: raw summing recovered 6/12 bits,
+    # i.e. chance, on a case where every individual repetition also
+    # decoded at only ~7/12; summing signs instead recovered 12/12).
+    # Equal-gain (sign) combining gives up some of coherent combining's
+    # theoretical SNR gain in exchange for not being destroyed by
+    # exactly the outliers fading produces routinely.
+    for c in invariant_chunks:
+        clo, chi = c * 24, (c + 1) * 24
+        summed = np.zeros(24)
+        for pos in grid:
+            summed += np.sign(chips[pos + SYNC_LEN + clo : pos + SYNC_LEN + chi])
+        bits = _decode_chunk_bits(summed)
+        blo, bhi = _chunk_bit_range(c)
+        callsign_bits[blo - callsign_lo : bhi - callsign_lo] = bits
+
+    # The chunk carrying the counter's own low bit 0 can't be voted on
+    # like the others below -- a genuinely *different* 12-bit value is
+    # correct at every repetition, not the same one imperfectly
+    # received, so joint-search it instead (see _search_counter_chunk).
+    counter_chunk = next(c for c in variant_chunks if _chunk_bit_range(c)[0] <= counter_lo)
+    result = _search_counter_chunk(chips, grid, anchor_off, counter_chunk, BEACON_COUNTER_BITS)
+    if result is None:
+        return None
+    frame_index, extra_bits_value = result
+    if not (0 <= frame_index <= MAX_FRAME_COUNTER):
+        return None
+    n_extra = 12 - BEACON_COUNTER_BITS
+    blo, bhi = _chunk_bit_range(counter_chunk)
+    lo, hi = max(blo, callsign_lo), min(bhi, callsign_hi)
+    if lo < hi:  # the counter chunk's tail bits are callsign, not counter
+        callsign_bits[lo - callsign_lo : hi - callsign_lo] = _int_to_bits(
+            extra_bits_value, n_extra
+        )[lo - (bhi - n_extra) :]
+
+    # Remaining variant chunks (here: the one mixing still-unknown
+    # callsign bits with the per-repetition CRC) can't be voted on
+    # either, for the same reason as the counter chunk above: the CRC
+    # bits riding along with the callsign differ every repetition
+    # (CRC depends on that repetition's own counter), so a "vote on
+    # independent per-repetition decodes" measured zero consensus at
+    # all -- 18 repetitions, 18 different guesses. Joint-search it too.
+    other_variant_chunks = [c for c in variant_chunks if c != counter_chunk]
+    for c in other_variant_chunks:
+        blo, bhi = _chunk_bit_range(c)
+        frag = _search_crc_mixed_chunk(chips, grid, anchor_off, c, frame_index, callsign_bits)
+        if frag is None:
+            return None
+        lo, hi = max(blo, callsign_lo), min(bhi, callsign_hi)
+        callsign_bits[lo - callsign_lo : hi - callsign_lo] = frag
+
+    if np.any(callsign_bits < 0):
+        return None  # a fragment nobody resolved (shouldn't happen given the layout)
+
+    codes = [
+        _bits_to_int(callsign_bits[i : i + BEACON_CALLSIGN_CHAR_BITS])
+        for i in range(0, BEACON_CALLSIGN_BITS, BEACON_CALLSIGN_CHAR_BITS)
+    ]
+    callsign = codes_to_callsign(np.array(codes))
+
+    # This assembly came from combined evidence, not a single verified
+    # CRC, and needs a real check before it's trusted -- not a
+    # correlation against the whole superframe, which is the wrong
+    # thing to check against.
+    #
+    # Chunks 0-4 were *used* to build (frame_index, callsign): both
+    # searches above pick whichever hypothesis best matches the noisy
+    # chips there, so a wrong hypothesis can still score deceptively
+    # well on them -- it's not really testing anything independent, and
+    # correlating against it measures how good a curve-fit the search
+    # found, not whether the fit is *right*. Diluted into a whole-
+    # superframe correlation this was silently catastrophic: measured on
+    # pure noise long enough to hold this many repetitions, 40 of 40
+    # trials produced a confident, fully-assembled, completely fake
+    # BeaconResult before this fix, at what looked like a comfortable
+    # multiple of a "3-sigma" bar -- exhaustively searching thousands of
+    # hypotheses and keeping the best one produces exactly the inflated,
+    # not-actually-3-sigma correlations extreme-value statistics predict.
+    # Restricting the correlation to just the chunks nothing was
+    # searched against (the two pure CRC/padding chunks) fixed the false
+    # locks, but a correlation *threshold* over so few chips (48, next
+    # to the whole superframe's 181) turned out to cost most of the
+    # measured gain: fading routinely knocks a real repetition's own
+    # agreement down far enough that no threshold cleanly separates a
+    # correct combine from a wrong one on 48 chips alone.
+    #
+    # A bit-exact check does, and needs no threshold to calibrate: Golay
+    # -decode the verify chunks at each repetition (a plain, unsearched
+    # decode, no hypothesis-fitting involved) and compare against what
+    # `_payload_bits` says they should be for that repetition's own
+    # counter -- if even *one* repetition matches exactly, accept. A
+    # wrong hypothesis's chance of an exact coincidental match this way
+    # is about (1/4096) per verify chunk (a Golay decode of noise is
+    # effectively a uniform draw over its 4096 codewords), roughly
+    # 6e-8 for both chunks in this layout at any one repetition -- comparable
+    # to or better than the false-accept rate the original single-
+    # superframe CRC check itself already relies on (1/65536 per
+    # attempt), and unlike a correlation threshold it doesn't get
+    # weaker just because fading make the chips noisier.
+    callsign_hi = BEACON_COUNTER_BITS + BEACON_CALLSIGN_BITS
+    verify_chunks = [c for c in range(N_CHUNKS) if _chunk_bit_range(c)[0] >= callsign_hi]
+    if not verify_chunks:
+        return None  # layout has no untouched chunk to verify against -- refuse rather than guess
+    verified = False
+    for pos in grid:
+        fi = frame_index + (pos // CHIPS_PER_FRAME - anchor_off // CHIPS_PER_FRAME)
+        if not (0 <= fi <= MAX_FRAME_COUNTER):
+            continue
+        payload = _payload_bits(fi, callsign)
+        if all(
+            np.array_equal(
+                _decode_chunk_bits(chips[pos + SYNC_LEN + c * 24 : pos + SYNC_LEN + (c + 1) * 24]),
+                payload[_chunk_bit_range(c)[0] : _chunk_bit_range(c)[1]]
+                if _chunk_bit_range(c)[1] <= len(payload)
+                else np.concatenate([
+                    payload[_chunk_bit_range(c)[0] :],
+                    np.zeros(_chunk_bit_range(c)[1] - len(payload), dtype=np.int64),
+                ]),
+            )
+            for c in verify_chunks
+        ):
+            verified = True
+            break
+    if not verified:
+        return None
+
+    return BeaconResult(chip_offset=anchor_off, frame_index=frame_index, callsign=callsign)

--- a/sstvae/modem/dsp.py
+++ b/sstvae/modem/dsp.py
@@ -44,6 +44,31 @@ def to_baseband(x: np.ndarray) -> np.ndarray:
     return x.astype(np.float64) * _HET_TABLE[(_HET_STEP * n) % _HET_PERIOD]
 
 
+def to_baseband_at(x: np.ndarray, start_sample: int) -> np.ndarray:
+    """`to_baseband(x)`, but as if `x` were a slice of a longer signal
+    starting at absolute sample index `start_sample` rather than at 0 --
+    i.e. exactly `to_baseband(full)[start_sample : start_sample + len(x)]`
+    for whatever longer `full` array `x` actually came from.
+
+    `to_baseband` always treats its own input's first sample as the
+    heterodyne's local n=0, which only matches the true carrier phase
+    when `start_sample` happens to be 0. A caller that baseband-converts
+    one long recording as a series of independent chunks (rather than
+    the whole thing in one call) needs this instead, or consecutive
+    chunks disagree about the carrier phase by an amount that depends on
+    where the chunk boundary fell -- invisible to code that only ever
+    looks within one chunk, and it matters only to code that carries
+    state *across* chunks the way sync.BlindAccumulator does.
+
+    Cheap because the heterodyne is periodic in 16 samples (see
+    to_baseband's own docstring): the correction needed is one constant
+    phasor for the whole chunk (`_HET_TABLE` composes multiplicatively
+    under addition of its index), not something that varies through it.
+    """
+    correction = _HET_TABLE[(_HET_STEP * start_sample) % _HET_PERIOD]
+    return correction * to_baseband(x)
+
+
 def sync_lowpass(z: np.ndarray) -> np.ndarray:
     """Selective lowpass used only for preamble detection, where FIR
     smearing is harmless and out-of-band noise would degrade the

--- a/sstvae/modem/dsp.py
+++ b/sstvae/modem/dsp.py
@@ -47,9 +47,18 @@ def to_baseband(x: np.ndarray) -> np.ndarray:
 def sync_lowpass(z: np.ndarray) -> np.ndarray:
     """Selective lowpass used only for preamble detection, where FIR
     smearing is harmless and out-of-band noise would degrade the
-    autocorrelation metric."""
+    autocorrelation metric.
+
+    FFT-based rather than a direct sum: `acquire()` runs this over the
+    whole ring-buffer snapshot (up to the full ~130 s capacity) on every
+    poll, not just a bounded search window, and the direct convolution
+    was measured as the single largest item in a live decode-loop
+    profile -- a per-poll cost that scaled with total buffer duration
+    rather than with anything acquisition actually needs. `convolve_same`
+    stays a direct sum for its other caller (`tx_condition`'s clip
+    filter), which runs once per transmit, not every poll."""
     taps = signal.firwin(129, 850.0, fs=FS)
-    return np.convolve(z, taps, mode="same")
+    return signal.fftconvolve(z, taps, mode="same")
 
 
 def wrap_cycles(cycles: np.ndarray) -> np.ndarray:

--- a/sstvae/modem/modem.py
+++ b/sstvae/modem/modem.py
@@ -46,7 +46,7 @@ from ..config import (
 from . import beacon, framing, ofdm
 from .beacon import BeaconResult
 from .dsp import to_baseband, freq_correct, tx_condition
-from .sync import acquire, acquire_blind, SyncError
+from .sync import acquire, acquire_blind, BlindAcquisition, SyncError
 
 __all__ = ["Modem", "DemodResult", "BlindDemodResult", "SyncError"]
 
@@ -322,7 +322,8 @@ class Modem:
         )
 
     def demodulate_blind(
-        self, x: np.ndarray, search_s: tuple[float, float] | None = None
+        self, x: np.ndarray, search_s: tuple[float, float] | None = None,
+        acquisition: BlindAcquisition | None = None,
     ) -> BlindDemodResult:
         """Recover frame timing purely from the pilot's own periodicity
         (sync.acquire_blind) — no preamble or header needed, so this
@@ -335,12 +336,23 @@ class Modem:
 
         No sample-clock drift tracking (that needs a preamble-phase
         reference); fine for the bounded windows this is meant for.
+
+        `acquisition`, if given, skips the internal acquire_blind call
+        and demodulates at that position instead -- for a caller (e.g.
+        rx/engine.py) that already found it via a persistent
+        sync.BlindAccumulator rather than a fresh bounded-window search.
+        The rest of this method is unaffected: it still demodulates
+        every frame the *whole* of `x` can hold, using `acquisition`
+        only to place frame 0.
         """
         z = to_baseband(np.asarray(x, dtype=np.float64))
-        search = None
-        if search_s is not None:
-            search = (int(search_s[0] * FS), int(search_s[1] * FS))
-        ba = acquire_blind(z, search=search)
+        if acquisition is not None:
+            ba = acquisition
+        else:
+            search = None
+            if search_s is not None:
+                search = (int(search_s[0] * FS), int(search_s[1] * FS))
+            ba = acquire_blind(z, search=search)
         z = freq_correct(z, ba.freq_offset)
 
         p0 = ba.frame_start - NCP  # CP-start of local frame 0

--- a/sstvae/modem/modem.py
+++ b/sstvae/modem/modem.py
@@ -372,7 +372,30 @@ class Modem:
             h_pilot[f] = raw[f, 0] / self.pilot
             p += FRAME_SAMPLES
 
-        med_h = np.median(np.abs(h_pilot))
+        # Blind demod always covers every frame the *whole current
+        # buffer* can hold, since the transmission's true length is
+        # unknown until the beacon resolves it -- unlike the preamble
+        # path (demodulate() above), which restricts this same
+        # computation to the header's known real frame count. Most of
+        # that range is often not the real transmission at all (silence
+        # or noise before it starts, or accumulating after it ends,
+        # while the loop waits to see whether a longer mode is still
+        # arriving) -- a straight median over the *whole* range
+        # describes "typical", which is the noise floor whenever noise
+        # frames are the numerical majority, and noise then reads as
+        # fully trustworthy (weight ~1) right alongside real frames
+        # instead of being down-weighted, feeding reconstruct() latents
+        # that are mostly garbage at full confidence. Anchoring instead
+        # on frames within an order of magnitude of the strongest ones
+        # seen needs only a few genuinely real frames to set the right
+        # reference, regardless of how much silence surrounds them; a
+        # real (even faded) frame is never excluded by this on its own
+        # account, since a *minority* of low-|h| frames barely moves a
+        # median in the first place.
+        h_mag = np.abs(h_pilot)
+        peak_h = np.max(h_mag) if h_mag.size else 0.0
+        plausible = h_mag > 0.1 * peak_h
+        med_h = np.median(h_mag[plausible]) if np.any(plausible) else 1.0
         floor = max(0.05 * med_h, 1e-9)
 
         def pilot_at(i: int) -> np.ndarray:

--- a/sstvae/modem/sync.py
+++ b/sstvae/modem/sync.py
@@ -247,6 +247,26 @@ class BlindAccumulator:
     and whole-recording CFO correction fold to the same energy. Checked
     against `acquire_blind`'s one-shot result in
     `tests/test_blind_acquisition.py`.
+
+    `window_s` bounds how long old audio keeps influencing the result --
+    without it, an ever-growing accumulator is wrong in a way that has
+    nothing to do with CPU cost: each phase bin's fold sums matched-
+    filter *power* over every period pushed, real signal or not, so a
+    real (but short) transmission surrounded by a long stretch of
+    silence or noise gets its peak diluted by all that irrelevant
+    history, and the score (peak / median) drifts toward 1 as the
+    irrelevant fraction grows -- a bounded-window search that only ever
+    looked at the recent signal would still find it clearly. Implemented
+    as exponential decay (`window_s` is the ~1/e time constant) rather
+    than exact eviction of aged-out blocks: eviction needs to retain
+    every bin's per-block contribution for the whole window to undo it
+    later (67 bins x ~8k samples x 25 blocks, tens of MB), while decay
+    needs none -- just scale the existing `folded` array down before
+    adding each new block, which is also this codebase's established
+    idiom for "recent-weighted, bounded-memory" state (see the pilot
+    clock-drift tracker in modem.py). `window_s=None` disables it, for
+    equivalence testing against acquire_blind's unweighted one-shot
+    integration.
     """
 
     def __init__(
@@ -256,6 +276,7 @@ class BlindAccumulator:
         min_periods: int = 8,
         threshold: float = 4.0,
         block_samples: int | None = None,
+        window_s: float | None = 25.0,
     ) -> None:
         template = pilot_template()
         kernel = np.conj(template[::-1])
@@ -286,6 +307,17 @@ class BlindAccumulator:
         self._shift_bins = shift_bins
         self._freqs = shift_bins * self._bin_hz
         self._kernel_f = fft(np.concatenate([kernel, np.zeros(self._block - m, dtype=complex)]))
+
+        # Applied once per processed block, uniformly across every phase
+        # and CFO bin, so it never changes the *shape* of a fresh block's
+        # contribution -- only how much the past is still worth relative
+        # to it. Because it scales every bin equally, the peak/median
+        # score (what's actually compared to `threshold`) is unaffected
+        # by decay alone; only the mix of old-vs-new evidence behind it
+        # changes.
+        self._decay_per_block = (
+            1.0 if window_s is None else float(np.exp(-self._step / (window_s * FS)))
+        )
 
         self._folded = np.zeros((len(shift_bins), FRAME_SAMPLES))
         self._n_valid = 0
@@ -320,6 +352,8 @@ class BlindAccumulator:
             abs0 = self._buf_start + pos
             phase0 = abs0 % FRAME_SAMPLES
             idx = (phase0 + np.arange(step)) % FRAME_SAMPLES
+            if self._decay_per_block != 1.0:
+                self._folded *= self._decay_per_block
             for i, shift in enumerate(self._shift_bins):
                 mf = ifft(np.roll(block_f, -shift) * self._kernel_f)[m - 1 : B]
                 np.add.at(self._folded[i], idx, np.abs(mf) ** 2)

--- a/sstvae/modem/sync.py
+++ b/sstvae/modem/sync.py
@@ -7,6 +7,7 @@ carrier spacing, resolved by trying integer-bin candidates against the
 known preamble template. Net tolerance comfortably exceeds +/-50 Hz.
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -217,15 +218,36 @@ def acquire_blind(
 class BlindAccumulator:
     """Incremental counterpart to `acquire_blind()`.
 
-    The one-shot function's search window is bounded (`rx/engine.py`
-    caps it at `blind_search_seconds`) purely for CPU reasons: it
-    recomputes the whole window's per-CFO-bin FFT from scratch on every
-    poll, even though most of a sliding window is audio it already
-    folded last poll. This class instead keeps a running per-CFO-bin,
-    per-phase-bin energy accumulator and folds in only the *new* samples
-    each call, via block-wise overlap-save -- so the cost of `push()` is
-    O(new samples), not O(window length), and the achievable integration
-    window becomes a memory question rather than a CPU one.
+    `rx/engine.py` used to bound the one-shot function's search window
+    purely for CPU reasons: it recomputes the whole window's per-CFO-bin
+    FFT from scratch on every poll, even though most of a sliding window
+    is audio it already folded last poll. This class instead keeps a
+    running per-CFO-bin, per-phase-bin energy accumulator and folds in
+    only the *new* samples each call, via block-wise overlap-save -- so
+    the cost of `push()` is O(new samples), not O(window length).
+
+    That does **not** mean longer integration lets this pull a weaker
+    signal out of the noise, and it is worth being precise about why,
+    because the intuitive "more integration = deeper into the noise"
+    story is wrong for this detector specifically. `result()`'s score is
+    a ratio: the winning phase bin's summed matched-filter *power* over
+    the other 1151 bins' median. Both numerator and denominator grow
+    roughly proportionally with the number of periods folded in, so the
+    ratio converges to a value set by the signal's *per-period* SNR, not
+    by how many periods you integrate -- confirmed by measurement
+    (`docs/todo.md`): at a fading SNR comfortably above the algorithm's
+    floor, score barely moves between a 10 s and a 95 s one-shot window;
+    well below the floor, no window length up to and including the
+    entire transmission ever crosses threshold. What longer integration
+    *does* buy is reliability near that floor: a signal whose true ratio
+    sits just above threshold can read below it on a short, noisy sample
+    and get missed, and a longer window converges to the true ratio and
+    catches it -- measured, one seed in eight went from a miss at a
+    10 s window to a catch at 95 s, at an SNR where every other seed
+    already passed at 10 s. That benefit runs out once the window covers
+    the transmission's own duration; audio older than the transmission
+    is pure dilution, not more signal to integrate (see `window_s`
+    below).
 
     The block size is chosen purely from the frequency resolution the
     search needs (`FS / bin_step_hz`), not from how long the caller
@@ -249,23 +271,38 @@ class BlindAccumulator:
     `tests/test_blind_acquisition.py`.
 
     `window_s` bounds how long old audio keeps influencing the result --
-    without it, an ever-growing accumulator is wrong in a way that has
-    nothing to do with CPU cost: each phase bin's fold sums matched-
-    filter *power* over every period pushed, real signal or not, so a
+    without it, an ever-growing accumulator is wrong independent of the
+    integration-time argument above: each phase bin's fold sums matched-
+    filter power over every period pushed, real signal or not, so a
     real (but short) transmission surrounded by a long stretch of
     silence or noise gets its peak diluted by all that irrelevant
-    history, and the score (peak / median) drifts toward 1 as the
-    irrelevant fraction grows -- a bounded-window search that only ever
-    looked at the recent signal would still find it clearly. Implemented
-    as exponential decay (`window_s` is the ~1/e time constant) rather
-    than exact eviction of aged-out blocks: eviction needs to retain
-    every bin's per-block contribution for the whole window to undo it
-    later (67 bins x ~8k samples x 25 blocks, tens of MB), while decay
-    needs none -- just scale the existing `folded` array down before
-    adding each new block, which is also this codebase's established
-    idiom for "recent-weighted, bounded-memory" state (see the pilot
-    clock-drift tracker in modem.py). `window_s=None` disables it, for
-    equivalence testing against acquire_blind's unweighted one-shot
+    history, and the score drifts toward 1 as the irrelevant fraction
+    grows. Implemented as exponential decay (`window_s` is the ~1/e time
+    constant) rather than exact eviction of aged-out blocks: eviction
+    needs to retain every bin's per-block contribution for the whole
+    window to undo it later (67 bins x ~8k samples x 25 blocks, tens of
+    MB), while decay needs none -- just scale the existing `folded`
+    array down before adding each new block, which is also this
+    codebase's established idiom for "recent-weighted, bounded-memory"
+    state (see the pilot clock-drift tracker in modem.py).
+
+    Since the two things `window_s` needs to balance -- enough of it to
+    get a marginal, long (mode C, ~95 s) transmission's full reliability
+    benefit, not so much that a short (mode A, ~32 s) one sits diluted by
+    an unrelated 60+ s of history behind it -- depend on which mode is
+    transmitting, which is exactly what blind acquisition does not know
+    yet, `window_s` accepts **several** timescales run in parallel
+    instead of a single one. The expensive part (block FFT + per-bin
+    matched filter) is shared and computed once per block regardless of
+    how many timescales are given; each just gets its own cheap decay-
+    and-fold pass over the same per-block result, so running e.g. three
+    timescales costs almost nothing beyond one. `result()` reports
+    whichever timescale's peak score is highest. `rx/engine.py` passes
+    one timescale per mode, each capped at that mode's own duration
+    (`config.MODES`), so no timescale ever integrates past the point
+    where there is any more real signal to gain from it. A single float
+    (or `None`, meaning no decay at all) still means one timescale, for
+    equivalence testing against `acquire_blind`'s unweighted one-shot
     integration.
     """
 
@@ -276,7 +313,7 @@ class BlindAccumulator:
         min_periods: int = 8,
         threshold: float = 4.0,
         block_samples: int | None = None,
-        window_s: float | None = 25.0,
+        window_s: float | None | Sequence[float | None] = 25.0,
     ) -> None:
         template = pilot_template()
         kernel = np.conj(template[::-1])
@@ -308,18 +345,27 @@ class BlindAccumulator:
         self._freqs = shift_bins * self._bin_hz
         self._kernel_f = fft(np.concatenate([kernel, np.zeros(self._block - m, dtype=complex)]))
 
+        # One or several decay timescales, run in parallel off the same
+        # per-block matched-filter result -- see the class docstring for
+        # why a single one can't serve every mode well. A bare float or
+        # None is still one timescale, for callers (and the equivalence
+        # tests) that only want that.
+        window_s_list = (
+            list(window_s) if isinstance(window_s, Sequence) and not isinstance(window_s, str)
+            else [window_s]
+        )
         # Applied once per processed block, uniformly across every phase
-        # and CFO bin, so it never changes the *shape* of a fresh block's
-        # contribution -- only how much the past is still worth relative
-        # to it. Because it scales every bin equally, the peak/median
-        # score (what's actually compared to `threshold`) is unaffected
-        # by decay alone; only the mix of old-vs-new evidence behind it
-        # changes.
-        self._decay_per_block = (
-            1.0 if window_s is None else float(np.exp(-self._step / (window_s * FS)))
+        # and CFO bin *within one timescale*, so it never changes the
+        # *shape* of a fresh block's contribution to that timescale --
+        # only how much the past is still worth relative to it. Because
+        # it scales a timescale's bins equally, that timescale's peak/
+        # median score is unaffected by decay alone; only the mix of
+        # old-vs-new evidence behind it changes.
+        self._decay_per_block = np.array(
+            [1.0 if w is None else float(np.exp(-self._step / (w * FS))) for w in window_s_list]
         )
 
-        self._folded = np.zeros((len(shift_bins), FRAME_SAMPLES))
+        self._folded = np.zeros((len(window_s_list), len(shift_bins), FRAME_SAMPLES))
         self._n_valid = 0
         self._buf = np.zeros(0, dtype=complex)
         self._buf_start: int | None = None
@@ -352,11 +398,24 @@ class BlindAccumulator:
             abs0 = self._buf_start + pos
             phase0 = abs0 % FRAME_SAMPLES
             idx = (phase0 + np.arange(step)) % FRAME_SAMPLES
-            if self._decay_per_block != 1.0:
-                self._folded *= self._decay_per_block
+            # Decay every timescale's whole array first -- cheap
+            # (n_timescales x n_bins x FRAME_SAMPLES scalars) next to the
+            # per-bin FFT below, which is why adding timescales barely
+            # moves push()'s cost.
+            self._folded *= self._decay_per_block[:, None, None]
             for i, shift in enumerate(self._shift_bins):
                 mf = ifft(np.roll(block_f, -shift) * self._kernel_f)[m - 1 : B]
-                np.add.at(self._folded[i], idx, np.abs(mf) ** 2)
+                p2 = np.abs(mf) ** 2
+                # Every timescale folds in the *same* per-block matched-
+                # filter power -- only the decay each one already applied
+                # to its own history differs. Looped rather than
+                # vectorized across timescales: np.add.at must run once
+                # per target array to handle idx's repeats (step exceeds
+                # FRAME_SAMPLES, so each block wraps the phase several
+                # times) correctly, and n_timescales is small enough
+                # (2-3) that the loop costs nothing next to the FFT.
+                for t in range(len(self._decay_per_block)):
+                    np.add.at(self._folded[t, i], idx, p2)
             self._n_valid += step
             pos += step
 
@@ -364,18 +423,25 @@ class BlindAccumulator:
         self._buf_start += pos
 
     def result(self) -> BlindAcquisition:
-        """The best (bin, phase) so far, in the same shape as
-        `acquire_blind`'s return value. Raises `SyncError` exactly as
-        the one-shot function does: too little data pushed yet, or no
-        bin's peak clears `threshold`."""
+        """The best (timescale, bin, phase) so far, in the same shape as
+        `acquire_blind`'s return value -- reports whichever timescale's
+        peak score is highest, not a fixed one, since which timescale
+        that is depends on which mode (if any) is actually transmitting.
+        Raises `SyncError` exactly as the one-shot function does: too
+        little data pushed yet, or no timescale's peak clears
+        `threshold`."""
         if self._n_valid < FRAME_SAMPLES * self._min_periods:
             raise SyncError("window too short for blind acquisition")
 
-        scores = self._folded.max(axis=1) / (np.median(self._folded, axis=1) + 1e-12)
-        i = int(np.argmax(scores))
-        score = float(scores[i])
+        # self._folded is (n_timescales, n_bins, FRAME_SAMPLES); reduce
+        # the phase axis to a score per (timescale, bin), then pick the
+        # best cell over both.
+        scores = self._folded.max(axis=2) / (np.median(self._folded, axis=2) + 1e-12)
+        t, i = np.unravel_index(np.argmax(scores), scores.shape)
+        t, i = int(t), int(i)
+        score = float(scores[t, i])
         if score < self._threshold:
             raise SyncError(f"no periodic pilot found (peak prominence {score:.3g})")
 
-        phase = int(np.argmax(self._folded[i]))
+        phase = int(np.argmax(self._folded[t, i]))
         return BlindAcquisition(frame_start=phase, freq_offset=float(self._freqs[i]), metric=score)

--- a/sstvae/modem/sync.py
+++ b/sstvae/modem/sync.py
@@ -212,3 +212,136 @@ def acquire_blind(
 
     off = (search[0] if search is not None else 0) + phase
     return BlindAcquisition(frame_start=off, freq_offset=f_hat, metric=float(score))
+
+
+class BlindAccumulator:
+    """Incremental counterpart to `acquire_blind()`.
+
+    The one-shot function's search window is bounded (`rx/engine.py`
+    caps it at `blind_search_seconds`) purely for CPU reasons: it
+    recomputes the whole window's per-CFO-bin FFT from scratch on every
+    poll, even though most of a sliding window is audio it already
+    folded last poll. This class instead keeps a running per-CFO-bin,
+    per-phase-bin energy accumulator and folds in only the *new* samples
+    each call, via block-wise overlap-save -- so the cost of `push()` is
+    O(new samples), not O(window length), and the achievable integration
+    window becomes a memory question rather than a CPU one.
+
+    The block size is chosen purely from the frequency resolution the
+    search needs (`FS / bin_step_hz`), not from how long the caller
+    intends to integrate for -- decoupling those two is the entire
+    point, and it also means the block's own FFT and the per-bin
+    circular-shift table are computed once for the accumulator's whole
+    lifetime rather than once per poll.
+
+    Correctness rests on one fact about the circular-shift CFO trick:
+    applied per block instead of over one huge segment, it is no longer
+    equivalent to continuous-phase demodulation from sample 0 of the
+    whole recording -- each block's phase resets to 0 at the block's own
+    start, introducing a constant (per block, per CFO bin) phase error
+    relative to the "true" correction. But the accumulator only ever
+    uses `|matched filter|**2`: multiplying an entire block by a
+    constant unit-magnitude phasor before a linear matched filter
+    multiplies that block's whole correlation output by the same
+    constant, which a squared magnitude removes exactly. So block-local
+    and whole-recording CFO correction fold to the same energy. Checked
+    against `acquire_blind`'s one-shot result in
+    `tests/test_blind_acquisition.py`.
+    """
+
+    def __init__(
+        self,
+        max_offset_hz: float = 55.0,
+        bin_step_hz: float = 1.7,
+        min_periods: int = 8,
+        threshold: float = 4.0,
+        block_samples: int | None = None,
+    ) -> None:
+        template = pilot_template()
+        kernel = np.conj(template[::-1])
+        m = len(kernel)
+        self._m = m
+        self._min_periods = min_periods
+        self._threshold = threshold
+
+        # Large enough that a block's own FFT still resolves
+        # bin_step_hz, and well above the kernel so overlap-save stays
+        # efficient (a 160-sample kernel against an ~8k block, not
+        # against the whole window as acquire_blind's single big FFT
+        # does).
+        min_block = int(np.ceil(FS / bin_step_hz))
+        self._block = next_fast_len(max(min_block, 4 * m))
+        self._step = self._block - (m - 1)
+        if self._step <= 0:
+            raise ValueError("block_samples too small for the pilot kernel")
+        if block_samples is not None:
+            self._block = block_samples
+            self._step = self._block - (m - 1)
+        self._bin_hz = FS / self._block
+
+        n_bins = int(np.ceil(max_offset_hz / bin_step_hz))
+        shift_bins = np.array(
+            [int(round(k * bin_step_hz / self._bin_hz)) for k in range(-n_bins, n_bins + 1)]
+        )
+        self._shift_bins = shift_bins
+        self._freqs = shift_bins * self._bin_hz
+        self._kernel_f = fft(np.concatenate([kernel, np.zeros(self._block - m, dtype=complex)]))
+
+        self._folded = np.zeros((len(shift_bins), FRAME_SAMPLES))
+        self._n_valid = 0
+        self._buf = np.zeros(0, dtype=complex)
+        self._buf_start: int | None = None
+
+    def push(self, z: np.ndarray, start_sample: int) -> None:
+        """Fold new complex-baseband samples in. `z[0]` must sit at
+        absolute sample index `start_sample`, and pushes must be
+        contiguous (no gaps, no re-sent samples) -- the overlap-save
+        history this needs is carried internally between calls."""
+        if self._buf_start is None:
+            self._buf_start = start_sample
+        elif start_sample != self._buf_start + self._buf.size:
+            raise ValueError(
+                "BlindAccumulator.push: expected a contiguous continuation "
+                f"at sample {self._buf_start + self._buf.size}, got {start_sample}"
+            )
+        buf = np.concatenate([self._buf, z]) if self._buf.size else np.asarray(z, dtype=complex)
+
+        B, m, step = self._block, self._m, self._step
+        pos = 0
+        while pos + B <= buf.size:
+            block_f = fft(buf[pos : pos + B])
+            # mf[i] (0-indexed within the valid slice) is the matched
+            # filter's response for a pilot window starting at block-
+            # local index i -- the same convention acquire_blind's p2[j]
+            # uses (its "lo = m - 1" offset into the FFT's own index
+            # space exactly cancels against the "-(m-1)" in a matched
+            # filter's window-start-from-output-index formula, so no
+            # (m - 1) belongs here).
+            abs0 = self._buf_start + pos
+            phase0 = abs0 % FRAME_SAMPLES
+            idx = (phase0 + np.arange(step)) % FRAME_SAMPLES
+            for i, shift in enumerate(self._shift_bins):
+                mf = ifft(np.roll(block_f, -shift) * self._kernel_f)[m - 1 : B]
+                np.add.at(self._folded[i], idx, np.abs(mf) ** 2)
+            self._n_valid += step
+            pos += step
+
+        self._buf = buf[pos:]
+        self._buf_start += pos
+
+    def result(self) -> BlindAcquisition:
+        """The best (bin, phase) so far, in the same shape as
+        `acquire_blind`'s return value. Raises `SyncError` exactly as
+        the one-shot function does: too little data pushed yet, or no
+        bin's peak clears `threshold`."""
+        if self._n_valid < FRAME_SAMPLES * self._min_periods:
+            raise SyncError("window too short for blind acquisition")
+
+        scores = self._folded.max(axis=1) / (np.median(self._folded, axis=1) + 1e-12)
+        i = int(np.argmax(scores))
+        score = float(scores[i])
+        if score < self._threshold:
+            raise SyncError(f"no periodic pilot found (peak prominence {score:.3g})")
+
+        phase = int(np.argmax(self._folded[i]))
+        return BlindAcquisition(frame_start=phase, freq_offset=float(self._freqs[i]), metric=score)

--- a/sstvae/rx/engine.py
+++ b/sstvae/rx/engine.py
@@ -38,8 +38,9 @@ from PIL import Image
 from ..codec import pad_to_full, reconstruct
 from ..config import FS, FRAME_SAMPLES, HEADER_SAMPLES, MODES, PREAMBLE_SAMPLES
 from ..modem import Modem, SyncError
-from ..modem.dsp import to_baseband
+from ..modem.dsp import to_baseband, to_baseband_at
 from ..modem.sync import acquire as sync_acquire
+from ..modem.sync import BlindAccumulator
 from .ringbuffer import RingBuffer
 
 __all__ = [
@@ -68,6 +69,12 @@ class RxConfig:
     end_grace: float = 8.0
     size: str | None = None  # "320x240" to downscale saved images
     once: bool = False
+    # BlindAccumulator's decay time constant, not a hard search-window
+    # bound any more: the accumulator folds in new audio incrementally
+    # (see decode_loop), so there is no longer a CPU reason to bound how
+    # far back it can search. This still bounds how far back it
+    # *effectively* searches, because integrating forever is wrong in a
+    # different way -- see BlindAccumulator's docstring.
     blind_search_seconds: float = 25.0
 
 
@@ -238,6 +245,19 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
     # the next one can make a brand-new reception look like it has
     # already stalled and end it early.
     tracked_reception_start = None
+    # Blind acquisition's persistent search state: a BlindAccumulator
+    # folds in only the audio that's new since the last poll (see
+    # sync.BlindAccumulator), so unlike the preamble path it carries
+    # state across iterations of this loop instead of re-deriving
+    # everything from the current snapshot each time. blind_acc_pushed
+    # is the absolute (ring-buffer-coordinate) sample count already
+    # folded in; None means "nothing pushed yet, or the last push's
+    # position fell out of the ring buffer's retained window" -- either
+    # way there is a gap push() cannot bridge contiguously, so the right
+    # response is a fresh accumulator over what is available now rather
+    # than guessing at what filled it.
+    blind_acc = None
+    blind_acc_pushed = None
 
     while not stop_event.is_set():
         stop_event.wait(config.poll_interval)
@@ -282,18 +302,27 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
             progress_frac = frames_received / n_frames_expected
             progress_metric = frames_received
         else:
-            # Bound where blind acquisition searches (the dominant CPU
-            # cost of this path) to the most recent slice of the buffer;
-            # the retrospective decode still covers everything once
-            # locked. Whole buffer if it's shorter than the window.
-            blind_span = int(config.blind_search_seconds * FS)
-            blind_search = (
-                None
-                if len(samples) <= blind_span
-                else ((len(samples) - blind_span) / FS, len(samples) / FS)
-            )
+            # Fold whatever's new since the last poll into the running
+            # accumulator -- O(new samples), not O(window), which is
+            # what lets this search as far back as config.blind_search_seconds
+            # of *decayed* history rather than a hard-bounded recent
+            # slice. The retrospective decode below still covers the
+            # whole current buffer once locked, exactly as before.
+            if blind_acc is None or blind_acc_pushed is None or blind_acc_pushed < buf_start:
+                blind_acc = BlindAccumulator(window_s=config.blind_search_seconds)
+                blind_acc_pushed = buf_start
+            new_lo = blind_acc_pushed - buf_start
+            if new_lo < len(samples):
+                new_chunk = to_baseband_at(samples[new_lo:], blind_acc_pushed)
+                blind_acc.push(new_chunk, blind_acc_pushed)
+                blind_acc_pushed = total
+
             try:
-                rb = modem.demodulate_blind(samples, search_s=blind_search)
+                ba = blind_acc.result()
+            except SyncError:
+                ba = None
+            try:
+                rb = modem.demodulate_blind(samples, acquisition=ba) if ba is not None else None
             except SyncError:
                 rb = None
             if rb is not None and rb.beacon is not None and rb.frame0_start is not None:

--- a/sstvae/rx/engine.py
+++ b/sstvae/rx/engine.py
@@ -69,13 +69,15 @@ class RxConfig:
     end_grace: float = 8.0
     size: str | None = None  # "320x240" to downscale saved images
     once: bool = False
-    # BlindAccumulator's decay time constant, not a hard search-window
-    # bound any more: the accumulator folds in new audio incrementally
-    # (see decode_loop), so there is no longer a CPU reason to bound how
-    # far back it can search. This still bounds how far back it
-    # *effectively* searches, because integrating forever is wrong in a
-    # different way -- see BlindAccumulator's docstring.
-    blind_search_seconds: float = 25.0
+    # A cap, not a fixed timescale: BlindAccumulator runs one decay
+    # timescale per mode (config.MODES), each capped at
+    # min(mode.duration_s, blind_search_seconds) -- see decode_loop.
+    # Default is above every mode's own duration, so nothing is capped:
+    # there is no reliability reason to raise it further, since there is
+    # no more real signal beyond a mode's own duration to integrate (see
+    # BlindAccumulator's docstring). Only useful to *shrink* below a
+    # mode's own duration.
+    blind_search_seconds: float = MODES["C"].duration_s
 
 
 @dataclass
@@ -303,13 +305,15 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
             progress_metric = frames_received
         else:
             # Fold whatever's new since the last poll into the running
-            # accumulator -- O(new samples), not O(window), which is
-            # what lets this search as far back as config.blind_search_seconds
-            # of *decayed* history rather than a hard-bounded recent
-            # slice. The retrospective decode below still covers the
-            # whole current buffer once locked, exactly as before.
+            # accumulator -- O(new samples), not O(window) -- which is
+            # what lets this run one decay timescale per mode (see
+            # RxConfig.blind_search_seconds) rather than a single
+            # one-size-fits-all window. The retrospective decode below
+            # still covers the whole current buffer once locked, exactly
+            # as before.
             if blind_acc is None or blind_acc_pushed is None or blind_acc_pushed < buf_start:
-                blind_acc = BlindAccumulator(window_s=config.blind_search_seconds)
+                timescales = [min(m.duration_s, config.blind_search_seconds) for m in MODES.values()]
+                blind_acc = BlindAccumulator(window_s=timescales)
                 blind_acc_pushed = buf_start
             new_lo = blind_acc_pushed - buf_start
             if new_lo < len(samples):

--- a/sstvae/rx/engine.py
+++ b/sstvae/rx/engine.py
@@ -12,7 +12,12 @@ from-here-on.
 
 Reception is considered finished either when a fully-synced decode
 reports all its frames received, or (blind case, true mode/duration
-unknown) when decoded progress stops advancing for --end-grace seconds.
+unknown) when decoded progress stops advancing for --end-grace seconds
+-- backstopped by a hard deadline, mode C's own duration (the longest
+mode) past the transmission's start as the beacon already reported it,
+so a reception can't sit in "receiving" indefinitely if the stall
+detector's metric never settles (see PROGRESS_WEIGHT_THRESHOLD and the
+deadline computation in decode_loop's blind branch).
 
 `decode_loop_low_cpu` is a cheaper variant that drops the blind fallback
 (and with it retrospective mid-stream decoding); see its docstring.
@@ -57,6 +62,10 @@ MIN_SECONDS_BEFORE_ATTEMPT = 3.0
 # How close two acquisitions' transmission-start sample position must be
 # to be treated as "the same reception" rather than a new one.
 SAME_RECEPTION_EPSILON_S = 1.0
+# Weight a blind-path latent must clear to count as "confidently
+# received" for the stall-detection progress metric -- see its use
+# below. Matches the "good" cutoff tests already judge latents by.
+PROGRESS_WEIGHT_THRESHOLD = 0.5
 
 
 @dataclass
@@ -345,7 +354,24 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
                 weights_full = rb.weights
                 callsign = rb.callsign
                 snr_db = rb.snr_db
-                progress_metric = int(np.count_nonzero(weights_full))
+                # Confidently-received latents only, not a bare nonzero
+                # count: demodulate_blind assigns *some* nonzero weight
+                # to essentially every legal abs_frame slot its ever-
+                # growing search range touches, real signal or not (just
+                # small for noise, after the med_h fix above), so a
+                # nonzero count keeps climbing every poll purely from
+                # the buffer growing -- independent of whether any new
+                # real data has arrived -- until buffer growth has
+                # mapped the *entire* legal abs_frame range, which can
+                # take up to a whole mode's duration after the real
+                # transmission already ended. That read as "stuck
+                # receiving forever": the stall detector below never saw
+                # a stable metric to end_grace against. PROGRESS_WEIGHT_
+                # THRESHOLD matches the "good" cutoff already used to
+                # judge latents elsewhere (see tests/test_blind_
+                # acquisition.py); only real frames clear it, so the
+                # count stops climbing exactly when the real data does.
+                progress_metric = int(np.count_nonzero(weights_full > PROGRESS_WEIGHT_THRESHOLD))
                 progress_frac = progress_metric / total_c_latents
             else:
                 reception_start = None
@@ -391,12 +417,33 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
         if n_frames_expected is not None:
             done = frames_received >= n_frames_expected
         else:
+            # Deterministic backstop: the beacon already told us exactly
+            # where this transmission's frame 0 sits (reception_start,
+            # in the same "preamble start" coordinate the header path
+            # uses), so the latest a real frame of it can possibly still
+            # be arriving is mode C's own duration -- the longest mode --
+            # after that point, fixed the moment reception_start is
+            # known. That is unlike "progress stopped changing" below,
+            # which rides on demodulate_blind's own noise floor and is
+            # not guaranteed to ever settle: a stuck reception was
+            # observed sitting in "receiving" for many minutes, far past
+            # any mode's duration, because the buffer kept growing and
+            # touching more of the blind search's legal frame range
+            # (see PROGRESS_WEIGHT_THRESHOLD above) or some other reason
+            # the metric kept moving. Once the buffer holds audio past
+            # this deadline there is provably no more real signal left
+            # to arrive for this reception, done or not.
+            deadline_abs = (
+                current_reception_start + PREAMBLE_SAMPLES + HEADER_SAMPLES
+                + MODES["C"].n_frames * FRAME_SAMPLES
+            )
             if progress_metric > 0 and progress_metric == last_progress_metric:
                 stable_since = stable_since or time.time()
                 done = (time.time() - stable_since) >= config.end_grace
             else:
                 stable_since = None
                 done = False
+            done = done or total >= deadline_abs
         last_progress_metric = progress_metric
 
         if done and progress_metric > 0:

--- a/sstvae/rx/ringbuffer.py
+++ b/sstvae/rx/ringbuffer.py
@@ -105,11 +105,22 @@ class RingBuffer:
         """Drop everything captured so far, keeping the sample counter
         monotonic.
 
-        Used when resuming receive after a transmission: the buffer is
-        full of our own sidetone, and the decode loop would happily lock
-        onto it and 'receive' the picture we just sent. Leaving
-        `total_written` alone keeps every absolute sample position the
-        loop has recorded (finished_starts) still meaningful.
+        Not currently on the resume-after-transmit path: both callers
+        that need to keep our own sidetone out of the decoder (the
+        "start receiving" button and resume-after-transmit) instead
+        discard the whole `RingBuffer` and construct a fresh one, which
+        starts `decode_loop` over from scratch -- so `blind_acc` and
+        every other loop-local accumulator get a clean slate too, not
+        just the audio. That leaves `total_written` restarting at 0
+        rather than staying monotonic through the gap, which is fine
+        because nothing survives the restart that could still be
+        indexing against the old count. This method stays as a lower-
+        overhead primitive (no reallocation, counter stays meaningful)
+        for a caller that wants to wipe the audio in place without
+        restarting the loop -- but pairing it with such a resume would
+        need its own explicit reset of `blind_acc`/`blind_acc_pushed`
+        and the other `decode_loop` locals, since none of those are
+        reachable from here.
         """
         with self.lock:
             self.buf[:] = 0.0

--- a/sstvae_listen.py
+++ b/sstvae_listen.py
@@ -40,7 +40,7 @@ from sstvae.codec import (  # noqa: F401  (re-exported)
     pad_to_full,
     reconstruct,
 )
-from sstvae.config import FS
+from sstvae.config import FS, MODES
 from sstvae.rx import (  # noqa: F401
     Reception,
     RingBuffer,
@@ -134,12 +134,17 @@ def main() -> None:
     )
     ap.add_argument("--poll-interval", type=float, default=5.0, help="seconds between decode attempts")
     ap.add_argument(
-        "--blind-search-seconds", type=float, default=25.0,
-        help="the blind CFO/timing search's effective integration window: "
-        "audio older than roughly this many seconds decays out of the "
-        "running search rather than being scanned fresh each poll (folding "
-        "in only new audio is what makes this cheap regardless of how long "
-        "it is). Must exceed MIN_FRAMES_FOR_SYNC's ~10.5s with margin; the "
+        "--blind-search-seconds", type=float, default=MODES["C"].duration_s,
+        help="a cap, not a fixed window: the blind CFO/timing search runs "
+        "one decay timescale per mode, each capped at min(mode duration, "
+        "this value), so audio older than roughly a mode's own duration "
+        "decays out of that mode's search rather than being scanned fresh "
+        "each poll (folding in only new audio is what makes this cheap "
+        "regardless of how long it is). Default is above every mode's own "
+        "duration, so nothing is capped by default -- lower it only to "
+        "shrink below a mode's duration (e.g. for a quick test), since "
+        "there is no reliability benefit to integrating past a mode's own "
+        "length. Must exceed MIN_FRAMES_FOR_SYNC's ~10.5s with margin; the "
         "retrospective decode itself still covers the full buffer once "
         "locked, this only bounds how long stale audio keeps influencing "
         "acquisition.",

--- a/sstvae_listen.py
+++ b/sstvae_listen.py
@@ -135,12 +135,14 @@ def main() -> None:
     ap.add_argument("--poll-interval", type=float, default=5.0, help="seconds between decode attempts")
     ap.add_argument(
         "--blind-search-seconds", type=float, default=25.0,
-        help="how much of the buffer's most recent audio the blind CFO/timing "
-        "search scans, rather than the whole --buffer-seconds window. Must "
-        "exceed MIN_FRAMES_FOR_SYNC's ~10.5s with margin; the retrospective "
-        "decode itself still covers the full buffer once locked, this only "
-        "bounds where acquisition looks (the dominant CPU cost of the blind "
-        "path).",
+        help="the blind CFO/timing search's effective integration window: "
+        "audio older than roughly this many seconds decays out of the "
+        "running search rather than being scanned fresh each poll (folding "
+        "in only new audio is what makes this cheap regardless of how long "
+        "it is). Must exceed MIN_FRAMES_FOR_SYNC's ~10.5s with margin; the "
+        "retrospective decode itself still covers the full buffer once "
+        "locked, this only bounds how long stale audio keeps influencing "
+        "acquisition.",
     )
     ap.add_argument(
         "--end-grace", type=float, default=8.0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,26 @@ def _native_adapters(native):
                           max_offset_hz, bin_step_hz, min_periods, threshold,
                           search)
 
+    # A whole class, not a function -- wraps the native object rather
+    # than replacing sstvae.modem.sync.BlindAccumulator's *instances*
+    # with a native one directly, since result() needs the same
+    # tuple->BlindAcquisition translation acquire_blind's shim does
+    # above, and push()/result() need the same SyncError translation.
+    class BlindAccumulator:
+        def __init__(self, max_offset_hz=55.0, bin_step_hz=1.7, min_periods=8,
+                     threshold=4.0, block_samples=None, window_s=25.0):
+            self._native = native.sync.BlindAccumulator(
+                max_offset_hz, bin_step_hz, min_periods, threshold,
+                block_samples, window_s)
+
+        def push(self, z, start_sample):
+            self._native.push(z, start_sample)
+
+        def result(self):
+            from sstvae.modem.sync import BlindAcquisition
+
+            return _sync_call(self._native.result, BlindAcquisition)
+
     # Modem's methods, rebuilt into the reference's dataclasses. The
     # binding returns plain dicts so the C++ core carries no knowledge of
     # Python object layout -- it is the same core the application links.
@@ -226,6 +246,7 @@ def _native_adapters(native):
         ("sstvae.modem.modem.Modem", "demodulate_blind"): modem_demodulate_blind,
         ("sstvae.modem.sync", "acquire"): acquire,
         ("sstvae.modem.sync", "acquire_blind"): acquire_blind,
+        ("sstvae.modem.sync", "BlindAccumulator"): BlindAccumulator,
         # modem.py from-imports both, so its copies need replacing too.
         ("sstvae.modem.modem", "acquire"): acquire,
         ("sstvae.modem.modem", "acquire_blind"): acquire_blind,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,9 +167,18 @@ def _native_adapters(native):
     class BlindAccumulator:
         def __init__(self, max_offset_hz=55.0, bin_step_hz=1.7, min_periods=8,
                      threshold=4.0, block_samples=None, window_s=25.0):
+            # The reference accepts a bare float/None as shorthand for one
+            # timescale; the binding always takes a list.
+            from collections.abc import Sequence
+
+            window_s_list = (
+                list(window_s)
+                if isinstance(window_s, Sequence) and not isinstance(window_s, str)
+                else [window_s]
+            )
             self._native = native.sync.BlindAccumulator(
                 max_offset_hz, bin_step_hz, min_periods, threshold,
-                block_samples, window_s)
+                block_samples, window_s_list)
 
         def push(self, z, start_sample):
             self._native.push(z, start_sample)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,11 +228,15 @@ def _native_adapters(native):
             beacon=_beacon_from_tuple(d["beacon"]), callsign=d["callsign"],
             preamble_start=d["preamble_start"], snr_db=d["snr_db"])
 
-    def modem_demodulate_blind(self, x, search_s=None):
+    def modem_demodulate_blind(self, x, search_s=None, acquisition=None):
         from sstvae.modem.modem import BlindDemodResult
 
+        acq_tuple = (
+            None if acquisition is None
+            else (acquisition.frame_start, acquisition.freq_offset, acquisition.metric)
+        )
         d = _sync_call(native.modem.demodulate_blind, dict,
-                       np.asarray(x, dtype=np.float64), search_s)
+                       np.asarray(x, dtype=np.float64), search_s, acq_tuple)
         return BlindDemodResult(
             latents=d["latents"], weights=d["weights"],
             freq_offset=d["freq_offset"], beacon=_beacon_from_tuple(d["beacon"]),

--- a/tests/test_beacon.py
+++ b/tests/test_beacon.py
@@ -77,7 +77,7 @@ def test_noise_tolerant_decode():
 # --- multi-repetition combining ----------------------------------------------
 
 
-def test_combining_decodes_where_no_single_repetition_can(request):
+def test_combining_decodes_where_no_single_repetition_can():
     """The core claim of the multi-repetition fallback: chip noise too
     heavy for any single ~5 s repetition's own Golay+CRC decode to
     survive can still be resolved once enough repetitions (here, mode
@@ -89,12 +89,13 @@ def test_combining_decodes_where_no_single_repetition_can(request):
     success to 100% once every case where the pilot itself locks also
     got a beacon decode.
 
-    Python-only for now -- the combining fallback hasn't been ported to
-    the C++ core, so this exercises exactly the feature `--native`
-    would otherwise silently not have.
+    Ported to native/ too -- `beacon._decode_payload` below is always
+    the Python reference regardless of --native (it isn't in
+    NATIVE_SUBSTITUTIONS, and doesn't need to be: it's only this test's
+    own diagnostic for "did combining actually have to do anything",
+    not the thing under test), but `beacon.decode` itself resolves to
+    the native binding under --native.
     """
-    if request.config.getoption("--native"):
-        pytest.skip("multi-repetition beacon combining is not yet ported to native/")
     n_frames = MODES["C"].n_frames
     chips = beacon.chip_stream(0, n_frames, "TEST")
     rng = np.random.default_rng(6)

--- a/tests/test_beacon.py
+++ b/tests/test_beacon.py
@@ -74,6 +74,52 @@ def test_noise_tolerant_decode():
     assert r.callsign == "KJ7ABC"
 
 
+# --- multi-repetition combining ----------------------------------------------
+
+
+def test_combining_decodes_where_no_single_repetition_can(request):
+    """The core claim of the multi-repetition fallback: chip noise too
+    heavy for any single ~5 s repetition's own Golay+CRC decode to
+    survive can still be resolved once enough repetitions (here, mode
+    C's ~18) are combined -- see beacon.py's module docstring on why
+    (invariant chunks summed by sign, the counter and CRC-mixed chunks
+    resolved by a joint search across repetitions, not per-repetition
+    voting). Regression for a real, measured gain: this exact scenario
+    (mode C, mpp fading, SNR -6..0 dB) went from 12-88% end-to-end
+    success to 100% once every case where the pilot itself locks also
+    got a beacon decode.
+
+    Python-only for now -- the combining fallback hasn't been ported to
+    the C++ core, so this exercises exactly the feature `--native`
+    would otherwise silently not have.
+    """
+    if request.config.getoption("--native"):
+        pytest.skip("multi-repetition beacon combining is not yet ported to native/")
+    n_frames = MODES["C"].n_frames
+    chips = beacon.chip_stream(0, n_frames, "TEST")
+    rng = np.random.default_rng(6)
+    # Calibrated so most *individual* repetitions fail on their own --
+    # asserted below -- while the combined decode still succeeds.
+    noisy = chips + rng.normal(scale=1.3, size=chips.shape)
+
+    n_solo_ok = 0
+    for off in beacon.find_sync(noisy, threshold=0.3, max_candidates=30):
+        end = off + beacon.SYNC_LEN + beacon.CODED_LEN
+        if end > len(noisy):
+            continue
+        if beacon._decode_payload(noisy[off + beacon.SYNC_LEN : end]) is not None:
+            n_solo_ok += 1
+    assert n_solo_ok <= 2, (
+        f"{n_solo_ok} individual repetitions already decoded on their own -- "
+        "noise scale needs raising so this test actually exercises combining"
+    )
+
+    r = beacon.decode(noisy)
+    assert r is not None, "combining should have rescued this from noise too heavy for any single repetition"
+    assert r.frame_index == r.chip_offset // CHIPS_PER_FRAME
+    assert r.callsign == "TEST"
+
+
 # --- integration with the real modem ----------------------------------------
 
 

--- a/tests/test_blind_acquisition.py
+++ b/tests/test_blind_acquisition.py
@@ -249,3 +249,74 @@ def test_blind_accumulator_decay_forgets_stale_history():
     decayed_metric = decayed.result().metric
 
     assert decayed_metric > 2.0 * undiluted_metric
+
+
+def test_blind_accumulator_multi_timescale_picks_the_better_one():
+    """A single decay constant can't serve every mode well: short enough
+    to not dilute a short transmission behind unrelated history means a
+    long transmission's own real duration doesn't get folded in fully,
+    and vice versa. window_s accepts several timescales run in parallel
+    off the same (shared, expensive) per-block matched-filter result, and
+    result() reports whichever scores best -- so it should never do worse
+    than the single timescale that happens to suit the situation, on
+    either a short-signal-behind-noise case (short timescale wins) or a
+    long-signal case (long timescale wins, since it gets more of the
+    real transmission's own duration folded in)."""
+    rng = np.random.default_rng(11)
+
+    def noisy_prefix(seconds):
+        n = int(seconds * FS)
+        return rng.normal(size=n) + 1j * rng.normal(size=n)
+
+    # Case 1: short real signal behind a long stretch of unrelated noise
+    # -- the short timescale alone should win, and multi-scale should
+    # match it (not get dragged down by the long timescale's dilution).
+    _, _, x, frames_start = _tx(seed=12)
+    win = _frames_slice(x, frames_start, 300, beacon.MIN_FRAMES_FOR_SYNC + 5)
+    z_short_signal = to_baseband(win)
+    z_noise = noisy_prefix(90.0)
+
+    short_only = BlindAccumulator(window_s=10.0)
+    long_only = BlindAccumulator(window_s=90.0)
+    multi = BlindAccumulator(window_s=[10.0, 90.0])
+    for acc in (short_only, long_only, multi):
+        acc.push(z_noise, 0)
+        acc.push(z_short_signal, z_noise.size)
+
+    short_metric = short_only.result().metric
+    long_metric = long_only.result().metric
+    multi_metric = multi.result().metric
+    assert short_metric > long_metric  # the dilution effect this case is built to show
+    assert multi_metric == pytest.approx(short_metric, rel=1e-9)
+
+    # Case 2: a long, continuous, genuinely marginal signal -- right at
+    # the SNR where a short window misses it but integrating over more
+    # of the transmission's own real duration catches it (this is the
+    # *reliability near the ceiling* benefit the class docstring
+    # describes, not a lower noise floor -- found by sweeping seeds at
+    # -7 dB mpp fading until a short-window miss / long-window catch
+    # turned up; most seeds pass at both window lengths, matching the
+    # docstring's "score barely moves once comfortably above the floor"
+    # measurement). Multi-scale should still catch it, not get stuck
+    # with the short timescale that lost this case.
+    from sstvae import hfchannel
+    from sstvae.config import MODES
+
+    modem = Modem()
+    lat = np.random.default_rng(4).normal(size=MODES["C"].n_latents)
+    lat /= np.sqrt(np.mean(lat**2))
+    tx_wave = modem.modulate(lat, "C", callsign="N0CALL")
+    clean = tx_wave[frames_start:]  # the whole mode C frame region, ~95 s
+    noisy = hfchannel.apply_channel(clean, snr_db=-7.0, fading_preset="mpp", seed=54)
+    z_long_signal = to_baseband(noisy)
+
+    short_only2 = BlindAccumulator(window_s=10.0)
+    long_only2 = BlindAccumulator(window_s=90.0)
+    multi2 = BlindAccumulator(window_s=[10.0, 90.0])
+    for acc in (short_only2, long_only2, multi2):
+        acc.push(z_long_signal, 0)
+
+    with pytest.raises(SyncError):
+        short_only2.result()
+    assert long_only2.result().metric > 4.0
+    assert multi2.result().metric > 4.0

--- a/tests/test_blind_acquisition.py
+++ b/tests/test_blind_acquisition.py
@@ -147,6 +147,59 @@ def test_window_shorter_than_min_frames_for_sync_may_fail_gracefully():
             assert r.frame_offset == start_frame
 
 
+def test_demodulate_blind_does_not_trust_silence_as_signal():
+    """demodulate_blind's per-latent confidence weight comes from how
+    each frame's pilot response compares to a "typical" |h| — but unlike
+    demodulate() (which only ever looks at the header's known real frame
+    count), the blind range is whatever the whole buffer holds, and a
+    short real transmission sitting in a lot of leading/trailing silence
+    or low-level noise made that "typical" value describe the noise
+    floor instead of the signal: a plain median() over the whole range
+    is dominated by however many silent frames surround the real ones,
+    so noise reads back as fully trustworthy (weight ~1) right alongside
+    the real signal, feeding reconstruct() latents that are mostly
+    garbage at full confidence -- the reported symptom was a
+    near-black decoded image when acquisition locked onto a buffer that
+    was mostly pre- or post-transmission silence.
+
+    Regression: real transmission is a small fraction of a much longer
+    buffer of low-level ambient noise (not exact digital silence, which
+    is the more realistic case and also exercises the >0 floor). Every
+    canonical latent slot the real transmission's own frames could not
+    have written to must come back at ~0 weight.
+    """
+    from sstvae.modem import framing
+
+    mode = "A"
+    modem = Modem()
+    lat = np.random.default_rng(3).normal(size=MODES[mode].n_latents)
+    lat /= np.sqrt(np.mean(lat**2))
+    x = modem.modulate(lat, mode, callsign="TEST")
+    frames_start = LEADIN_SAMPLES + PREAMBLE_SAMPLES + HEADER_SAMPLES
+    sig = x[frames_start:]
+    n_real_frames = MODES[mode].n_frames
+
+    rng = np.random.default_rng(1)
+    pre = rng.normal(scale=0.01, size=int(100.0 * FS))
+    audio = np.concatenate([pre, sig])
+
+    r = modem.demodulate_blind(audio)
+    assert r.beacon is not None
+
+    real_indices = np.zeros(MODES["C"].n_latents, dtype=bool)
+    for abs_frame in range(n_real_frames):
+        _, idx = framing.slot_range_for_frame(abs_frame)
+        real_indices[idx] = True
+
+    spurious = r.weights[~real_indices]
+    assert np.all(spurious < 0.3), (
+        f"{np.count_nonzero(spurious >= 0.3)} canonical latent slots outside "
+        "the real transmission's own frames came back with high confidence "
+        f"(max spurious weight {spurious.max():.3f}) -- silence is being "
+        "trusted as signal"
+    )
+
+
 def test_blind_accumulator_chunking_is_invariant():
     """The whole point of BlindAccumulator is that a caller can feed it
     audio in whatever pieces arrive off the ring buffer -- so the

--- a/tests/test_blind_acquisition.py
+++ b/tests/test_blind_acquisition.py
@@ -172,8 +172,13 @@ def test_blind_accumulator_chunking_is_invariant():
         pos += n
         i += 1
 
-    np.testing.assert_allclose(chunked._folded, whole._folded, rtol=1e-9, atol=1e-6)
-    assert chunked._n_valid == whole._n_valid
+    # Internal-state check: precise, but only meaningful against the
+    # Python reference -- the native adapter wraps an opaque C++ object
+    # with no equivalent attributes, and pytest --native substitutes
+    # BlindAccumulator with that adapter.
+    if hasattr(whole, "_folded"):
+        np.testing.assert_allclose(chunked._folded, whole._folded, rtol=1e-9, atol=1e-6)
+        assert chunked._n_valid == whole._n_valid
 
     r_whole = whole.result()
     r_chunked = chunked.result()
@@ -188,17 +193,59 @@ def test_blind_accumulator_matches_acquire_blind_one_shot():
     window) on the same signal. The two use different-sized FFTs and so
     a different, independently-rounded grid of candidate CFO bins --
     exact frequency/score agreement isn't expected -- but they must
-    agree on the thing that actually matters: which pilot phase wins."""
+    agree on the thing that actually matters: which pilot phase wins.
+
+    window_s=None: acquire_blind weights every period equally, so this
+    is a check on the block-decomposition math, not on the (separate,
+    separately tested) decay feature."""
     _, _, x, frames_start = _tx(seed=7)
     win = _frames_slice(x, frames_start, 300, beacon.MIN_FRAMES_FOR_SYNC + 5)
     z = to_baseband(win)
 
     one_shot = acquire_blind(z)
 
-    acc = BlindAccumulator()
+    acc = BlindAccumulator(window_s=None)
     acc.push(z, 0)
     streamed = acc.result()
 
     assert streamed.frame_start == one_shot.frame_start
     assert abs(streamed.freq_offset - one_shot.freq_offset) < 2.0
     assert streamed.metric > 4.0
+
+
+def test_blind_accumulator_decay_forgets_stale_history():
+    """Without decay, a real (but short) transmission preceded by a long
+    stretch of unrelated noise gets diluted: the peak bin's fold sums
+    matched-filter power over *every* period pushed, real signal or not,
+    so the score (peak / median) drifts toward 1 as the irrelevant
+    fraction of history grows -- measured (not asserted here, to keep
+    this test fast): 30 s of noise prefix barely dents it (9.3 vs. an
+    undiluted ~18), 90 s roughly halves it to right at the default
+    threshold (4.6), and 180 s pushes it below threshold entirely (3.0,
+    a SyncError) even though the same signal alone locks cleanly. A
+    bounded-window search of just the recent audio wouldn't see any of
+    that dilution, which is the whole reason acquire_blind's caller
+    bounds its search window in the first place.
+
+    Rather than reproduce the slow (~180 s of noise) threshold-crossing
+    case, compare metrics directly: decay should recover most of the
+    undiluted score regardless of how much stale noise came before it."""
+    rng = np.random.default_rng(9)
+    _, _, x, frames_start = _tx(seed=9)
+    win = _frames_slice(x, frames_start, 300, beacon.MIN_FRAMES_FOR_SYNC + 5)
+    z_signal = to_baseband(win)
+
+    noise_s = 90.0
+    z_noise = rng.normal(size=int(noise_s * FS)) + 1j * rng.normal(size=int(noise_s * FS))
+
+    undecayed = BlindAccumulator(window_s=None)
+    undecayed.push(z_noise, 0)
+    undecayed.push(z_signal, z_noise.size)
+    undiluted_metric = undecayed.result().metric
+
+    decayed = BlindAccumulator(window_s=10.0)
+    decayed.push(z_noise, 0)
+    decayed.push(z_signal, z_noise.size)
+    decayed_metric = decayed.result().metric
+
+    assert decayed_metric > 2.0 * undiluted_metric

--- a/tests/test_blind_acquisition.py
+++ b/tests/test_blind_acquisition.py
@@ -11,7 +11,8 @@ from sstvae.config import (
     FRAME_SAMPLES,
 )
 from sstvae.modem import Modem, beacon
-from sstvae.modem.sync import acquire_blind, SyncError
+from sstvae.modem.dsp import to_baseband
+from sstvae.modem.sync import BlindAccumulator, acquire_blind, SyncError
 
 from conftest import snr_floor_db
 
@@ -144,3 +145,60 @@ def test_window_shorter_than_min_frames_for_sync_may_fail_gracefully():
             continue
         if r.beacon is not None:
             assert r.frame_offset == start_frame
+
+
+def test_blind_accumulator_chunking_is_invariant():
+    """The whole point of BlindAccumulator is that a caller can feed it
+    audio in whatever pieces arrive off the ring buffer -- so the
+    accumulated result must not depend on how the same total signal was
+    sliced into push() calls. Uses ragged, mutually-prime-ish chunk
+    sizes deliberately, so a bug that only shows up when a chunk
+    boundary lands mid-block (rather than conveniently on a block
+    boundary) has somewhere to hide."""
+    _, _, x, frames_start = _tx(seed=6)
+    win = _frames_slice(x, frames_start, 100, beacon.MIN_FRAMES_FOR_SYNC + 20)
+    z = to_baseband(win)
+
+    whole = BlindAccumulator()
+    whole.push(z, 0)
+
+    chunked = BlindAccumulator()
+    chunk_sizes = [4001, 1500, 9999, 2000, 12345]
+    pos = 0
+    i = 0
+    while pos < len(z):
+        n = min(chunk_sizes[i % len(chunk_sizes)], len(z) - pos)
+        chunked.push(z[pos : pos + n], pos)
+        pos += n
+        i += 1
+
+    np.testing.assert_allclose(chunked._folded, whole._folded, rtol=1e-9, atol=1e-6)
+    assert chunked._n_valid == whole._n_valid
+
+    r_whole = whole.result()
+    r_chunked = chunked.result()
+    assert r_chunked.frame_start == r_whole.frame_start
+    assert r_chunked.freq_offset == pytest.approx(r_whole.freq_offset)
+    assert r_chunked.metric == pytest.approx(r_whole.metric, rel=1e-6)
+
+
+def test_blind_accumulator_matches_acquire_blind_one_shot():
+    """Cross-checks the streaming, block-decomposed accumulator against
+    the existing one-shot acquire_blind (one huge FFT over the whole
+    window) on the same signal. The two use different-sized FFTs and so
+    a different, independently-rounded grid of candidate CFO bins --
+    exact frequency/score agreement isn't expected -- but they must
+    agree on the thing that actually matters: which pilot phase wins."""
+    _, _, x, frames_start = _tx(seed=7)
+    win = _frames_slice(x, frames_start, 300, beacon.MIN_FRAMES_FOR_SYNC + 5)
+    z = to_baseband(win)
+
+    one_shot = acquire_blind(z)
+
+    acc = BlindAccumulator()
+    acc.push(z, 0)
+    streamed = acc.result()
+
+    assert streamed.frame_start == one_shot.frame_start
+    assert abs(streamed.freq_offset - one_shot.freq_offset) < 2.0
+    assert streamed.metric > 4.0

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from sstvae.modem.dsp import to_baseband, to_baseband_at
+
+
+def test_to_baseband_at_matches_a_slice_of_the_whole_signal():
+    """to_baseband_at(x, g) must equal to_baseband(full)[g:g+len(x)] for
+    whatever longer `full` array `x` is a slice of -- including start
+    offsets that are not multiples of the heterodyne's 16-sample period,
+    which is exactly the case a naive to_baseband(x) gets wrong."""
+    rng = np.random.default_rng(0)
+    full = rng.normal(size=5000)
+
+    for start in [0, 1, 7, 15, 16, 17, 31, 32, 33, 999, 4321]:
+        for n in [1, 5, 37, 400]:
+            if start + n > len(full):
+                continue
+            chunk = full[start : start + n]
+            want = to_baseband(full)[start : start + n]
+            got = to_baseband_at(chunk, start)
+            np.testing.assert_allclose(got, want, atol=1e-12)
+
+
+def test_to_baseband_at_zero_start_matches_to_baseband():
+    rng = np.random.default_rng(1)
+    x = rng.normal(size=257)
+    np.testing.assert_allclose(to_baseband_at(x, 0), to_baseband(x), atol=1e-12)

--- a/tests/test_listen_state_machine.py
+++ b/tests/test_listen_state_machine.py
@@ -126,6 +126,187 @@ def test_two_transmissions_in_buffer_save_two_distinct_images(tmp_path):
     assert len(digests) == 2, "the same image was saved twice"
 
 
+def _frames_only(mode: str, seed: int) -> np.ndarray:
+    """A transmission with no preamble/header at all -- forces
+    decode_loop past `_find_new_reception` (which needs one) and into
+    the blind path on every poll, the situation these tests target."""
+    x = _transmission(mode, seed)
+    from sstvae.config import LEADIN_SAMPLES, PREAMBLE_SAMPLES, HEADER_SAMPLES
+
+    return x[LEADIN_SAMPLES + PREAMBLE_SAMPLES + HEADER_SAMPLES :]
+
+
+def _run_decode_loop_incremental(loop_fn, chunks, tmp_path, args,
+                                 timeout_s=180.0, expect_saves=1,
+                                 ring_seconds=None):
+    """Like `_run_decode_loop`, but the audio arrives as a sequence of
+    `chunks` written to the ring buffer one at a time rather than all up
+    front -- needed to reproduce bugs that only show up while the buffer
+    is still growing. Returns (saves, state, handle) once `chunks` has
+    been written and either `expect_saves` images have appeared or
+    `timeout_s` has elapsed.
+
+    The decode_loop thread is left running: the caller owns its
+    lifecycle from here and must call `handle.stop()` when done (whether
+    or not more is fed via `handle.feed()` first) -- stopping it here
+    instead would join the thread before a caller-fed follow-up chunk
+    ever reached it.
+
+    `ring_seconds`, if given, must cover everything that will ever be
+    fed, including via the handle's `feed` after this returns -- a ring
+    too small for a later feed silently evicts the reception's own
+    earlier audio instead of erroring."""
+    total_len = sum(len(c) for c in chunks)
+    ring = sstvae_listen.RingBuffer(
+        ring_seconds if ring_seconds is not None else total_len / FS + 5.0
+    )
+
+    from PIL import Image
+
+    def fake_reconstruct(model, latents, weights):
+        img = Image.new("RGB", (8, 8))
+        img.putdata([(1, 2, 3)] * 64)
+        return img
+
+    real_reconstruct = rx_engine.reconstruct
+    rx_engine.reconstruct = fake_reconstruct
+
+    state = sstvae_listen.SharedState()
+    stop = threading.Event()
+    th = threading.Thread(
+        target=loop_fn, args=(ring, None, state, args, stop), daemon=True
+    )
+    th.start()
+
+    class _Handle:
+        def feed(self, chunk):
+            ring.write(chunk)
+
+        def wait_for_saves(self, n, timeout_s):
+            deadline = time.time() + timeout_s
+            while time.time() < deadline:
+                files = sorted(Path(tmp_path).glob("*.png"))
+                if len(files) >= n:
+                    return files
+                if not th.is_alive():
+                    break
+                time.sleep(0.05)
+            return sorted(Path(tmp_path).glob("*.png"))
+
+        def stop(self):
+            stop.set()
+            th.join(timeout=10.0)
+            rx_engine.reconstruct = real_reconstruct
+
+    h = _Handle()
+    for c in chunks:
+        h.feed(c)
+    saves = h.wait_for_saves(expect_saves, timeout_s)
+    return saves, state, h
+
+
+@pytest.mark.slow
+def test_blind_reception_completes_promptly_despite_a_growing_buffer(tmp_path):
+    """A short (mode A) blind-only reception must finish shortly after
+    end_grace once the real transmission is over -- not stay in
+    "receiving" while trailing silence keeps accumulating.
+
+    demodulate_blind's weight for a frame it demodulates is nonzero
+    (just small, for noise) essentially always, and it demodulates every
+    frame the *whole current buffer* can hold. A bare nonzero count as
+    the stall-detector's progress metric therefore keeps climbing every
+    poll as the buffer grows and touches more of the legal frame range —
+    real signal or not — so the "progress stopped changing" condition
+    was never met until buffer growth had mapped the *entire* range,
+    tens of seconds after the real (32 s) transmission was long over.
+    Regression for a report of receptions sitting in "receiving"
+    seemingly forever.
+    """
+    sig = _frames_only("A", seed=11)
+    pre = np.random.default_rng(1).normal(scale=0.01, size=int(5.0 * FS))
+    trailing = np.random.default_rng(2).normal(scale=0.01, size=int(40.0 * FS))
+
+    args = _Args(tmp_path, poll_interval=0.3, end_grace=2.0)
+    real_end_s = (len(pre) + len(sig)) / FS
+
+    t0 = time.time()
+    saves, state, h = _run_decode_loop_incremental(
+        sstvae_listen.decode_loop,
+        [pre, sig, trailing],
+        tmp_path,
+        args,
+        timeout_s=60.0,
+        expect_saves=1,
+    )
+    h.stop()
+    elapsed_after_end = time.time() - t0 - real_end_s
+    assert len(saves) == 1, f"expected 1 saved image, got {len(saves)}: {saves}"
+    # Generous margin over end_grace for scheduling/poll-interval slop,
+    # but nowhere near the ~55 s of trailing silence available, let
+    # alone mode C's ~95 s deadline -- this is what pins the fix rather
+    # than merely re-checking the (much weaker) "it saved eventually"
+    # deadline test below.
+    assert elapsed_after_end < 15.0, (
+        f"reception took {elapsed_after_end:.1f}s past the real transmission's end "
+        f"to finish (end_grace={args.end_grace}s) -- still climbing on buffer growth?"
+    )
+
+
+@pytest.mark.slow
+def test_blind_reception_has_a_hard_deadline_even_if_progress_never_settles(tmp_path):
+    """Even if the stall detector's "progress stopped changing" never
+    fires -- end_grace set absurdly high here, to isolate this from the
+    prompt-completion behavior tested above -- a blind reception must
+    still finish once the buffer holds audio past mode C's own duration
+    from the transmission's known start (from the beacon). Before this
+    backstop existed, a reception stuck for any reason simply never
+    ended -- observed sitting in "receiving" for many minutes.
+    """
+    from sstvae.config import MODES, FRAME_SAMPLES
+
+    sig = _frames_only("A", seed=12)
+    pre = np.random.default_rng(3).normal(scale=0.01, size=int(5.0 * FS))
+    # Enough trailing silence after this to lock and sit in "receiving",
+    # but nowhere near mode C's duration past the transmission's start.
+    short_trailing = np.random.default_rng(4).normal(scale=0.01, size=int(10.0 * FS))
+
+    args = _Args(tmp_path, poll_interval=0.1, end_grace=1e9)
+    needed_total_s = len(pre) / FS + MODES["C"].n_frames * FRAME_SAMPLES / FS
+
+    saves, state, h = _run_decode_loop_incremental(
+        sstvae_listen.decode_loop,
+        [pre, sig, short_trailing],
+        tmp_path,
+        args,
+        timeout_s=20.0,
+        expect_saves=1,
+        ring_seconds=needed_total_s + 15.0,
+    )
+    try:
+        assert len(saves) == 0, (
+            "reception finished before its deadline could possibly be reached -- "
+            "end_grace=1e9 should have made that impossible; the fix under test "
+            "isn't isolated"
+        )
+        assert state.status != "done"
+
+        # Push the buffer well past frame 0's position + mode C's duration.
+        # reception_start lands close to len(pre) (see decode_loop's blind
+        # branch); pad generously past exactness rather than reproduce its
+        # arithmetic here.
+        have_s = (len(pre) + len(sig) + len(short_trailing)) / FS
+        more = np.random.default_rng(5).normal(
+            scale=0.01, size=int((needed_total_s - have_s + 5.0) * FS)
+        )
+        h.feed(more)
+        saves = h.wait_for_saves(1, timeout_s=60.0)
+        assert len(saves) == 1, (
+            f"expected 1 saved image past the deadline, got {len(saves)}: {saves}"
+        )
+    finally:
+        h.stop()
+
+
 @pytest.mark.slow
 def test_low_cpu_does_not_resave_the_same_transmission(tmp_path):
     """The low-CPU loop resumes its preamble search from the position it

--- a/tests/test_listen_state_machine.py
+++ b/tests/test_listen_state_machine.py
@@ -320,3 +320,65 @@ def test_low_cpu_does_not_resave_the_same_transmission(tmp_path):
         timeout_s=120.0, expect_saves=2,
     )
     assert len(saves) == 1, f"one transmission should save once, got {len(saves)}"
+
+
+@pytest.mark.slow
+def test_fresh_session_does_not_inherit_blind_evidence_from_a_prior_one(tmp_path):
+    """The app's 'start receiving' button and resume_after_transmit both
+    work by discarding the whole RingBuffer and calling decode_loop
+    again from scratch (see native/gui/rx_panel.cpp's start() /
+    resume_after_transmit(), and RingBuffer.clear()'s docstring, which
+    records that clear() is *not* how that path works) rather than
+    clearing state in place. blind_acc is a plain local inside
+    decode_loop, so a brand-new call gets a clean one for free -- but
+    that's a property of scoping, and nothing pins it against a future
+    change that keeps decode_loop (and its locals) running across a
+    'session' boundary instead of restarting it, which is exactly the
+    scenario the indeterminate gap in real captured audio -- silence
+    while transmitting, or whatever a fresh capture stream first hands
+    back -- has no way to signal to a *stale* accumulator.
+
+    Session 1 gets a real, complete mode-A transmission and is left to
+    lock and finish, so it isn't just idling. Session 2 is a brand-new
+    RingBuffer + decode_loop call, exactly as start()/resume_after_
+    transmit() produce, fed nothing but noise: it must never save a
+    reception. If blind_acc's folded evidence ever leaked across that
+    boundary, session 2 would begin already most of the way to session
+    1's lock rather than from nothing.
+    """
+    sig = _frames_only("A", seed=31)
+    pre = np.random.default_rng(8).normal(scale=0.01, size=int(2.0 * FS))
+    trailing = np.random.default_rng(9).normal(scale=0.01, size=int(10.0 * FS))
+
+    session1_dir = tmp_path / "session1"
+    session1_dir.mkdir()
+    args1 = _Args(session1_dir, poll_interval=0.1, end_grace=1.0)
+    saves1, _, h1 = _run_decode_loop_incremental(
+        sstvae_listen.decode_loop, [pre, sig, trailing], session1_dir, args1,
+        timeout_s=60.0, expect_saves=1,
+    )
+    h1.stop()
+    assert len(saves1) == 1, (
+        "session 1 should have locked on and saved a real transmission -- "
+        "otherwise this isn't exercising real blind-accumulator evidence"
+    )
+
+    # A brand-new session: fresh RingBuffer, fresh decode_loop call, same
+    # shape as what start()/resume_after_transmit() actually do. Fed
+    # nothing but noise -- a fixed seed, so this is deterministic rather
+    # than a rare-false-lock flake.
+    session2_dir = tmp_path / "session2"
+    session2_dir.mkdir()
+    noise = np.random.default_rng(10).normal(scale=0.01, size=int(10.0 * FS))
+    args2 = _Args(session2_dir, poll_interval=0.1, end_grace=1.0)
+    saves2, _, h2 = _run_decode_loop_incremental(
+        sstvae_listen.decode_loop, [noise], session2_dir, args2,
+        timeout_s=5.0, expect_saves=1,
+    )
+    try:
+        assert len(saves2) == 0, (
+            "a brand-new session fed only noise saved a reception -- "
+            "blind_acc leaked evidence across a session boundary"
+        )
+    finally:
+        h2.stop()


### PR DESCRIPTION
## Summary

- Replace `acquire_blind`'s per-poll O(window) recompute with an incremental `BlindAccumulator` (O(new samples) per poll), with one decay timescale per mode run in parallel off a shared block-FFT front end, so no timescale integrates past the point where there's more real signal to gain from it (Python + native, with parity tests).
- Fix a black-image bug: `demodulate_blind`'s per-latent confidence weight used a plain median over the *whole* possible demod range, which degenerates to the noise floor whenever silence/noise dominates that range (routine at the start/end of a blind-only reception) — noise then reads as fully trustworthy right alongside real data. Fixed in both implementations.
- Fix blind receptions that could sit in "receiving" indefinitely: the stall-detection progress metric was a bare `count_nonzero(weights)`, which climbs every poll purely from the buffer growing (more of the legal frame range touched by noise), independent of whether new real data arrived. Switched to a confidence threshold, and added a deterministic backstop — the beacon already reports exactly where the transmission's frame 0 sits, so the latest a real frame can arrive is mode C's own duration after that point, checked regardless of what the stall detector is doing.
- Recover the beacon side-channel from every superframe repetition in the buffer instead of just one. The beacon repeats every ~5.2 s (~18 times in a mode C transmission), but decode only ever tried whichever single repetition's own Golay+CRC decode happened to succeed. Measured against the pilot lock's own sensitivity, this was the real bottleneck gating whether a reception could be placed at all. Ported to both implementations, including a bit-exact verification step added after an initial version produced confident false locks on pure noise.

## Measured results

Beacon decode success, mode C, mpp fading, same seeds before/after (N=8 per point):

| SNR | Before | After |
|---|---|---|
| −6 dB | 0% | 25% |
| −4 dB | 0% | 62.5% |
| −2 dB | 0% | 75% |
| 0 dB | 12.5% | 100% |
| 2 dB | 37.5% | 100% |

Validated through manual loopback testing as well as the automated suites below.

## Testing

- `pytest` and `pytest --native`: full pass, plus the slow-marked live-loop suite (both plain and native)
- Native `ctest`: 17/17, including a new `test_beacon` covering the two properties with no golden-vector oracle (recovers a superframe from combined evidence when no single repetition decodes alone; zero false locks over 200 trials of long pure noise)
- `tools/check_includes.py` / `tools/check_layering.py`: clean
- New regression tests added throughout for each fix (blind accumulator chunking/decay/multi-timescale behavior, the stuck-reception deadline, the med_h weighting fix, and the beacon combining gain)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01KmgxnSomDHLfHfPGSmTi6E


---
_Generated by [Claude Code](https://claude.ai/code/session_01KmgxnSomDHLfHfPGSmTi6E)_