### PR TITLE
DSP performance fixes

### DIFF
--- a/native/core/audio/audio.cpp
+++ b/native/core/audio/audio.cpp
@@ -126,7 +126,7 @@ std::vector<double> StreamResampler::operator()(std::span<const double> chunk) {
     if (n == 0) return {};
 
     const std::vector<double> y = dsp::resample_poly(
-        std::span<const double>(buf_.data(), 2 * pad_ + n), up_, down_);
+        std::span<const double>(buf_.data(), 2 * pad_ + n), up_, down_, &filter_taps_);
     const std::size_t skip = pad_ * static_cast<std::size_t>(up_) / d;
     const std::size_t take = n * static_cast<std::size_t>(up_) / d;
 

--- a/native/core/audio/audio.hpp
+++ b/native/core/audio/audio.hpp
@@ -88,6 +88,10 @@ private:
     int down_;
     std::size_t pad_;
     std::vector<double> buf_;
+    // dsp::resample_poly's filter_cache slot: designed on this instance's
+    // first operator() call and reused on every later one, since up_/
+    // down_ never change -- see resample_poly's doc comment.
+    std::optional<std::vector<double>> filter_taps_;
 };
 
 // The device sample formats we can convert, named as QtMultimedia names

--- a/native/core/dsp/dsp.cpp
+++ b/native/core/dsp/dsp.cpp
@@ -147,6 +147,33 @@ std::vector<T> convolve_same_impl(std::span<const T> a, std::span<const double> 
     return out;
 }
 
+// numpy.convolve(a, v, mode="same") for complex a / real v, via FFT
+// rather than the direct sum convolve_same_impl uses. Only sync_lowpass
+// wants this: its 129-tap kernel against a's full length (the whole
+// ring-buffer snapshot, not a bounded search window) made the direct sum
+// the single largest cost in a live decode-loop profile -- a poll-cycle
+// tax that scaled with total buffer duration rather than with anything
+// acquisition actually needs. Same offset arithmetic as
+// convolve_same_impl, just applied to the FFT-computed full convolution
+// instead of a materialized one.
+std::vector<cdouble> fftconvolve_same(std::span<const cdouble> a,
+                                       std::span<const double> v) {
+    const std::size_t full = a.size() + v.size() - 1;
+    const std::size_t n = next_fast_len(full, /*real=*/false);
+    std::vector<cdouble> pa(n, cdouble{}), pv(n, cdouble{});
+    std::copy(a.begin(), a.end(), pa.begin());
+    for (std::size_t i = 0; i < v.size(); ++i) pv[i] = cdouble{v[i], 0.0};
+    std::vector<cdouble> fa = fft(pa, true);
+    const std::vector<cdouble> fv = fft(pv, true);
+    for (std::size_t i = 0; i < n; ++i) fa[i] *= fv[i];
+    const std::vector<cdouble> conv = fft(fa, false);
+
+    const std::size_t offset = (v.size() - 1) / 2;
+    return std::vector<cdouble>(
+        conv.begin() + static_cast<std::ptrdiff_t>(offset),
+        conv.begin() + static_cast<std::ptrdiff_t>(offset + a.size()));
+}
+
 }  // namespace
 
 std::vector<cdouble> to_baseband(std::span<const double> x) {
@@ -306,7 +333,7 @@ std::vector<cdouble> convolve_same(std::span<const cdouble> a,
 
 std::vector<cdouble> sync_lowpass(std::span<const cdouble> z) {
     static const std::vector<double> taps = firwin_lowpass(129, 850.0);
-    return convolve_same(z, std::span<const double>(taps));
+    return fftconvolve_same(z, std::span<const double>(taps));
 }
 
 std::vector<cdouble> hilbert(std::span<const double> x) {

--- a/native/core/dsp/dsp.cpp
+++ b/native/core/dsp/dsp.cpp
@@ -6,6 +6,7 @@
 #include <numbers>
 #include <numeric>
 #include <stdexcept>
+#include <utility>
 
 #include "dsp/fft.hpp"
 
@@ -260,7 +261,8 @@ std::size_t upfirdn_out_len(std::size_t len_h, std::size_t len_x, int up, int do
     return (in_len - 1) / static_cast<std::size_t>(down) + 1;
 }
 
-std::vector<double> resample_poly(std::span<const double> x, int up, int down) {
+std::vector<double> resample_poly(std::span<const double> x, int up, int down,
+                                  std::optional<std::vector<double>>* filter_cache) {
     if (up <= 0 || down <= 0) throw std::invalid_argument("resample_poly: up/down must be positive");
     const int g = static_cast<int>(std::gcd(up, down));
     up /= g;
@@ -275,12 +277,22 @@ std::vector<double> resample_poly(std::span<const double> x, int up, int down) {
 
     // Filter design, exactly scipy's: cutoff 1/max(up,down) relative to
     // Nyquist, 10*max(up,down) taps either side, Kaiser(5.0).
+    //
+    // `slot` is the caller's filter_cache if one was given, or a local
+    // optional that only lives for this one call otherwise -- either
+    // way the design-and-populate logic below runs unchanged, and reads
+    // back through the same `h` reference.
     const int max_rate = std::max(up, down);
-    const double f_c = 1.0 / max_rate;
     const int half_len = 10 * max_rate;
-    const int numtaps = 2 * half_len + 1;
-    std::vector<double> h = firwin_band(numtaps, 0.0, f_c, kaiser(numtaps, 5.0));
-    for (double& v : h) v *= up;
+    std::optional<std::vector<double>> local_filter;
+    std::optional<std::vector<double>>& slot = filter_cache ? *filter_cache : local_filter;
+    if (!slot.has_value()) {
+        const int numtaps = 2 * half_len + 1;
+        std::vector<double> h = firwin_band(numtaps, 0.0, 1.0 / max_rate, kaiser(numtaps, 5.0));
+        for (double& v : h) v *= up;
+        slot = std::move(h);
+    }
+    const std::vector<double>& h = *slot;
 
     // Zero-pad the filter so the output samples land at the centre.
     const std::size_t n_pre_pad =

--- a/native/core/dsp/dsp.hpp
+++ b/native/core/dsp/dsp.hpp
@@ -10,6 +10,7 @@
 
 #include <complex>
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -56,7 +57,19 @@ std::vector<double> kaiser(int m, double beta);
 // that per-chunk resampling cost. This function is the whole-signal
 // form, correct for a file or a complete waveform and wrong for a
 // stream of blocks.
-std::vector<double> resample_poly(std::span<const double> x, int up, int down);
+//
+// The Kaiser-windowed sinc filter this designs depends only on (up,
+// down), not on `x`, so `filter_cache`, if given, is a slot this fills
+// in on first use and reuses on every later call with it -- for a
+// caller (StreamResampler) that resamples many chunks at one fixed
+// ratio and would otherwise redesign the same (up to ~8821-tap) filter
+// from scratch on every chunk. Owned entirely by the caller: no shared
+// state, no locking, no eviction policy -- the caller's own lifetime is
+// the cache's lifetime. Passing the same slot across two different
+// (up, down) ratios is a caller bug, same as reusing any other
+// single-purpose local for two things, and is not detected.
+std::vector<double> resample_poly(std::span<const double> x, int up, int down,
+                                  std::optional<std::vector<double>>* filter_cache = nullptr);
 
 // numpy.convolve(a, v, mode="same"): the centre len(a) samples of the
 // full convolution, for len(a) >= len(v).

--- a/native/core/dsp/fft.hpp
+++ b/native/core/dsp/fft.hpp
@@ -14,6 +14,28 @@
 #include <cstddef>
 #include <vector>
 
+// Cache a handful of FFT plans (twiddle factors) instead of rebuilding
+// one on every call. Must be defined before pocketfft_hdronly.h is
+// first included, which happens right below -- this is that header's
+// only include site in the codebase.
+//
+// Off (0) by default upstream. A live-decode-loop perf capture showed
+// 5.45% of total CPU time in `cfftp<double>::cfftp` -- the plan
+// *constructor*, not the transform itself -- because every FFT call
+// anywhere in the native code, including 67 back-to-back same-length
+// calls inside a single acquire_blind() invocation, was rebuilding its
+// twiddle-factor table from scratch. The cache is a thread-safe,
+// mutex-protected LRU keyed by transform length (pocketfft_hdronly.h's
+// own `get_plan`), so this only removes redundant setup work; the
+// transform math, and so every golden vector's tolerance, is unchanged.
+// Sized generously above the small, fixed set of distinct lengths this
+// codebase's hot paths actually use, not tuned to it exactly -- eviction
+// churn from an undersized cache would be worse than the memory a few
+// extra unused slots cost.
+#ifndef POCKETFFT_CACHE_SIZE
+#define POCKETFFT_CACHE_SIZE 16
+#endif
+
 #include "pocketfft_hdronly.h"
 
 namespace sstvae::dsp {

--- a/native/tests/test_golden.cpp
+++ b/native/tests/test_golden.cpp
@@ -200,8 +200,13 @@ void test_dsp() {
     check::close(dsp::hilbert(x_odd), load_c16(g("dsp/hilbert_odd")), 1e-11,
                  "dsp/hilbert at odd length (the other mask branch)");
 
+    // FFT-based here (pocketfft) against a direct-sum-equivalent Python
+    // reference (scipy.signal.fftconvolve, itself within 1e-15 of the
+    // np.convolve values the golden vector was generated from) -- same
+    // "FFT sums 4096 terms" cross-implementation spread as dsp/hilbert
+    // just above, hence the same bound.
     check::close(dsp::sync_lowpass(dsp::to_baseband(x)),
-                 load_c16(g("dsp/sync_lowpass")), 1e-13, "dsp/sync_lowpass");
+                 load_c16(g("dsp/sync_lowpass")), 1e-11, "dsp/sync_lowpass");
 
     const std::vector<double> papr = load_f8(g("dsp/papr_db"));
     check::close(std::vector<double>{dsp::papr_db(x)}, papr, 1e-11, "dsp/papr_db");

--- a/sstvae/modem/dsp.py
+++ b/sstvae/modem/dsp.py
@@ -47,9 +47,18 @@ def to_baseband(x: np.ndarray) -> np.ndarray:
 def sync_lowpass(z: np.ndarray) -> np.ndarray:
     """Selective lowpass used only for preamble detection, where FIR
     smearing is harmless and out-of-band noise would degrade the
-    autocorrelation metric."""
+    autocorrelation metric.
+
+    FFT-based rather than a direct sum: `acquire()` runs this over the
+    whole ring-buffer snapshot (up to the full ~130 s capacity) on every
+    poll, not just a bounded search window, and the direct convolution
+    was measured as the single largest item in a live decode-loop
+    profile -- a per-poll cost that scaled with total buffer duration
+    rather than with anything acquisition actually needs. `convolve_same`
+    stays a direct sum for its other caller (`tx_condition`'s clip
+    filter), which runs once per transmit, not every poll."""
     taps = signal.firwin(129, 850.0, fs=FS)
-    return np.convolve(z, taps, mode="same")
+    return signal.fftconvolve(z, taps, mode="same")
 
 
 def wrap_cycles(cycles: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
A few basically-free changes to reduce the CPU used while waiting to acquire a signal:

* Enable plan caching in PocketFFT so that it doesn't recalculate the plan on every FFT call
* Don't recalculate the windowing function for the audio resampler on every block of audio
* Use a more efficient filter method in the preamble sync detector

All together these reduce the total CPU usage of SSTVAE by about 5%.