### PR TITLE
Respect EXIF orientation when loading pictures

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -117,6 +117,9 @@ add_library(sstvae_core STATIC
   core/optimize/speculative.cpp
   core/overlay/model.cpp
   core/sync/sync.cpp
+  # Vendored, and the only non-header-only one -- see
+  # third_party/easyexif/README.md. Read for JPEG orientation alone.
+  third_party/easyexif/exif.cpp
 )
 target_include_directories(sstvae_core PUBLIC core third_party/pocketfft)
 # stb is SYSTEM: 20k lines of vendored single-header C that is not

--- a/native/bindings/module/module.cpp
+++ b/native/bindings/module/module.cpp
@@ -665,6 +665,10 @@ PYBIND11_MODULE(sstvae_native, m) {
     images.attr("IMG_H") = sstvae::images::IMG_H;
     images.attr("MIN_W") = sstvae::images::MIN_W;
     images.attr("MIN_H") = sstvae::images::MIN_H;
+    // Exposed so the parity suite can assert the two implementations
+    // refuse the same files, rather than each asserting its own copy of
+    // the number.
+    images.attr("MAX_FILE_BYTES") = sstvae::images::MAX_FILE_BYTES;
 
 #ifdef SSTVAE_HAVE_CODEC
     // --- codec ---------------------------------------------------------

--- a/native/core/images/images.cpp
+++ b/native/core/images/images.cpp
@@ -2,7 +2,15 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
 #include <stdexcept>
+#include <vector>
+
+// Vendored; read for the orientation tag alone. See
+// native/third_party/easyexif/README.md.
+#include "easyexif/exif.h"
 
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_FAILURE_USERMSG
@@ -15,6 +23,37 @@
 #include "stb_image_resize2.h"
 
 namespace sstvae::images {
+namespace {
+
+// Whole file into memory. Both consumers -- the stb decoder and the
+// EXIF parser -- want the bytes rather than a path, and a picture is
+// already being held decoded at several times this size.
+std::vector<std::uint8_t> read_file(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) throw std::runtime_error("cannot read " + path);
+    std::vector<std::uint8_t> bytes;
+    in.seekg(0, std::ios::end);
+    const std::streamoff size = in.tellg();
+    if (size < 0) throw std::runtime_error("cannot read " + path);
+    // Refused before the allocation, not after -- the point is to not
+    // reserve a gigabyte on the strength of a file name. The message
+    // names the size, because the usual cause is a file that is not a
+    // picture at all and the operator will recognise it by its length.
+    if (static_cast<std::uintmax_t>(size) > MAX_FILE_BYTES) {
+        throw std::runtime_error(path + " is " + std::to_string(size) +
+                                 " bytes; the limit for a picture file is " +
+                                 std::to_string(MAX_FILE_BYTES));
+    }
+    in.seekg(0, std::ios::beg);
+    bytes.resize(static_cast<std::size_t>(size));
+    if (size > 0) {
+        in.read(reinterpret_cast<char*>(bytes.data()), size);
+        if (!in) throw std::runtime_error("cannot read " + path);
+    }
+    return bytes;
+}
+
+}  // namespace
 
 Picture resize(const Picture& img, int width, int height) {
     if (img.width == width && img.height == height) return img;
@@ -108,18 +147,130 @@ ImageArray to_array(const Picture& img) {
     return out;
 }
 
+namespace {
+
+// PNG stores EXIF in an `eXIf` chunk holding a bare TIFF stream -- no
+// `Exif\0\0` signature, which is what a JPEG APP1 segment carries and
+// what easyexif's segment entry point expects. So the chunk is located
+// here and the signature prepended, leaving the TIFF parsing (byte
+// order, IFD offsets, bounds) where it belongs: in the vendored code.
+//
+// Walking PNG chunks is not the same kind of undertaking as walking a
+// TIFF: every chunk is a 4-byte big-endian length followed by a 4-byte
+// type, so the whole walk is bounds-checkable by inspection and there
+// are no internal offsets that can point anywhere.
+//
+// Pillow honours this chunk, so not reading it would mean a tagged PNG
+// rotating in `sstvae/images.py` and not here -- exactly the silent,
+// consequential disagreement the parity test exists to prevent.
+std::vector<std::uint8_t> png_exif_segment(const std::uint8_t* data, std::size_t len) {
+    static constexpr std::uint8_t SIGNATURE[8] = {0x89, 0x50, 0x4E, 0x47,
+                                                  0x0D, 0x0A, 0x1A, 0x0A};
+    if (len < sizeof(SIGNATURE) || !std::equal(SIGNATURE, SIGNATURE + sizeof(SIGNATURE), data)) {
+        return {};
+    }
+    std::size_t pos = sizeof(SIGNATURE);
+    while (pos + 8 <= len) {
+        const std::size_t size = (static_cast<std::size_t>(data[pos]) << 24) |
+                                 (static_cast<std::size_t>(data[pos + 1]) << 16) |
+                                 (static_cast<std::size_t>(data[pos + 2]) << 8) |
+                                 static_cast<std::size_t>(data[pos + 3]);
+        const std::uint8_t* type = data + pos + 4;
+        const std::size_t body = pos + 8;
+        // The 4-byte CRC follows the body. Overflow is not reachable --
+        // `size` is at most 2^32-1 and `body` at most `len` -- but the
+        // comparison is written so it would not matter if it were.
+        if (size > len || body > len - size || body + size + 4 > len) break;
+        if (std::equal(type, type + 4, "eXIf")) {
+            std::vector<std::uint8_t> out = {'E', 'x', 'i', 'f', 0x00, 0x00};
+            out.insert(out.end(), data + body, data + body + size);
+            return out;
+        }
+        pos = body + size + 4;
+    }
+    return {};
+}
+
+}  // namespace
+
+int exif_orientation(const std::uint8_t* data, std::size_t len) {
+    if (data == nullptr || len == 0) return 1;
+    easyexif::EXIFInfo info;
+    // Anything either parser objects to -- not a JPEG or PNG, no EXIF, a
+    // truncated or corrupt segment -- is an unrotated picture, not a
+    // failure. The return code is deliberately not distinguished: there
+    // is nothing a caller could do differently with "no EXIF" than with
+    // "corrupt".
+    const std::vector<std::uint8_t> png = png_exif_segment(data, len);
+    const int status =
+        png.empty()
+            ? info.parseFrom(data, static_cast<unsigned>(len))
+            : info.parseFromEXIFSegment(png.data(), static_cast<unsigned>(png.size()));
+    if (status != PARSE_EXIF_SUCCESS) return 1;
+    const int value = static_cast<int>(info.Orientation);
+    // 0 is easyexif's "tag absent"; anything above 8 is undefined in the
+    // spec and has been seen in the wild from buggy writers.
+    return (value >= 1 && value <= 8) ? value : 1;
+}
+
+Picture apply_orientation(const Picture& img, int orientation) {
+    if (orientation <= 1 || orientation > 8 || img.empty()) return img;
+
+    // Each case is the *inverse* map: where in the source does the
+    // destination pixel come from. Written out rather than composed from
+    // flip/transpose flags because the composition order is exactly the
+    // thing that is easy to get backwards, and eight explicit lines can
+    // be read against the spec's table one at a time.
+    //
+    // 5..8 exchange the axes, so the output's geometry changes -- which
+    // is the whole point, and why this must run before `fit` decides
+    // what to crop.
+    const int sw = img.width, sh = img.height;
+    const bool swap_axes = orientation >= 5;
+    Picture out(swap_axes ? sh : sw, swap_axes ? sw : sh);
+
+    for (int dy = 0; dy < out.height; ++dy) {
+        for (int dx = 0; dx < out.width; ++dx) {
+            int sx = 0, sy = 0;
+            switch (orientation) {
+                case 2: sx = sw - 1 - dx; sy = dy;             break;  // mirror
+                case 3: sx = sw - 1 - dx; sy = sh - 1 - dy;    break;  // 180
+                case 4: sx = dx;          sy = sh - 1 - dy;    break;  // flip
+                case 5: sx = dy;          sy = dx;             break;  // transpose
+                case 6: sx = dy;          sy = sh - 1 - dx;    break;  // 90 CW
+                case 7: sx = sw - 1 - dy; sy = sh - 1 - dx;    break;  // transverse
+                case 8: sx = sw - 1 - dy; sy = dx;             break;  // 90 CCW
+                default: sx = dx;         sy = dy;             break;
+            }
+            const std::size_t src = (static_cast<std::size_t>(sy) * sw + sx) * 3;
+            const std::size_t dst = (static_cast<std::size_t>(dy) * out.width + dx) * 3;
+            out.rgb[dst] = img.rgb[src];
+            out.rgb[dst + 1] = img.rgb[src + 1];
+            out.rgb[dst + 2] = img.rgb[src + 2];
+        }
+    }
+    return out;
+}
+
 Picture load(const std::string& path) {
+    // Read the file once and decode from memory, because the orientation
+    // tag and the pixels come from the same bytes: stb ignores EXIF, and
+    // easyexif wants the whole file. `stbi_load(path, ...)` would mean
+    // opening it twice.
+    std::vector<std::uint8_t> bytes = read_file(path);
+
     int w = 0, h = 0, channels = 0;
     // Forced to 3 channels: an RGBA or greyscale source is converted the
     // way `Image.convert("RGB")` would.
-    std::uint8_t* data = stbi_load(path.c_str(), &w, &h, &channels, 3);
+    std::uint8_t* data = stbi_load_from_memory(bytes.data(), static_cast<int>(bytes.size()),
+                                               &w, &h, &channels, 3);
     if (data == nullptr) {
         throw std::runtime_error("cannot read " + path + ": " + stbi_failure_reason());
     }
     Picture out(w, h);
     std::copy(data, data + static_cast<std::size_t>(w) * h * 3, out.rgb.begin());
     stbi_image_free(data);
-    return out;
+    return apply_orientation(out, exif_orientation(bytes.data(), bytes.size()));
 }
 
 ImageArray load_array(const std::string& path) { return to_array(fit(load(path))); }

--- a/native/core/images/images.hpp
+++ b/native/core/images/images.hpp
@@ -13,6 +13,8 @@
 #ifndef SSTVAE_IMAGES_IMAGES_HPP
 #define SSTVAE_IMAGES_IMAGES_HPP
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -71,8 +73,41 @@ Picture fit(const Picture& img, const Framing& framing);
 // Exact: a transpose and a divide by 255.
 ImageArray to_array(const Picture& img);
 
+// The largest picture file that will be opened at all. `load` reads the
+// whole file into memory before decoding -- both the decoder and the
+// EXIF parser want the bytes -- so an absurd file is refused up front
+// rather than allocated for. A GiB is far above any real photograph and
+// far below what would trouble a desktop, so it is a guard against a
+// mistake (a WAV, a disk image, a truncated download of something else)
+// rather than a limit anyone should meet.
+inline constexpr std::size_t MAX_FILE_BYTES = 1024u * 1024u * 1024u;
+
+// The EXIF orientation tag (0x0112), 1..8, as it appears in a JPEG's
+// APP1 segment. 1 is the identity: stored top-left, no transform.
+// Values 5..8 exchange width and height.
+//
+// Returns 1 for a file with no EXIF, no orientation tag, a value
+// outside 1..8, or metadata too corrupt to parse -- an unreadable tag
+// costs the operator a rotation, never the picture. `data` is the whole
+// file, not a segment.
+int exif_orientation(const std::uint8_t* data, std::size_t len);
+
+// Undo an EXIF orientation, producing the upright picture. Orientation
+// 1 (and anything outside 1..8) returns the input untouched.
+//
+// The counterpart of Pillow's `ImageOps.exif_transpose`, and required
+// to agree with it exactly -- `tests/test_native_parity.py -k exif`
+// holds both implementations to the same eight results, since a
+// disagreement here is a rotated transmission rather than an error.
+Picture apply_orientation(const Picture& img, int orientation);
+
 // Open any stb-readable picture (PNG, JPEG, BMP, GIF, TGA, ...).
 // Throws with the file name and stb's reason on failure.
+//
+// JPEG orientation metadata is applied here, so everything downstream
+// -- `fit`'s framing above all -- sees the picture the way it was
+// taken. stb decodes pixels and ignores EXIF entirely; the tag is read
+// separately (third_party/easyexif).
 Picture load(const std::string& path);
 
 // Cover-resize, centre-crop, convert -- `images.load_image`.

--- a/native/tests/CMakeLists.txt
+++ b/native/tests/CMakeLists.txt
@@ -37,6 +37,14 @@ target_include_directories(test_framing PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME framing COMMAND test_framing)
 set_tests_properties(framing PROPERTIES TIMEOUT 180)
 
+# EXIF orientation. Writes JPEGs, so it is given a directory to write
+# them in rather than dropping them in whatever the runner's cwd is.
+add_executable(test_images test_images.cpp)
+target_link_libraries(test_images PRIVATE sstvae_core)
+target_include_directories(test_images PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME images COMMAND test_images ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(images PROPERTIES TIMEOUT 120)
+
 add_executable(test_beacon test_beacon.cpp)
 target_link_libraries(test_beacon PRIVATE sstvae_core)
 target_include_directories(test_beacon PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/native/tests/test_images.cpp
+++ b/native/tests/test_images.cpp
@@ -1,0 +1,453 @@
+// EXIF orientation: the transform, the tag reader, and the load path
+// that joins them.
+//
+// The transform is eight cases of index arithmetic, and the way it goes
+// wrong is not subtle in its effect (a sideways picture) but is very
+// easy to get backwards in the source: `dst(x,y) = src(y,x)` and its
+// seven relatives all look equally plausible on the page. So the oracle
+// here is a *second derivation* -- each orientation expressed as a
+// composition of three primitives (transpose, mirror-x, mirror-y) taken
+// straight from the EXIF table -- rather than a restatement of the same
+// inverse maps, which would only prove the file was copied correctly.
+//
+// The tag reader is vendored (third_party/easyexif), so what is checked
+// here is not its parsing but *our* handling of what it returns: the
+// defaults on a file it rejects, and the range clamp. Those are the
+// lines that decide whether a corrupt photo loads sideways or not at
+// all.
+
+#include "images/images.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "check.hpp"
+#include "images/types.hpp"
+#include "stb_image_write.h"
+
+namespace check = sstvae::check;
+using sstvae::images::Picture;
+
+namespace {
+
+// Every pixel encodes its own position, and no two of the eight
+// transforms of it are equal -- which is what makes a wrong case
+// visible rather than absorbed by symmetry. Deliberately non-square for
+// the same reason: 5..8 must exchange the axes.
+Picture ramp(int width, int height) {
+    Picture p(width, height);
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            const std::size_t i = (static_cast<std::size_t>(y) * width + x) * 3;
+            p.rgb[i] = static_cast<std::uint8_t>(x * 3 % 251);
+            p.rgb[i + 1] = static_cast<std::uint8_t>(y * 7 % 241);
+            p.rgb[i + 2] = static_cast<std::uint8_t>((x * 5 + y * 11) % 239);
+        }
+    }
+    return p;
+}
+
+// --- the independent derivation ---------------------------------------
+//
+// The EXIF table says which corner of the *stored* picture holds the
+// visual top-left, and each row of it is naturally read as a sequence of
+// these three primitives. Composing them is a different mental operation
+// from writing an inverse map, which is the point.
+
+Picture transpose(const Picture& p) {
+    Picture out(p.height, p.width);
+    for (int y = 0; y < out.height; ++y) {
+        for (int x = 0; x < out.width; ++x) {
+            const std::size_t d = (static_cast<std::size_t>(y) * out.width + x) * 3;
+            const std::size_t s = (static_cast<std::size_t>(x) * p.width + y) * 3;
+            for (int c = 0; c < 3; ++c) out.rgb[d + c] = p.rgb[s + c];
+        }
+    }
+    return out;
+}
+
+Picture mirror_x(const Picture& p) {
+    Picture out(p.width, p.height);
+    for (int y = 0; y < p.height; ++y) {
+        for (int x = 0; x < p.width; ++x) {
+            const std::size_t d = (static_cast<std::size_t>(y) * p.width + x) * 3;
+            const std::size_t s =
+                (static_cast<std::size_t>(y) * p.width + (p.width - 1 - x)) * 3;
+            for (int c = 0; c < 3; ++c) out.rgb[d + c] = p.rgb[s + c];
+        }
+    }
+    return out;
+}
+
+Picture mirror_y(const Picture& p) {
+    Picture out(p.width, p.height);
+    for (int y = 0; y < p.height; ++y) {
+        const std::size_t d = static_cast<std::size_t>(y) * p.width * 3;
+        const std::size_t s = static_cast<std::size_t>(p.height - 1 - y) * p.width * 3;
+        std::copy(p.rgb.begin() + s, p.rgb.begin() + s + p.width * 3, out.rgb.begin() + d);
+    }
+    return out;
+}
+
+// Transpose first where it appears; the two mirrors commute, so their
+// relative order is not a choice this has to make.
+Picture reference_orientation(const Picture& p, int orientation) {
+    switch (orientation) {
+        case 1: return p;                                   // top-left
+        case 2: return mirror_x(p);                         // top-right
+        case 3: return mirror_y(mirror_x(p));               // bottom-right
+        case 4: return mirror_y(p);                         // bottom-left
+        case 5: return transpose(p);                        // left-top
+        case 6: return mirror_x(transpose(p));              // right-top
+        case 7: return mirror_y(mirror_x(transpose(p)));    // right-bottom
+        case 8: return mirror_y(transpose(p));              // left-bottom
+        default: return p;
+    }
+}
+
+void test_orientation_matches_the_exif_table() {
+    const Picture src = ramp(37, 23);  // odd both ways: no accidental symmetry
+    for (int o = 1; o <= 8; ++o) {
+        const Picture got = sstvae::images::apply_orientation(src, o);
+        const Picture want = reference_orientation(src, o);
+        const std::string label = "orientation " + std::to_string(o);
+        check::equal(got.width, want.width, "images/exif: width, " + label);
+        check::equal(got.height, want.height, "images/exif: height, " + label);
+        check::is_true(got.rgb == want.rgb, "images/exif: pixels, " + label);
+    }
+}
+
+void test_the_eight_transforms_are_distinguishable() {
+    // Without this the test above could pass on a picture symmetric
+    // enough that several cases coincide -- and then a swapped pair of
+    // cases would be invisible. Asserting the sample's fitness for
+    // purpose, not the code.
+    const Picture src = ramp(37, 23);
+    for (int a = 1; a <= 8; ++a) {
+        for (int b = a + 1; b <= 8; ++b) {
+            const Picture pa = sstvae::images::apply_orientation(src, a);
+            const Picture pb = sstvae::images::apply_orientation(src, b);
+            check::is_true(pa.width != pb.width || pa.height != pb.height || pa.rgb != pb.rgb,
+                           "images/exif: transforms " + std::to_string(a) + " and " +
+                               std::to_string(b) + " differ on the test picture");
+        }
+    }
+}
+
+void test_axes_swap_only_above_four() {
+    const Picture src = ramp(37, 23);
+    for (int o = 1; o <= 8; ++o) {
+        const Picture got = sstvae::images::apply_orientation(src, o);
+        const bool swapped = got.width == src.height && got.height == src.width;
+        check::equal(swapped, o >= 5,
+                     "images/exif: axes exchanged iff orientation >= 5, at " +
+                         std::to_string(o));
+    }
+}
+
+void test_out_of_range_is_the_identity() {
+    const Picture src = ramp(9, 5);
+    // 0 is easyexif's "absent"; 9 and above are undefined in the spec.
+    // Both must leave the picture alone rather than fall through to some
+    // case's arithmetic.
+    for (int o : {-3, 0, 1, 9, 65535}) {
+        const Picture got = sstvae::images::apply_orientation(src, o);
+        check::is_true(got.width == src.width && got.height == src.height &&
+                           got.rgb == src.rgb,
+                       "images/exif: orientation " + std::to_string(o) + " is the identity");
+    }
+}
+
+// --- the tag reader ----------------------------------------------------
+
+// A minimal but real APP1 segment: TIFF header, one IFD entry holding
+// tag 0x0112, no next IFD. Big-endian ("MM"), so the byte order path is
+// the non-native one on every machine this is built for.
+std::vector<std::uint8_t> app1_segment(int orientation) {
+    std::vector<std::uint8_t> tiff = {
+        'M',  'M',  0x00, 0x2a,              // byte order, magic
+        0x00, 0x00, 0x00, 0x08,              // offset of IFD0
+        0x00, 0x01,                          // one entry
+        0x01, 0x12,                          // tag: Orientation
+        0x00, 0x03,                          // type: SHORT
+        0x00, 0x00, 0x00, 0x01,              // count
+        static_cast<std::uint8_t>(orientation >> 8),
+        static_cast<std::uint8_t>(orientation & 0xff),
+        0x00, 0x00,                          // value, left-aligned in 4 bytes
+        0x00, 0x00, 0x00, 0x00,              // no next IFD
+    };
+    std::vector<std::uint8_t> body = {'E', 'x', 'i', 'f', 0x00, 0x00};
+    body.insert(body.end(), tiff.begin(), tiff.end());
+
+    const std::size_t length = body.size() + 2;  // the length field counts itself
+    std::vector<std::uint8_t> seg = {0xFF, 0xE1,
+                                     static_cast<std::uint8_t>(length >> 8),
+                                     static_cast<std::uint8_t>(length & 0xff)};
+    seg.insert(seg.end(), body.begin(), body.end());
+    return seg;
+}
+
+std::vector<std::uint8_t> jpeg_bytes(const Picture& p) {
+    std::vector<std::uint8_t> out;
+    stbi_write_jpg_to_func(
+        [](void* ctx, void* data, int size) {
+            auto* v = static_cast<std::vector<std::uint8_t>*>(ctx);
+            const auto* b = static_cast<const std::uint8_t*>(data);
+            v->insert(v->end(), b, b + size);
+        },
+        &out, p.width, p.height, 3, p.rgb.data(), 95);
+    return out;
+}
+
+// A JPEG with the segment spliced in immediately after SOI, which is
+// where a camera puts it.
+std::vector<std::uint8_t> jpeg_with_orientation(const Picture& p, int orientation) {
+    std::vector<std::uint8_t> jpeg = jpeg_bytes(p);
+    const std::vector<std::uint8_t> app1 = app1_segment(orientation);
+    jpeg.insert(jpeg.begin() + 2, app1.begin(), app1.end());
+    return jpeg;
+}
+
+void write_bytes(const std::string& path, const std::vector<std::uint8_t>& bytes) {
+    std::ofstream out(path, std::ios::binary);
+    out.write(reinterpret_cast<const char*>(bytes.data()),
+              static_cast<std::streamsize>(bytes.size()));
+}
+
+void test_tag_is_read_from_a_jpeg() {
+    const Picture src = ramp(32, 16);
+    for (int o = 1; o <= 8; ++o) {
+        const std::vector<std::uint8_t> jpeg = jpeg_with_orientation(src, o);
+        check::equal(sstvae::images::exif_orientation(jpeg.data(), jpeg.size()), o,
+                     "images/exif: tag read back, orientation " + std::to_string(o));
+    }
+}
+
+void test_unreadable_metadata_defaults_to_upright() {
+    const Picture src = ramp(32, 16);
+    const std::vector<std::uint8_t> plain = jpeg_bytes(src);
+    const std::vector<std::uint8_t> tagged = jpeg_with_orientation(src, 6);
+
+    // No EXIF at all.
+    check::equal(sstvae::images::exif_orientation(plain.data(), plain.size()), 1,
+                 "images/exif: a JPEG with no APP1 reads as upright");
+    // Nothing at all.
+    check::equal(sstvae::images::exif_orientation(nullptr, 0), 1,
+                 "images/exif: an empty buffer reads as upright");
+    // Not a JPEG.
+    const std::vector<std::uint8_t> junk(64, 0xAB);
+    check::equal(sstvae::images::exif_orientation(junk.data(), junk.size()), 1,
+                 "images/exif: junk reads as upright");
+    // An APP1 that claims more bytes than are present -- the shape a
+    // truncated download has, and the one that must not read past the
+    // end. Cut inside the segment, after the length field.
+    for (std::size_t cut : {tagged.size() - 4, tagged.size() / 2, std::size_t{8}}) {
+        const std::vector<std::uint8_t> truncated(tagged.begin(), tagged.begin() + cut);
+        const int got = sstvae::images::exif_orientation(truncated.data(), truncated.size());
+        check::is_true(got >= 1 && got <= 8,
+                       "images/exif: a truncated file yields a legal orientation");
+    }
+    // A value outside the spec's range, which buggy writers do emit.
+    for (int bad : {0, 9, 240}) {
+        const std::vector<std::uint8_t> odd = jpeg_with_orientation(src, bad);
+        check::equal(sstvae::images::exif_orientation(odd.data(), odd.size()), 1,
+                     "images/exif: out-of-range tag " + std::to_string(bad) +
+                         " reads as upright");
+    }
+}
+
+// A PNG carries EXIF in an `eXIf` chunk holding a bare TIFF stream --
+// no `Exif\0\0` signature. Nothing here validates CRCs, so a synthetic
+// buffer exercises the chunk walk without needing a PNG encoder or a
+// CRC32: the walk is what is under test, and it is reached the same way
+// by a real file.
+std::vector<std::uint8_t> png_chunk(const std::string& type,
+                                    const std::vector<std::uint8_t>& body) {
+    const std::size_t n = body.size();
+    std::vector<std::uint8_t> out = {
+        static_cast<std::uint8_t>((n >> 24) & 0xff), static_cast<std::uint8_t>((n >> 16) & 0xff),
+        static_cast<std::uint8_t>((n >> 8) & 0xff),  static_cast<std::uint8_t>(n & 0xff),
+    };
+    out.insert(out.end(), type.begin(), type.end());
+    out.insert(out.end(), body.begin(), body.end());
+    out.insert(out.end(), 4, 0x00);  // CRC, unchecked
+    return out;
+}
+
+std::vector<std::uint8_t> png_with_orientation(int orientation) {
+    std::vector<std::uint8_t> png = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+    // A chunk before it, so a walk that only ever looks at the first one
+    // fails here rather than passing by luck.
+    const std::vector<std::uint8_t> ihdr(13, 0x01);
+    const std::vector<std::uint8_t> header = png_chunk("IHDR", ihdr);
+    png.insert(png.end(), header.begin(), header.end());
+
+    // The APP1 body without its `Exif\0\0` prefix -- which is exactly
+    // what a PNG stores and what the code under test has to re-add.
+    const std::vector<std::uint8_t> app1 = app1_segment(orientation);
+    const std::vector<std::uint8_t> tiff(app1.begin() + 4 + 6, app1.end());
+    const std::vector<std::uint8_t> exif = png_chunk("eXIf", tiff);
+    png.insert(png.end(), exif.begin(), exif.end());
+    return png;
+}
+
+void test_png_exif_chunk_is_read() {
+    // Pillow reads this chunk, so not reading it would mean a tagged PNG
+    // rotating on one side of the port and not the other.
+    for (int o = 1; o <= 8; ++o) {
+        const std::vector<std::uint8_t> png = png_with_orientation(o);
+        check::equal(sstvae::images::exif_orientation(png.data(), png.size()), o,
+                     "images/exif: PNG eXIf chunk, orientation " + std::to_string(o));
+    }
+
+    // A chunk whose declared length runs past the end -- the walk must
+    // stop rather than read past it.
+    std::vector<std::uint8_t> truncated = png_with_orientation(6);
+    truncated.resize(truncated.size() - 6);
+    const int got = sstvae::images::exif_orientation(truncated.data(), truncated.size());
+    check::equal(got, 1, "images/exif: a truncated eXIf chunk reads as upright");
+
+    // A PNG with no eXIf chunk at all.
+    std::vector<std::uint8_t> plain = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+    const std::vector<std::uint8_t> ihdr = png_chunk("IHDR", std::vector<std::uint8_t>(13, 0x01));
+    plain.insert(plain.end(), ihdr.begin(), ihdr.end());
+    check::equal(sstvae::images::exif_orientation(plain.data(), plain.size()), 1,
+                 "images/exif: a PNG with no eXIf chunk reads as upright");
+}
+
+// --- the two joined ----------------------------------------------------
+
+void test_load_applies_the_tag(const std::string& tmpdir) {
+    // JPEG is lossy, so this checks geometry and gross structure rather
+    // than pixels -- the exact-transform claim is the tests above. What
+    // it does prove is that `load` reads the tag and acts on it at all,
+    // which no unit test of either half can.
+    const Picture src = ramp(64, 32);
+    for (int o = 1; o <= 8; ++o) {
+        const std::string path = tmpdir + "/exif_" + std::to_string(o) + ".jpg";
+        write_bytes(path, jpeg_with_orientation(src, o));
+        const Picture got = sstvae::images::load(path);
+        const Picture want = reference_orientation(src, o);
+        const std::string label = "orientation " + std::to_string(o);
+        check::equal(got.width, want.width, "images/exif: loaded width, " + label);
+        check::equal(got.height, want.height, "images/exif: loaded height, " + label);
+
+        // Mean absolute error against the intended transform, versus the
+        // best of the other seven. A tolerance alone could be met by a
+        // picture that is merely blurry; requiring the right transform to
+        // win by a margin is what makes this a test of the transform.
+        double best_wrong = 1e9;
+        for (int other = 1; other <= 8; ++other) {
+            if (other == o) continue;
+            const Picture cand = reference_orientation(src, other);
+            if (cand.width != got.width || cand.height != got.height) continue;
+            double err = 0.0;
+            for (std::size_t i = 0; i < got.rgb.size(); ++i) {
+                err += std::abs(static_cast<double>(got.rgb[i]) - cand.rgb[i]);
+            }
+            best_wrong = std::min(best_wrong, err / got.rgb.size());
+        }
+        double err = 0.0;
+        for (std::size_t i = 0; i < got.rgb.size(); ++i) {
+            err += std::abs(static_cast<double>(got.rgb[i]) - want.rgb[i]);
+        }
+        err /= got.rgb.size();
+        check::is_true(err < 8.0, "images/exif: loaded picture matches the transform, " +
+                                      label + " (mae " + std::to_string(err) + ")");
+        check::is_true(err * 3.0 < best_wrong,
+                       "images/exif: the intended transform beats every other, " + label +
+                           " (mae " + std::to_string(err) + " vs " +
+                           std::to_string(best_wrong) + ")");
+    }
+}
+
+void test_an_enormous_file_is_refused(const std::string& tmpdir) {
+    // A *sparse* file: `resize_file` sets the length without writing the
+    // bytes on every filesystem this is built for (ext4, APFS, NTFS), so
+    // this costs no disk and no time. If the platform declines, the
+    // check is skipped rather than failed -- an unwritable temp
+    // directory is not evidence about the loader.
+    const std::string path = tmpdir + "/enormous.jpg";
+    {
+        std::ofstream create(path, std::ios::binary);
+        if (!create) return;
+    }
+    std::error_code ec;
+    std::filesystem::resize_file(path, sstvae::images::MAX_FILE_BYTES + 1, ec);
+    if (ec) {
+        std::filesystem::remove(path, ec);
+        return;
+    }
+
+    const auto load_error = [&](const std::string& p) {
+        try {
+            sstvae::images::load(p);
+        } catch (const std::exception& e) {
+            return std::string(e.what());
+        }
+        return std::string();
+    };
+
+    // Refused *for its size*, which is the claim. A file this large is
+    // not a valid JPEG either, so asserting only that something was
+    // thrown would pass with the limit deleted -- the decoder would
+    // reject it a moment later and a gigabyte further on.
+    const std::string over = load_error(path);
+    check::is_true(over.find("limit") != std::string::npos,
+                   "images/limit: a file above MAX_FILE_BYTES is refused for its size "
+                   "(got: " +
+                       over + ")");
+
+    // The boundary is inclusive: at exactly the limit the file reaches
+    // the decoder and fails there instead, with stb's message. Resized
+    // before the removal below -- deleting it first is how the first
+    // draft of this silently skipped everything after this point.
+    std::filesystem::resize_file(path, sstvae::images::MAX_FILE_BYTES, ec);
+    const std::string message = ec ? std::string() : load_error(path);
+    std::filesystem::remove(path, ec);
+    if (message.empty()) return;
+    check::is_true(message.find("limit") == std::string::npos,
+                   "images/limit: a file at exactly the limit is not refused for size "
+                   "(got: " +
+                       message + ")");
+}
+
+void test_a_png_is_untouched(const std::string& tmpdir) {
+    // No EXIF path exists for PNG here, and the orientation reader must
+    // not corrupt the load of one. Lossless, so this is exact.
+    const Picture src = ramp(19, 41);
+    const std::string path = tmpdir + "/plain.png";
+    sstvae::images::save_png(src, path);
+    const Picture got = sstvae::images::load(path);
+    check::equal(got.width, src.width, "images/exif: PNG width unchanged");
+    check::equal(got.height, src.height, "images/exif: PNG height unchanged");
+    check::is_true(got.rgb == src.rgb, "images/exif: PNG pixels unchanged");
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    check::report_crashes_instead_of_prompting();
+    const std::string tmpdir = argc > 1 ? argv[1] : ".";
+
+    test_orientation_matches_the_exif_table();
+    test_the_eight_transforms_are_distinguishable();
+    test_axes_swap_only_above_four();
+    test_out_of_range_is_the_identity();
+    test_tag_is_read_from_a_jpeg();
+    test_unreadable_metadata_defaults_to_upright();
+    test_png_exif_chunk_is_read();
+    test_load_applies_the_tag(tmpdir);
+    test_an_enormous_file_is_refused(tmpdir);
+    test_a_png_is_untouched(tmpdir);
+
+    return check::report("images");
+}

--- a/native/third_party/easyexif/LICENSE
+++ b/native/third_party/easyexif/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2010-2015 Mayank Lahiri
+mlahiri@gmail.com
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+-- Redistributions of source code must retain the above copyright notice, 
+	this list of conditions and the following disclaimer.
+-- Redistributions in binary form must reproduce the above copyright notice, 
+	this list of conditions and the following disclaimer in the documentation 
+	and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY EXPRESS 
+	OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN 
+	NO EVENT SHALL THE FREEBSD PROJECT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+	INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+	DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY 
+	OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+	EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/native/third_party/easyexif/README.md
+++ b/native/third_party/easyexif/README.md
@@ -1,0 +1,70 @@
+# easyexif (vendored)
+
+`exif.h` and `exif.cpp` from https://github.com/mayanklahiri/easyexif,
+branch `master`, commit `cd994a3b6009bc3c1f84062e96bd7f5ad16e85f6`
+(2020-05-22), fetched 2026-08-06. BSD-2-Clause -- see `LICENSE`, which
+is upstream's own file.
+
+**Vendored rather than fetched at configure time**, for the same reason
+as `../pocketfft` and `../stb`: two files with no build system of their
+own, and a `FetchContent` would make every CI job on three platforms
+depend on GitHub being reachable during `cmake`. Updating means
+replacing two files.
+
+Unlike the other four vendored libraries this one is not header-only,
+so `exif.cpp` is listed in `sstvae_core`'s sources. It compiles clean
+under `-Wall -Wextra`, so it is *not* given the `-w` treatment stb gets
+-- if a future update introduces warnings, suppress them then rather
+than pre-emptively.
+
+## What it is used for
+
+Exactly one field: `EXIFInfo::Orientation`, read by
+`core/images/images.cpp` so a phone photograph is framed the way it was
+taken. Nothing else in the struct is looked at. The library is doing
+the part that is genuinely fiddly and easy to get subtly wrong --
+walking the JPEG marker segments to find APP1, the `II`/`MM` byte
+order, the TIFF IFD offsets, and bounds-checking all of it against a
+possibly-hostile file. Applying the resulting transform to the pixels
+is ours (`images::apply_orientation`), because that part is eight cases
+of index arithmetic with no format subtleties in it.
+
+One other thing stayed ours, and it is worth knowing why. easyexif
+parses **JPEG only**, but Pillow also honours orientation in a PNG
+`eXIf` chunk -- so leaving PNG alone would have meant a tagged file
+rotating in `sstvae/images.py` and not here, silently. `images.cpp`
+therefore locates that chunk itself and prepends the `Exif\0\0`
+signature a PNG omits, handing the TIFF stream to
+`parseFromEXIFSegment`. That keeps the split intact: walking PNG chunks
+is a length-prefixed scan that is bounds-checkable by inspection, with
+no internal offsets that can point anywhere, which is not the kind of
+thing TIFF is.
+
+## Why this one
+
+The alternative considered was
+[TinyEXIF](https://github.com/cdcseacave/TinyEXIF) (MIT, also two
+files). Two things decided it:
+
+- easyexif's documented entry point is a **memory buffer**
+  (`parseFrom(data, len)`), which is the shape `images::load` needs
+  since it hands the same bytes to `stbi_load_from_memory`. TinyEXIF's
+  documented usage is stream-based.
+- TinyEXIF parses XMP as well, which needs tinyxml2. It is optional,
+  but it makes "which dependencies does this pull in" a build
+  configuration question, for a feature this project has no use for.
+
+The tradeoff accepted in exchange: easyexif is **dormant** -- 41
+commits, nothing since May 2020. That matters much less than usual
+here. EXIF orientation is a frozen format, we read one tag of it, and
+vendoring makes upstream's activity irrelevant to us either way. If it
+ever does matter, TinyEXIF is the maintained one.
+
+## It is a parser, and the input is a file the operator picked
+
+A malformed or malicious APP1 segment must fail to a sane default, not
+propagate. `images::load` therefore treats **any** non-zero return from
+`parseFrom` -- and an `Orientation` outside 1..8 -- as orientation 1,
+the identity, so an unreadable tag costs the operator a rotation rather
+than a load failure. `test_images.cpp` plants a truncated APP1 to hold
+that.

--- a/native/third_party/easyexif/exif.cpp
+++ b/native/third_party/easyexif/exif.cpp
@@ -1,0 +1,918 @@
+/**************************************************************************
+  exif.cpp  -- A simple ISO C++ library to parse basic EXIF
+               information from a JPEG file.
+
+  Copyright (c) 2010-2015 Mayank Lahiri
+  mlahiri@gmail.com
+  All rights reserved (BSD License).
+
+  See exif.h for version history.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  -- Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  -- Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY EXPRESS
+  OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+  NO EVENT SHALL THE FREEBSD PROJECT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "exif.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <stdio.h>
+#include <vector>
+
+using std::string;
+
+namespace {
+
+struct Rational {
+  uint32_t numerator, denominator;
+  operator double() const {
+    if (denominator < 1e-20) {
+      return 0;
+    }
+    return static_cast<double>(numerator) / static_cast<double>(denominator);
+  }
+};
+
+// IF Entry
+class IFEntry {
+ public:
+  using byte_vector = std::vector<uint8_t>;
+  using ascii_vector = std::string;
+  using short_vector = std::vector<uint16_t>;
+  using long_vector = std::vector<uint32_t>;
+  using rational_vector = std::vector<Rational>;
+
+  IFEntry()
+      : tag_(0xFF), format_(0xFF), data_(0), length_(0), val_byte_(nullptr) {}
+  IFEntry(const IFEntry &) = delete;
+  IFEntry &operator=(const IFEntry &) = delete;
+  IFEntry(IFEntry &&other)
+      : tag_(other.tag_),
+        format_(other.format_),
+        data_(other.data_),
+        length_(other.length_),
+        val_byte_(other.val_byte_) {
+    other.tag_ = 0xFF;
+    other.format_ = 0xFF;
+    other.data_ = 0;
+    other.length_ = 0;
+    other.val_byte_ = nullptr;
+  }
+  ~IFEntry() { delete_union(); }
+  unsigned short tag() const { return tag_; }
+  void tag(unsigned short tag) { tag_ = tag; }
+  unsigned short format() const { return format_; }
+  bool format(unsigned short format) {
+    switch (format) {
+      case 0x01:
+      case 0x02:
+      case 0x03:
+      case 0x04:
+      case 0x05:
+      case 0x07:
+      case 0x09:
+      case 0x0a:
+      case 0xff:
+        break;
+      default:
+        return false;
+    }
+    delete_union();
+    format_ = format;
+    new_union();
+    return true;
+  }
+  unsigned data() const { return data_; }
+  void data(unsigned data) { data_ = data; }
+  unsigned length() const { return length_; }
+  void length(unsigned length) { length_ = length; }
+
+  // functions to access the data
+  //
+  // !! it's CALLER responsibility to check that format !!
+  // !! is correct before accessing it's field          !!
+  //
+  // - getters are use here to allow future addition
+  //   of checks if format is correct
+  byte_vector &val_byte() { return *val_byte_; }
+  ascii_vector &val_string() { return *val_string_; }
+  short_vector &val_short() { return *val_short_; }
+  long_vector &val_long() { return *val_long_; }
+  rational_vector &val_rational() { return *val_rational_; }
+
+ private:
+  // Raw fields
+  unsigned short tag_;
+  unsigned short format_;
+  unsigned data_;
+  unsigned length_;
+
+  // Parsed fields
+  union {
+    byte_vector *val_byte_;
+    ascii_vector *val_string_;
+    short_vector *val_short_;
+    long_vector *val_long_;
+    rational_vector *val_rational_;
+  };
+
+  void delete_union() {
+    switch (format_) {
+      case 0x1:
+        delete val_byte_;
+        val_byte_ = nullptr;
+        break;
+      case 0x2:
+        delete val_string_;
+        val_string_ = nullptr;
+        break;
+      case 0x3:
+        delete val_short_;
+        val_short_ = nullptr;
+        break;
+      case 0x4:
+        delete val_long_;
+        val_long_ = nullptr;
+        break;
+      case 0x5:
+        delete val_rational_;
+        val_rational_ = nullptr;
+        break;
+      case 0xff:
+        break;
+      default:
+        // should not get here
+        // should I throw an exception or ...?
+        break;
+    }
+  }
+  void new_union() {
+    switch (format_) {
+      case 0x1:
+        val_byte_ = new byte_vector();
+        break;
+      case 0x2:
+        val_string_ = new ascii_vector();
+        break;
+      case 0x3:
+        val_short_ = new short_vector();
+        break;
+      case 0x4:
+        val_long_ = new long_vector();
+        break;
+      case 0x5:
+        val_rational_ = new rational_vector();
+        break;
+      case 0xff:
+        break;
+      default:
+        // should not get here
+        // should I throw an exception or ...?
+        break;
+    }
+  }
+};
+
+// Helper functions
+template <typename T, bool alignIntel>
+T parse(const unsigned char *buf);
+
+template <>
+uint8_t parse<uint8_t, false>(const unsigned char *buf) {
+  return *buf;
+}
+
+template <>
+uint8_t parse<uint8_t, true>(const unsigned char *buf) {
+  return *buf;
+}
+
+template <>
+uint16_t parse<uint16_t, false>(const unsigned char *buf) {
+  return (static_cast<uint16_t>(buf[0]) << 8) | buf[1];
+}
+
+template <>
+uint16_t parse<uint16_t, true>(const unsigned char *buf) {
+  return (static_cast<uint16_t>(buf[1]) << 8) | buf[0];
+}
+
+template <>
+uint32_t parse<uint32_t, false>(const unsigned char *buf) {
+  return (static_cast<uint32_t>(buf[0]) << 24) |
+         (static_cast<uint32_t>(buf[1]) << 16) |
+         (static_cast<uint32_t>(buf[2]) << 8) | buf[3];
+}
+
+template <>
+uint32_t parse<uint32_t, true>(const unsigned char *buf) {
+  return (static_cast<uint32_t>(buf[3]) << 24) |
+         (static_cast<uint32_t>(buf[2]) << 16) |
+         (static_cast<uint32_t>(buf[1]) << 8) | buf[0];
+}
+
+template <>
+Rational parse<Rational, true>(const unsigned char *buf) {
+  Rational r;
+  r.numerator = parse<uint32_t, true>(buf);
+  r.denominator = parse<uint32_t, true>(buf + 4);
+  return r;
+}
+
+template <>
+Rational parse<Rational, false>(const unsigned char *buf) {
+  Rational r;
+  r.numerator = parse<uint32_t, false>(buf);
+  r.denominator = parse<uint32_t, false>(buf + 4);
+  return r;
+}
+
+/**
+ * Try to read entry.length() values for this entry.
+ *
+ * Returns:
+ *  true  - entry.length() values were read
+ *  false - something went wrong, vec's content was not touched
+ */
+template <typename T, bool alignIntel, typename C>
+bool extract_values(C &container, const unsigned char *buf, const unsigned base,
+                    const unsigned len, const IFEntry &entry) {
+  const unsigned char *data;
+  uint32_t reversed_data;
+  // if data fits into 4 bytes, they are stored directly in
+  // the data field in IFEntry
+  if (sizeof(T) * entry.length() <= 4) {
+    if (alignIntel) {
+      reversed_data = entry.data();
+    } else {
+      reversed_data = entry.data();
+      // this reversing works, but is ugly
+      unsigned char *rdata = reinterpret_cast<unsigned char *>(&reversed_data);
+      unsigned char tmp;
+      tmp = rdata[0];
+      rdata[0] = rdata[3];
+      rdata[3] = tmp;
+      tmp = rdata[1];
+      rdata[1] = rdata[2];
+      rdata[2] = tmp;
+    }
+    data = reinterpret_cast<const unsigned char *>(&(reversed_data));
+  } else {
+    data = buf + base + entry.data();
+    if (data + sizeof(T) * entry.length() > buf + len) {
+      return false;
+    }
+  }
+  container.resize(entry.length());
+  for (size_t i = 0; i < entry.length(); ++i) {
+    container[i] = parse<T, alignIntel>(data + sizeof(T) * i);
+  }
+  return true;
+}
+
+template <bool alignIntel>
+void parseIFEntryHeader(const unsigned char *buf, unsigned short &tag,
+                        unsigned short &format, unsigned &length,
+                        unsigned &data) {
+  // Each directory entry is composed of:
+  // 2 bytes: tag number (data field)
+  // 2 bytes: data format
+  // 4 bytes: number of components
+  // 4 bytes: data value or offset to data value
+  tag = parse<uint16_t, alignIntel>(buf);
+  format = parse<uint16_t, alignIntel>(buf + 2);
+  length = parse<uint32_t, alignIntel>(buf + 4);
+  data = parse<uint32_t, alignIntel>(buf + 8);
+}
+
+template <bool alignIntel>
+void parseIFEntryHeader(const unsigned char *buf, IFEntry &result) {
+  unsigned short tag;
+  unsigned short format;
+  unsigned length;
+  unsigned data;
+
+  parseIFEntryHeader<alignIntel>(buf, tag, format, length, data);
+
+  result.tag(tag);
+  result.format(format);
+  result.length(length);
+  result.data(data);
+}
+
+template <bool alignIntel>
+IFEntry parseIFEntry_temp(const unsigned char *buf, const unsigned offs,
+                          const unsigned base, const unsigned len) {
+  IFEntry result;
+
+  // check if there even is enough data for IFEntry in the buffer
+  if (buf + offs + 12 > buf + len) {
+    result.tag(0xFF);
+    return result;
+  }
+
+  parseIFEntryHeader<alignIntel>(buf + offs, result);
+
+  // Parse value in specified format
+  switch (result.format()) {
+    case 1:
+      if (!extract_values<uint8_t, alignIntel>(result.val_byte(), buf, base,
+                                               len, result)) {
+        result.tag(0xFF);
+      }
+      break;
+    case 2:
+      // string is basically sequence of uint8_t (well, according to EXIF even
+      // uint7_t, but
+      // we don't have that), so just read it as bytes
+      if (!extract_values<uint8_t, alignIntel>(result.val_string(), buf, base,
+                                               len, result)) {
+        result.tag(0xFF);
+      }
+      // and cut zero byte at the end, since we don't want that in the
+      // std::string
+      if (result.val_string()[result.val_string().length() - 1] == '\0') {
+        result.val_string().resize(result.val_string().length() - 1);
+      }
+      break;
+    case 3:
+      if (!extract_values<uint16_t, alignIntel>(result.val_short(), buf, base,
+                                                len, result)) {
+        result.tag(0xFF);
+      }
+      break;
+    case 4:
+      if (!extract_values<uint32_t, alignIntel>(result.val_long(), buf, base,
+                                                len, result)) {
+        result.tag(0xFF);
+      }
+      break;
+    case 5:
+      if (!extract_values<Rational, alignIntel>(result.val_rational(), buf,
+                                                base, len, result)) {
+        result.tag(0xFF);
+      }
+      break;
+    case 7:
+    case 9:
+    case 10:
+      break;
+    default:
+      result.tag(0xFF);
+  }
+  return result;
+}
+
+// helper functions for convinience
+template <typename T>
+T parse_value(const unsigned char *buf, bool alignIntel) {
+  if (alignIntel) {
+    return parse<T, true>(buf);
+  } else {
+    return parse<T, false>(buf);
+  }
+}
+
+void parseIFEntryHeader(const unsigned char *buf, bool alignIntel,
+                        unsigned short &tag, unsigned short &format,
+                        unsigned &length, unsigned &data) {
+  if (alignIntel) {
+    parseIFEntryHeader<true>(buf, tag, format, length, data);
+  } else {
+    parseIFEntryHeader<false>(buf, tag, format, length, data);
+  }
+}
+
+IFEntry parseIFEntry(const unsigned char *buf, const unsigned offs,
+                     const bool alignIntel, const unsigned base,
+                     const unsigned len) {
+  if (alignIntel) {
+    return parseIFEntry_temp<true>(buf, offs, base, len);
+  } else {
+    return parseIFEntry_temp<false>(buf, offs, base, len);
+  }
+}
+}
+
+//
+// Locates the EXIF segment and parses it using parseFromEXIFSegment
+//
+int easyexif::EXIFInfo::parseFrom(const unsigned char *buf, unsigned len) {
+  // Sanity check: all JPEG files start with 0xFFD8.
+  if (!buf || len < 4) return PARSE_EXIF_ERROR_NO_JPEG;
+  if (buf[0] != 0xFF || buf[1] != 0xD8) return PARSE_EXIF_ERROR_NO_JPEG;
+
+  // Sanity check: some cameras pad the JPEG image with some bytes at the end.
+  // Normally, we should be able to find the JPEG end marker 0xFFD9 at the end
+  // of the image buffer, but not always. As long as there are some bytes
+  // except 0xD9 at the end of the image buffer, keep decrementing len until
+  // an 0xFFD9 is found. If JPEG end marker 0xFFD9 is not found,
+  // then we can be reasonably sure that the buffer is not a JPEG.
+  while (len > 2) {
+    if (buf[len - 1] == 0xD9 && buf[len - 2] == 0xFF)
+      break;
+    len--;
+  }
+  if (len <= 2)
+    return PARSE_EXIF_ERROR_NO_JPEG;
+
+  clear();
+
+  // Scan for EXIF header (bytes 0xFF 0xE1) and do a sanity check by
+  // looking for bytes "Exif\0\0". The marker length data is in Motorola
+  // byte order, which results in the 'false' parameter to parse16().
+  // The marker has to contain at least the TIFF header, otherwise the
+  // EXIF data is corrupt. So the minimum length specified here has to be:
+  //   2 bytes: section size
+  //   6 bytes: "Exif\0\0" string
+  //   2 bytes: TIFF header (either "II" or "MM" string)
+  //   2 bytes: TIFF magic (short 0x2a00 in Motorola byte order)
+  //   4 bytes: Offset to first IFD
+  // =========
+  //  16 bytes
+  unsigned offs = 0;  // current offset into buffer
+  for (offs = 0; offs < len - 1; offs++)
+    if (buf[offs] == 0xFF && buf[offs + 1] == 0xE1) break;
+  if (offs + 4 > len) return PARSE_EXIF_ERROR_NO_EXIF;
+  offs += 2;
+  unsigned short section_length = parse_value<uint16_t>(buf + offs, false);
+  if (offs + section_length > len || section_length < 16)
+    return PARSE_EXIF_ERROR_CORRUPT;
+  offs += 2;
+
+  return parseFromEXIFSegment(buf + offs, len - offs);
+}
+
+int easyexif::EXIFInfo::parseFrom(const string &data) {
+  return parseFrom(
+      reinterpret_cast<const unsigned char *>(data.data()), static_cast<unsigned>(data.length()));
+}
+
+//
+// Main parsing function for an EXIF segment.
+//
+// PARAM: 'buf' start of the EXIF TIFF, which must be the bytes "Exif\0\0".
+// PARAM: 'len' length of buffer
+//
+int easyexif::EXIFInfo::parseFromEXIFSegment(const unsigned char *buf,
+                                             unsigned len) {
+  bool alignIntel = true;  // byte alignment (defined in EXIF header)
+  unsigned offs = 0;       // current offset into buffer
+  if (!buf || len < 6) return PARSE_EXIF_ERROR_NO_EXIF;
+
+  if (!std::equal(buf, buf + 6, "Exif\0\0")) return PARSE_EXIF_ERROR_NO_EXIF;
+  offs += 6;
+
+  // Now parsing the TIFF header. The first two bytes are either "II" or
+  // "MM" for Intel or Motorola byte alignment. Sanity check by parsing
+  // the unsigned short that follows, making sure it equals 0x2a. The
+  // last 4 bytes are an offset into the first IFD, which are added to
+  // the global offset counter. For this block, we expect the following
+  // minimum size:
+  //  2 bytes: 'II' or 'MM'
+  //  2 bytes: 0x002a
+  //  4 bytes: offset to first IDF
+  // -----------------------------
+  //  8 bytes
+  if (offs + 8 > len) return PARSE_EXIF_ERROR_CORRUPT;
+  unsigned tiff_header_start = offs;
+  if (buf[offs] == 'I' && buf[offs + 1] == 'I')
+    alignIntel = true;
+  else {
+    if (buf[offs] == 'M' && buf[offs + 1] == 'M')
+      alignIntel = false;
+    else
+      return PARSE_EXIF_ERROR_UNKNOWN_BYTEALIGN;
+  }
+  this->ByteAlign = alignIntel;
+  offs += 2;
+  if (0x2a != parse_value<uint16_t>(buf + offs, alignIntel))
+    return PARSE_EXIF_ERROR_CORRUPT;
+  offs += 2;
+  unsigned first_ifd_offset = parse_value<uint32_t>(buf + offs, alignIntel);
+  offs += first_ifd_offset - 4;
+  if (offs >= len) return PARSE_EXIF_ERROR_CORRUPT;
+
+  // Now parsing the first Image File Directory (IFD0, for the main image).
+  // An IFD consists of a variable number of 12-byte directory entries. The
+  // first two bytes of the IFD section contain the number of directory
+  // entries in the section. The last 4 bytes of the IFD contain an offset
+  // to the next IFD, which means this IFD must contain exactly 6 + 12 * num
+  // bytes of data.
+  if (offs + 2 > len) return PARSE_EXIF_ERROR_CORRUPT;
+  int num_entries = parse_value<uint16_t>(buf + offs, alignIntel);
+  if (offs + 6 + 12 * num_entries > len) return PARSE_EXIF_ERROR_CORRUPT;
+  offs += 2;
+  unsigned exif_sub_ifd_offset = len;
+  unsigned gps_sub_ifd_offset = len;
+  while (--num_entries >= 0) {
+    IFEntry result =
+        parseIFEntry(buf, offs, alignIntel, tiff_header_start, len);
+    offs += 12;
+    switch (result.tag()) {
+      case 0x102:
+        // Bits per sample
+        if (result.format() == 3 && result.val_short().size())
+          this->BitsPerSample = result.val_short().front();
+        break;
+
+      case 0x10E:
+        // Image description
+        if (result.format() == 2) this->ImageDescription = result.val_string();
+        break;
+
+      case 0x10F:
+        // Digicam make
+        if (result.format() == 2) this->Make = result.val_string();
+        break;
+
+      case 0x110:
+        // Digicam model
+        if (result.format() == 2) this->Model = result.val_string();
+        break;
+
+      case 0x112:
+        // Orientation of image
+        if (result.format() == 3 && result.val_short().size())
+          this->Orientation = result.val_short().front();
+        break;
+
+      case 0x131:
+        // Software used for image
+        if (result.format() == 2) this->Software = result.val_string();
+        break;
+
+      case 0x132:
+        // EXIF/TIFF date/time of image modification
+        if (result.format() == 2) this->DateTime = result.val_string();
+        break;
+
+      case 0x8298:
+        // Copyright information
+        if (result.format() == 2) this->Copyright = result.val_string();
+        break;
+
+      case 0x8825:
+        // GPS IFS offset
+        gps_sub_ifd_offset = tiff_header_start + result.data();
+        break;
+
+      case 0x8769:
+        // EXIF SubIFD offset
+        exif_sub_ifd_offset = tiff_header_start + result.data();
+        break;
+    }
+  }
+
+  // Jump to the EXIF SubIFD if it exists and parse all the information
+  // there. Note that it's possible that the EXIF SubIFD doesn't exist.
+  // The EXIF SubIFD contains most of the interesting information that a
+  // typical user might want.
+  if (exif_sub_ifd_offset + 4 <= len) {
+    offs = exif_sub_ifd_offset;
+    int num_sub_entries = parse_value<uint16_t>(buf + offs, alignIntel);
+    if (offs + 6 + 12 * num_sub_entries > len) return PARSE_EXIF_ERROR_CORRUPT;
+    offs += 2;
+    while (--num_sub_entries >= 0) {
+      IFEntry result =
+          parseIFEntry(buf, offs, alignIntel, tiff_header_start, len);
+      switch (result.tag()) {
+        case 0x829a:
+          // Exposure time in seconds
+          if (result.format() == 5 && result.val_rational().size())
+            this->ExposureTime = result.val_rational().front();
+          break;
+
+        case 0x829d:
+          // FNumber
+          if (result.format() == 5 && result.val_rational().size())
+            this->FNumber = result.val_rational().front();
+          break;
+
+      case 0x8822:
+        // Exposure Program
+        if (result.format() == 3 && result.val_short().size())
+          this->ExposureProgram = result.val_short().front();
+        break;
+
+        case 0x8827:
+          // ISO Speed Rating
+          if (result.format() == 3 && result.val_short().size())
+            this->ISOSpeedRatings = result.val_short().front();
+          break;
+
+        case 0x9003:
+          // Original date and time
+          if (result.format() == 2)
+            this->DateTimeOriginal = result.val_string();
+          break;
+
+        case 0x9004:
+          // Digitization date and time
+          if (result.format() == 2)
+            this->DateTimeDigitized = result.val_string();
+          break;
+
+        case 0x9201:
+          // Shutter speed value
+          if (result.format() == 5 && result.val_rational().size())
+            this->ShutterSpeedValue = result.val_rational().front();
+          break;
+
+        case 0x9204:
+          // Exposure bias value
+          if (result.format() == 5 && result.val_rational().size())
+            this->ExposureBiasValue = result.val_rational().front();
+          break;
+
+        case 0x9206:
+          // Subject distance
+          if (result.format() == 5 && result.val_rational().size())
+            this->SubjectDistance = result.val_rational().front();
+          break;
+
+        case 0x9209:
+          // Flash used
+          if (result.format() == 3 && result.val_short().size()) {
+            uint16_t data = result.val_short().front();
+            
+            this->Flash = data & 1;
+            this->FlashReturnedLight = (data & 6) >> 1;
+            this->FlashMode = (data & 24) >> 3;
+          }
+          break;
+
+        case 0x920a:
+          // Focal length
+          if (result.format() == 5 && result.val_rational().size())
+            this->FocalLength = result.val_rational().front();
+          break;
+
+        case 0x9207:
+          // Metering mode
+          if (result.format() == 3 && result.val_short().size())
+            this->MeteringMode = result.val_short().front();
+          break;
+
+        case 0x9291:
+          // Subsecond original time
+          if (result.format() == 2)
+            this->SubSecTimeOriginal = result.val_string();
+          break;
+
+        case 0xa002:
+          // EXIF Image width
+          if (result.format() == 4 && result.val_long().size())
+            this->ImageWidth = result.val_long().front();
+          if (result.format() == 3 && result.val_short().size())
+            this->ImageWidth = result.val_short().front();
+          break;
+
+        case 0xa003:
+          // EXIF Image height
+          if (result.format() == 4 && result.val_long().size())
+            this->ImageHeight = result.val_long().front();
+          if (result.format() == 3 && result.val_short().size())
+            this->ImageHeight = result.val_short().front();
+          break;
+
+        case 0xa20e:
+          // EXIF Focal plane X-resolution
+          if (result.format() == 5) {
+            this->LensInfo.FocalPlaneXResolution = result.val_rational()[0];
+          }
+          break;
+
+        case 0xa20f:
+          // EXIF Focal plane Y-resolution
+          if (result.format() == 5) {
+            this->LensInfo.FocalPlaneYResolution = result.val_rational()[0];
+          }
+          break;
+
+        case 0xa210:
+            // EXIF Focal plane resolution unit
+            if (result.format() == 3 && result.val_short().size()) {
+                this->LensInfo.FocalPlaneResolutionUnit = result.val_short().front();
+            }
+            break;
+
+        case 0xa405:
+          // Focal length in 35mm film
+          if (result.format() == 3 && result.val_short().size())
+            this->FocalLengthIn35mm = result.val_short().front();
+          break;
+
+        case 0xa432:
+          // Focal length and FStop.
+          if (result.format() == 5) {
+            int sz = static_cast<unsigned>(result.val_rational().size());
+            if (sz)
+              this->LensInfo.FocalLengthMin = result.val_rational()[0];
+            if (sz > 1)
+              this->LensInfo.FocalLengthMax = result.val_rational()[1];
+            if (sz > 2)
+              this->LensInfo.FStopMin = result.val_rational()[2];
+            if (sz > 3)
+              this->LensInfo.FStopMax = result.val_rational()[3];
+          }
+          break;
+
+        case 0xa433:
+          // Lens make.
+          if (result.format() == 2) {
+            this->LensInfo.Make = result.val_string();
+          }
+          break;
+
+        case 0xa434:
+          // Lens model.
+          if (result.format() == 2) {
+            this->LensInfo.Model = result.val_string();
+          }
+          break;
+      }
+      offs += 12;
+    }
+  }
+
+  // Jump to the GPS SubIFD if it exists and parse all the information
+  // there. Note that it's possible that the GPS SubIFD doesn't exist.
+  if (gps_sub_ifd_offset + 4 <= len) {
+    offs = gps_sub_ifd_offset;
+    int num_sub_entries = parse_value<uint16_t>(buf + offs, alignIntel);
+    if (offs + 6 + 12 * num_sub_entries > len) return PARSE_EXIF_ERROR_CORRUPT;
+    offs += 2;
+    while (--num_sub_entries >= 0) {
+      unsigned short tag, format;
+      unsigned length, data;
+      parseIFEntryHeader(buf + offs, alignIntel, tag, format, length, data);
+      switch (tag) {
+        case 1:
+          // GPS north or south
+          this->GeoLocation.LatComponents.direction = *(buf + offs + 8);
+          if (this->GeoLocation.LatComponents.direction == 0) {
+            this->GeoLocation.LatComponents.direction = '?';
+          }
+          if ('S' == this->GeoLocation.LatComponents.direction) {
+            this->GeoLocation.Latitude = -this->GeoLocation.Latitude;
+          }
+          break;
+
+        case 2:
+          // GPS latitude
+          if ((format == 5 || format == 10) && length == 3) {
+            this->GeoLocation.LatComponents.degrees = parse_value<Rational>(
+                buf + data + tiff_header_start, alignIntel);
+            this->GeoLocation.LatComponents.minutes = parse_value<Rational>(
+                buf + data + tiff_header_start + 8, alignIntel);
+            this->GeoLocation.LatComponents.seconds = parse_value<Rational>(
+                buf + data + tiff_header_start + 16, alignIntel);
+            this->GeoLocation.Latitude =
+                this->GeoLocation.LatComponents.degrees +
+                this->GeoLocation.LatComponents.minutes / 60 +
+                this->GeoLocation.LatComponents.seconds / 3600;
+            if ('S' == this->GeoLocation.LatComponents.direction) {
+              this->GeoLocation.Latitude = -this->GeoLocation.Latitude;
+            }
+          }
+          break;
+
+        case 3:
+          // GPS east or west
+          this->GeoLocation.LonComponents.direction = *(buf + offs + 8);
+          if (this->GeoLocation.LonComponents.direction == 0) {
+            this->GeoLocation.LonComponents.direction = '?';
+          }
+          if ('W' == this->GeoLocation.LonComponents.direction) {
+            this->GeoLocation.Longitude = -this->GeoLocation.Longitude;
+          }
+          break;
+
+        case 4:
+          // GPS longitude
+          if ((format == 5 || format == 10) && length == 3) {
+            this->GeoLocation.LonComponents.degrees = parse_value<Rational>(
+                buf + data + tiff_header_start, alignIntel);
+            this->GeoLocation.LonComponents.minutes = parse_value<Rational>(
+                buf + data + tiff_header_start + 8, alignIntel);
+            this->GeoLocation.LonComponents.seconds = parse_value<Rational>(
+                buf + data + tiff_header_start + 16, alignIntel);
+            this->GeoLocation.Longitude =
+                this->GeoLocation.LonComponents.degrees +
+                this->GeoLocation.LonComponents.minutes / 60 +
+                this->GeoLocation.LonComponents.seconds / 3600;
+            if ('W' == this->GeoLocation.LonComponents.direction)
+              this->GeoLocation.Longitude = -this->GeoLocation.Longitude;
+          }
+          break;
+
+        case 5:
+          // GPS altitude reference (below or above sea level)
+          this->GeoLocation.AltitudeRef = *(buf + offs + 8);
+          if (1 == this->GeoLocation.AltitudeRef) {
+            this->GeoLocation.Altitude = -this->GeoLocation.Altitude;
+          }
+          break;
+
+        case 6:
+          // GPS altitude
+          if ((format == 5 || format == 10)) {
+            this->GeoLocation.Altitude = parse_value<Rational>(
+                buf + data + tiff_header_start, alignIntel);
+            if (1 == this->GeoLocation.AltitudeRef) {
+              this->GeoLocation.Altitude = -this->GeoLocation.Altitude;
+            }
+          }
+          break;
+
+        case 11:
+          // GPS degree of precision (DOP)
+          if ((format == 5 || format == 10)) {
+            this->GeoLocation.DOP = parse_value<Rational>(
+                buf + data + tiff_header_start, alignIntel);
+          }
+          break;
+      }
+      offs += 12;
+    }
+  }
+
+  return PARSE_EXIF_SUCCESS;
+}
+
+void easyexif::EXIFInfo::clear() {
+  // Strings
+  ImageDescription = "";
+  Make = "";
+  Model = "";
+  Software = "";
+  DateTime = "";
+  DateTimeOriginal = "";
+  DateTimeDigitized = "";
+  SubSecTimeOriginal = "";
+  Copyright = "";
+
+  // Shorts / unsigned / double
+  ByteAlign = 0;
+  Orientation = 0;
+
+  BitsPerSample = 0;
+  ExposureTime = 0;
+  FNumber = 0;
+  ExposureProgram = 0;
+  ISOSpeedRatings = 0;
+  ShutterSpeedValue = 0;
+  ExposureBiasValue = 0;
+  SubjectDistance = 0;
+  FocalLength = 0;
+  FocalLengthIn35mm = 0;
+  Flash = 0;
+  FlashReturnedLight = 0;
+  FlashMode = 0;
+  MeteringMode = 0;
+  ImageWidth = 0;
+  ImageHeight = 0;
+
+  // Geolocation
+  GeoLocation.Latitude = 0;
+  GeoLocation.Longitude = 0;
+  GeoLocation.Altitude = 0;
+  GeoLocation.AltitudeRef = 0;
+  GeoLocation.DOP = 0;
+  GeoLocation.LatComponents.degrees = 0;
+  GeoLocation.LatComponents.minutes = 0;
+  GeoLocation.LatComponents.seconds = 0;
+  GeoLocation.LatComponents.direction = '?';
+  GeoLocation.LonComponents.degrees = 0;
+  GeoLocation.LonComponents.minutes = 0;
+  GeoLocation.LonComponents.seconds = 0;
+  GeoLocation.LonComponents.direction = '?';
+
+  // LensInfo
+  LensInfo.FocalLengthMax = 0;
+  LensInfo.FocalLengthMin = 0;
+  LensInfo.FStopMax = 0;
+  LensInfo.FStopMin = 0;
+  LensInfo.FocalPlaneYResolution = 0;
+  LensInfo.FocalPlaneXResolution = 0;
+  LensInfo.FocalPlaneResolutionUnit = 0;
+  LensInfo.Make = "";
+  LensInfo.Model = "";
+}

--- a/native/third_party/easyexif/exif.h
+++ b/native/third_party/easyexif/exif.h
@@ -1,0 +1,168 @@
+/**************************************************************************
+  exif.h  -- A simple ISO C++ library to parse basic EXIF
+             information from a JPEG file.
+
+  Based on the description of the EXIF file format at:
+  -- http://park2.wakwak.com/~tsuruzoh/Computer/Digicams/exif-e.html
+  -- http://www.media.mit.edu/pia/Research/deepview/exif.html
+  -- http://www.exif.org/Exif2-2.PDF
+
+  Copyright (c) 2010-2016 Mayank Lahiri
+  mlahiri@gmail.com
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  -- Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  -- Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+   NO EVENT SHALL THE FREEBSD PROJECT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+   INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+   BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+   OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef __EXIF_H
+#define __EXIF_H
+
+#include <string>
+
+namespace easyexif {
+
+//
+// Class responsible for storing and parsing EXIF information from a JPEG blob
+//
+class EXIFInfo {
+ public:
+  // Parsing function for an entire JPEG image buffer.
+  //
+  // PARAM 'data': A pointer to a JPEG image.
+  // PARAM 'length': The length of the JPEG image.
+  // RETURN:  PARSE_EXIF_SUCCESS (0) on succes with 'result' filled out
+  //          error code otherwise, as defined by the PARSE_EXIF_ERROR_* macros
+  int parseFrom(const unsigned char *data, unsigned length);
+  int parseFrom(const std::string &data);
+
+  // Parsing function for an EXIF segment. This is used internally by parseFrom()
+  // but can be called for special cases where only the EXIF section is
+  // available (i.e., a blob starting with the bytes "Exif\0\0").
+  int parseFromEXIFSegment(const unsigned char *buf, unsigned len);
+
+  // Set all data members to default values.
+  void clear();
+
+  // Data fields filled out by parseFrom()
+  char ByteAlign;                   // 0 = Motorola byte alignment, 1 = Intel
+  std::string ImageDescription;     // Image description
+  std::string Make;                 // Camera manufacturer's name
+  std::string Model;                // Camera model
+  unsigned short Orientation;       // Image orientation, start of data corresponds to
+                                    // 0: unspecified in EXIF data
+                                    // 1: upper left of image
+                                    // 3: lower right of image
+                                    // 6: upper right of image
+                                    // 8: lower left of image
+                                    // 9: undefined
+  unsigned short BitsPerSample;     // Number of bits per component
+  std::string Software;             // Software used
+  std::string DateTime;             // File change date and time
+  std::string DateTimeOriginal;     // Original file date and time (may not exist)
+  std::string DateTimeDigitized;    // Digitization date and time (may not exist)
+  std::string SubSecTimeOriginal;   // Sub-second time that original picture was taken
+  std::string Copyright;            // File copyright information
+  double ExposureTime;              // Exposure time in seconds
+  double FNumber;                   // F/stop
+  unsigned short ExposureProgram;   // Exposure program
+                                    // 0: Not defined
+                                    // 1: Manual
+                                    // 2: Normal program
+                                    // 3: Aperture priority
+                                    // 4: Shutter priority
+                                    // 5: Creative program
+                                    // 6: Action program
+                                    // 7: Portrait mode
+                                    // 8: Landscape mode
+  unsigned short ISOSpeedRatings;   // ISO speed
+  double ShutterSpeedValue;         // Shutter speed (reciprocal of exposure time)
+  double ExposureBiasValue;         // Exposure bias value in EV
+  double SubjectDistance;           // Distance to focus point in meters
+  double FocalLength;               // Focal length of lens in millimeters
+  unsigned short FocalLengthIn35mm; // Focal length in 35mm film
+  char Flash;                       // 0 = no flash, 1 = flash used
+  unsigned short FlashReturnedLight;// Flash returned light status
+                                    // 0: No strobe return detection function
+                                    // 1: Reserved
+                                    // 2: Strobe return light not detected
+                                    // 3: Strobe return light detected
+  unsigned short FlashMode;         // Flash mode
+                                    // 0: Unknown
+                                    // 1: Compulsory flash firing
+                                    // 2: Compulsory flash suppression
+                                    // 3: Automatic mode
+  unsigned short MeteringMode;      // Metering mode
+                                    // 1: average
+                                    // 2: center weighted average
+                                    // 3: spot
+                                    // 4: multi-spot
+                                    // 5: multi-segment
+  unsigned ImageWidth;              // Image width reported in EXIF data
+  unsigned ImageHeight;             // Image height reported in EXIF data
+  struct Geolocation_t {            // GPS information embedded in file
+    double Latitude;                  // Image latitude expressed as decimal
+    double Longitude;                 // Image longitude expressed as decimal
+    double Altitude;                  // Altitude in meters, relative to sea level
+    char AltitudeRef;                 // 0 = above sea level, -1 = below sea level
+    double DOP;                       // GPS degree of precision (DOP)
+    struct Coord_t {
+      double degrees;
+      double minutes;
+      double seconds;
+      char direction;
+    } LatComponents, LonComponents;   // Latitude, Longitude expressed in deg/min/sec
+  } GeoLocation;
+  struct LensInfo_t {               // Lens information
+    double FStopMin;                // Min aperture (f-stop)
+    double FStopMax;                // Max aperture (f-stop)
+    double FocalLengthMin;          // Min focal length (mm)
+    double FocalLengthMax;          // Max focal length (mm)
+    double FocalPlaneXResolution;   // Focal plane X-resolution
+    double FocalPlaneYResolution;   // Focal plane Y-resolution
+    unsigned short FocalPlaneResolutionUnit; // Focal plane resolution unit
+                                             // 1: No absolute unit of measurement.
+                                             // 2: Inch.
+                                             // 3: Centimeter.
+                                             // 4: Millimeter.
+                                             // 5: Micrometer.
+    std::string Make;               // Lens manufacturer
+    std::string Model;              // Lens model
+  } LensInfo;
+
+
+  EXIFInfo() {
+    clear();
+  }
+};
+
+}
+
+// Parse was successful
+#define PARSE_EXIF_SUCCESS                    0
+// No JPEG markers found in buffer, possibly invalid JPEG file
+#define PARSE_EXIF_ERROR_NO_JPEG              1982
+// No EXIF header found in JPEG file.
+#define PARSE_EXIF_ERROR_NO_EXIF              1983
+// Byte alignment specified in EXIF file was unknown (not Motorola or Intel).
+#define PARSE_EXIF_ERROR_UNKNOWN_BYTEALIGN    1984
+// EXIF header was found, but data was corrupted.
+#define PARSE_EXIF_ERROR_CORRUPT              1985
+
+#endif

--- a/sstvae/images.py
+++ b/sstvae/images.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
-from PIL import Image, ImageFont
+from PIL import Image, ImageFont, ImageOps
 
 if TYPE_CHECKING:  # pragma: no cover - typing only, never imported at runtime
     import torch
@@ -83,6 +83,51 @@ def fit_image(img: Image.Image) -> Image.Image:
     return img.crop((left, top, left + IMG_W, top + IMG_H))
 
 
+MAX_FILE_BYTES = 1024 * 1024 * 1024
+"""The largest picture file that will be opened at all.
+
+Matches `images::MAX_FILE_BYTES` in the native app, which needs the
+limit for a concrete reason -- it reads the whole file into memory
+before decoding. Here it buys less, since PIL opens lazily, but the two
+declining the same files is worth more than the few lines: an operator
+who is told a picture is too large by one implementation should not
+find the other sending it.
+
+A GiB is far above any real photograph, so meeting it means the file is
+almost certainly not a picture.
+"""
+
+
+def open_image(path: str | Path) -> Image.Image:
+    """Open a picture file, upright.
+
+    JPEGs from phones and most cameras are stored in the sensor's own
+    orientation with an EXIF tag (0x0112) saying how to turn them; a
+    portrait photograph is a landscape file plus "rotate 90". Ignoring
+    the tag doesn't merely turn the picture -- it changes which pixels
+    `fit_image` keeps, because the cover-crop is computed from the wrong
+    aspect ratio, so a portrait photo goes out as a centre-crop of its
+    sideways self.
+
+    `exif_transpose` handles all eight orientations, including the two
+    diagonal ones, and strips the tag so the transform cannot be applied
+    twice. The native app does the same thing at the same point
+    (`images::load`); doing it at *open* rather than inside `fit_image`
+    is what keeps the two comparable, since a C++ `Picture` carries no
+    metadata to defer the decision with.
+
+    Raises `ValueError` for a file above `MAX_FILE_BYTES`, before
+    opening it.
+    """
+    size = os.path.getsize(path)
+    if size > MAX_FILE_BYTES:
+        raise ValueError(
+            f"{path} is {size} bytes; the limit for a picture file is "
+            f"{MAX_FILE_BYTES}"
+        )
+    return ImageOps.exif_transpose(Image.open(path))
+
+
 def image_to_array(img: Image.Image) -> np.ndarray:
     """IMG_W x IMG_H RGB image -> (3, IMG_H, IMG_W) float32 in [0,1]."""
     return np.array(img, dtype=np.float32).transpose(2, 0, 1) / 255.0
@@ -91,10 +136,11 @@ def image_to_array(img: Image.Image) -> np.ndarray:
 def load_image(path: str | Path) -> np.ndarray:
     """Open any PIL-readable image -> (3, IMG_H, IMG_W) float32 in [0,1].
 
-    Deterministic: cover-resize then centre-crop. For the augmented
-    training variant see `sstvae.data.load_image`.
+    Deterministic: cover-resize then centre-crop, after EXIF orientation
+    (see `open_image`). For the augmented training variant see
+    `sstvae.data.load_image`.
     """
-    return image_to_array(fit_image(Image.open(path)))
+    return image_to_array(fit_image(open_image(path)))
 
 
 def image_to_tensor(img: Image.Image) -> "torch.Tensor":

--- a/sstvae/overlay/render.py
+++ b/sstvae/overlay/render.py
@@ -22,7 +22,7 @@ from .model import ImageItem, OverlayDoc, SOURCE_LAST_RX, TextItem
 # Same font search the training overlays use, so the GUI's default face
 # matches what the model was trained on rather than being an arbitrary
 # second choice.
-from ..images import AVAILABLE_FONTS
+from ..images import AVAILABLE_FONTS, open_image
 
 
 @lru_cache(maxsize=64)
@@ -70,8 +70,15 @@ def _resolve_source(source: str, last_rx: Image.Image | None) -> Image.Image | N
     if not source or not os.path.exists(source):
         return None
     try:
-        return Image.open(source).convert("RGB")
-    except OSError:
+        # Upright, like the main picture -- an inset is usually a
+        # photograph too, and one of the two arriving sideways would be
+        # the more confusing outcome.
+        return open_image(source).convert("RGB")
+    except (OSError, ValueError):
+        # ValueError is `open_image`'s size refusal. An inset that is too
+        # large to open draws nothing, like every other unusable source
+        # here -- refusing to render the whole composition over one
+        # decorative element would be the worse failure.
         return None
 
 

--- a/tests/test_images_exif.py
+++ b/tests/test_images_exif.py
@@ -1,0 +1,184 @@
+"""EXIF orientation on the Python side of the send path.
+
+The C++ counterpart is `native/tests/test_images.cpp`, and the two are
+held to the same result by `tests/test_native_parity.py -k exif`. What
+is checked here is the thing neither of those can: that the *framing*
+sees the upright picture. Orientation 6 turns a 480x640 portrait file
+into a 640x480 landscape one, and `fit_image` computes its cover-crop
+from that geometry -- so getting this wrong does not merely rotate the
+transmission, it centre-crops a sideways picture and sends a strip out
+of the middle of it. That is much worse than a rotation and looks like
+a framing bug rather than a metadata one.
+"""
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from sstvae.images import IMG_H, IMG_W, fit_image, load_image, open_image
+
+# The eight orientations, as the transform each one *undoes*, expressed
+# with Pillow's primitives. Independent of `exif_transpose`'s own table.
+_EXPECTED = {
+    1: lambda im: im,
+    2: lambda im: im.transpose(Image.FLIP_LEFT_RIGHT),
+    3: lambda im: im.transpose(Image.ROTATE_180),
+    4: lambda im: im.transpose(Image.FLIP_TOP_BOTTOM),
+    5: lambda im: im.transpose(Image.TRANSPOSE),
+    6: lambda im: im.transpose(Image.ROTATE_270),
+    7: lambda im: im.transpose(Image.TRANSVERSE),
+    8: lambda im: im.transpose(Image.ROTATE_90),
+}
+
+
+def _tagged(tmp_path, orientation, size=(61, 37), fmt="jpeg"):
+    """A picture with an orientation tag, saved losslessly by default.
+
+    PNG rather than JPEG wherever the comparison is exact -- Pillow
+    writes the tag into a PNG `eXIf` chunk and reads it back, so the
+    transform can be checked on the pixels themselves rather than
+    through a lossy codec.
+    """
+    w, h = size
+    y, x = np.mgrid[0:h, 0:w]
+    arr = np.stack([(x * 4) % 256, (y * 6) % 256, (x * 2 + y * 3) % 256], -1)
+    img = Image.fromarray(arr.astype(np.uint8))
+    exif = Image.Exif()
+    exif[0x0112] = orientation
+    path = tmp_path / f"probe_{orientation}.{'png' if fmt == 'png' else 'jpg'}"
+    img.save(path, exif=exif, quality=95)
+    return img, path
+
+
+@pytest.mark.parametrize("orientation", range(1, 9))
+def test_open_image_applies_the_tag(tmp_path, orientation):
+    src, path = _tagged(tmp_path, orientation, fmt="png")
+
+    got = np.array(open_image(path).convert("RGB"))
+    want = np.array(_EXPECTED[orientation](src).convert("RGB"))
+
+    assert np.array_equal(got, want)
+
+
+def test_untagged_files_are_untouched(tmp_path):
+    """The common case, and the one a bug here would break for everyone."""
+    y, x = np.mgrid[0:37, 0:61]
+    arr = np.stack([(x * 4) % 256, (y * 6) % 256, (x + y) % 256], -1).astype(np.uint8)
+    path = tmp_path / "plain.png"
+    Image.fromarray(arr).save(path)
+
+    assert np.array_equal(np.array(open_image(path).convert("RGB")), arr)
+
+
+def test_the_eight_transforms_are_distinguishable(tmp_path):
+    """Asserts the probe's fitness, not the code: on a picture symmetric
+    enough for two cases to coincide, a swapped pair would pass."""
+    src, _ = _tagged(tmp_path, 1, fmt="png")
+    seen = [np.array(_EXPECTED[o](src).convert("RGB")) for o in range(1, 9)]
+    for i, a in enumerate(seen):
+        for b in seen[i + 1:]:
+            assert a.shape != b.shape or not np.array_equal(a, b)
+
+
+@pytest.mark.parametrize("orientation", [1, 6])
+def test_framing_sees_the_upright_picture(tmp_path, orientation):
+    """The consequence that matters: a portrait file must be framed as
+    the portrait picture it is, not as the landscape file it is stored
+    as.
+
+    A 480x640 portrait tagged 6 is stored 640x480. Framed without the
+    rotation it is already the target shape and passes through
+    untouched; framed correctly it is 3:4, and covering a 4:3 target
+    means scaling up and cropping top and bottom. Those two results have
+    almost nothing in common, which is what makes this a sharp check
+    rather than a rotation check.
+    """
+    # Stored landscape, meant to be seen portrait.
+    y, x = np.mgrid[0:IMG_H, 0:IMG_W]
+    arr = np.stack([(x % 256), (y % 256), ((x + y) % 256)], -1).astype(np.uint8)
+    img = Image.fromarray(arr)
+    exif = Image.Exif()
+    exif[0x0112] = orientation
+    path = tmp_path / "portrait.png"
+    img.save(path, exif=exif)
+
+    opened = open_image(path)
+    if orientation == 6:
+        assert opened.size == (IMG_H, IMG_W), "stored landscape, seen portrait"
+    else:
+        assert opened.size == (IMG_W, IMG_H)
+
+    fitted = fit_image(opened)
+    assert fitted.size == (IMG_W, IMG_H)
+
+    # And the whole path agrees with itself.
+    got = load_image(path)
+    assert got.shape == (3, IMG_H, IMG_W)
+    assert np.allclose(got, np.array(fitted, dtype=np.float32).transpose(2, 0, 1) / 255.0)
+
+    if orientation == 6:
+        # The untouched-landscape result is what the bug would produce.
+        # It must not be what we produce.
+        assert not np.array_equal(np.array(fitted), arr)
+
+
+def test_an_enormous_file_is_refused(tmp_path, monkeypatch):
+    """The limit is patched rather than met.
+
+    Writing a gigabyte to prove a comparison would be slow and would
+    need a sparse file to be honest about disk use; what is under test
+    is the comparison and the refusal, and neither cares what the
+    constant is. The constant itself is checked separately, against the
+    C++ one, in `tests/test_native_parity.py` -- which is the check that
+    matters, since a limit the two implementations disagreed about would
+    mean one of them sending a file the other refused.
+    """
+    from sstvae import images as images_mod
+
+    path = tmp_path / "big.png"
+    Image.fromarray(np.zeros((8, 8, 3), np.uint8)).save(path)
+    monkeypatch.setattr(images_mod, "MAX_FILE_BYTES", 4)
+
+    with pytest.raises(ValueError, match="limit"):
+        images_mod.open_image(path)
+
+    # And at exactly the limit it opens, so the boundary is inclusive on
+    # the same side as the C++.
+    monkeypatch.setattr(images_mod, "MAX_FILE_BYTES", path.stat().st_size)
+    assert images_mod.open_image(path).size == (8, 8)
+
+
+def test_an_oversized_overlay_inset_draws_nothing(tmp_path, monkeypatch):
+    """The refusal must not take the whole composition down with it.
+
+    `_resolve_source` returns None for every other unusable source, and
+    a size refusal is one more of those -- an operator mid-transmission
+    would rather lose a decorative inset than the picture.
+    """
+    from importlib import import_module
+
+    from sstvae import images as images_mod
+
+    # `sstvae.overlay` re-exports a *function* named `render`, which
+    # shadows the submodule of the same name on the package.
+    render_mod = import_module("sstvae.overlay.render")
+
+    path = tmp_path / "inset.png"
+    Image.fromarray(np.zeros((8, 8, 3), np.uint8)).save(path)
+    monkeypatch.setattr(images_mod, "MAX_FILE_BYTES", 4)
+
+    assert render_mod._resolve_source(str(path), None) is None
+
+
+def test_corrupt_metadata_does_not_break_the_load(tmp_path):
+    """A truncated or nonsense tag costs a rotation, never the picture --
+    the same rule `images::exif_orientation` follows in C++."""
+    y, x = np.mgrid[0:37, 0:61]
+    arr = np.stack([(x * 4) % 256, (y * 6) % 256, (x + y) % 256], -1).astype(np.uint8)
+    img = Image.fromarray(arr)
+    exif = Image.Exif()
+    exif[0x0112] = 99  # outside 1..8
+    path = tmp_path / "bogus.png"
+    img.save(path, exif=exif)
+
+    assert np.array_equal(np.array(open_image(path).convert("RGB")), arr)

--- a/tests/test_native_parity.py
+++ b/tests/test_native_parity.py
@@ -1009,6 +1009,11 @@ def test_images_geometry_agrees(native):
     assert native.images.IMG_H == ref.IMG_H
     assert native.images.MIN_W == ref.MIN_W
     assert native.images.MIN_H == ref.MIN_H
+    # Two implementations that refused different files would mean an
+    # operator being told a picture is too large by one and watching the
+    # other send it. Neither number is derived from anything, so this is
+    # the only thing keeping them equal.
+    assert native.images.MAX_FILE_BYTES == ref.MAX_FILE_BYTES
 
 
 def test_images_to_array_is_exact(native):
@@ -1044,6 +1049,111 @@ def test_images_load_reads_the_same_pixels(native, tmp_path):
     Image.fromarray(pic).save(path)
 
     assert np.array_equal(native.images.load(str(path)), pic)
+
+
+# EXIF orientation is the one place where the two loaders could disagree
+# *silently and consequentially*: a phone photograph would go out
+# sideways from one implementation and upright from the other, with
+# neither raising anything. It is also the one image comparison that
+# cannot be exact -- these are JPEGs, and stb's decoder is not libjpeg
+# (CLAUDE.md records that as an accepted above-the-modem difference).
+#
+# So the claim under test is "both applied the same transform", not
+# "both produced the same bytes", and it is made falsifiable by
+# requiring the intended transform to beat all seven alternatives by a
+# wide margin rather than merely to be within a tolerance. A tolerance
+# on its own would be satisfied by any sufficiently blurry picture.
+
+def _exif_probe(width: int = 61, height: int = 37):
+    """A picture no two of whose eight transforms are equal.
+
+    Both odd and non-square: a symmetric probe would let a swapped pair
+    of cases pass unnoticed, which is the failure this exists to catch.
+    Smooth rather than random, because JPEG at quality 95 keeps a
+    gradient nearly intact and turns white noise into porridge.
+    """
+    from PIL import Image
+
+    y, x = np.mgrid[0:height, 0:width]
+    pic = np.stack(
+        [(x * 4) % 256, (y * 6) % 256, ((x * 2 + y * 3) % 256)], axis=-1
+    ).astype(np.uint8)
+    return Image.fromarray(pic)
+
+
+@pytest.mark.parametrize("orientation", range(1, 9))
+def test_images_exif_orientation_agrees_exactly_on_png(native, tmp_path, orientation):
+    """PNG carries orientation in an `eXIf` chunk, and Pillow honours it.
+
+    This is the sharper of the two comparisons and the reason it exists:
+    PNG is lossless, so *both* decoders must produce the same bytes, and
+    the transform can be held to equality rather than to a margin. It is
+    also the case that actually diverged during development -- easyexif
+    parses JPEG only, so reading the chunk is code on the C++ side with
+    no counterpart in Pillow, and without this test a tagged PNG would
+    have rotated in Python and not in C++ with nothing to say so.
+    """
+    from PIL import Image
+
+    from sstvae.images import open_image
+
+    src = _exif_probe()
+    exif = Image.Exif()
+    exif[0x0112] = orientation
+    path = tmp_path / f"o{orientation}.png"
+    src.save(path, exif=exif)
+
+    want = np.array(open_image(path).convert("RGB"))
+    got = native.images.load(str(path))
+    assert got.shape == want.shape
+    assert np.array_equal(got, want)
+
+
+@pytest.mark.parametrize("orientation", range(1, 9))
+def test_images_exif_orientation_agrees(native, tmp_path, orientation):
+    from PIL import Image
+
+    from sstvae.images import open_image
+
+    src = _exif_probe()
+    exif = Image.Exif()
+    exif[0x0112] = orientation
+    path = tmp_path / f"o{orientation}.jpg"
+    src.save(path, exif=exif, quality=95)
+
+    want = np.array(open_image(path).convert("RGB"))
+    got = native.images.load(str(path))
+
+    assert got.shape == want.shape, (
+        f"orientation {orientation}: C++ produced {got.shape}, "
+        f"Pillow {want.shape} -- the axes were exchanged by one and not "
+        "the other"
+    )
+    err = float(np.mean(np.abs(got.astype(float) - want.astype(float))))
+
+    # The alternatives, built from Pillow's own primitives so this is not
+    # a restatement of either implementation's arithmetic.
+    others = []
+    for other in range(1, 9):
+        if other == orientation:
+            continue
+        alt = Image.Exif()
+        alt[0x0112] = other
+        alt_path = tmp_path / f"alt{other}.jpg"
+        src.save(alt_path, exif=alt, quality=95)
+        cand = np.array(open_image(alt_path).convert("RGB"))
+        if cand.shape == got.shape:
+            others.append(float(np.mean(np.abs(got.astype(float) - cand.astype(float)))))
+
+    assert err < 4.0, (
+        f"orientation {orientation}: the two loaders disagree by {err:.2f} "
+        "levels on average, which is more than two JPEG decoders should"
+    )
+    assert err * 4 < min(others), (
+        f"orientation {orientation}: {err:.2f} against the intended "
+        f"transform but {min(others):.2f} against the nearest other -- "
+        "not a decisive enough margin to call these the same transform"
+    )
 
 
 # --- resampling -------------------------------------------------------------


### PR DESCRIPTION
Phone photographs are stored in the sensor's orientation with an EXIF tag (0x0112) saying how to turn them. Neither loader read it.

The consequence is worse than a rotation: `fit_image` computes its cover-crop from the *stored* aspect ratio, so a portrait photo went out as a centre-crop of its own sideways self — which looks like a framing bug rather than a metadata one.

## Approach

Both implementations apply the tag at **open**, before framing.

- **Python** — `sstvae/images.py` gains `open_image`, which is `ImageOps.exif_transpose(Image.open(path))`. Used by `load_image` and by `overlay/render.py` for insets.
- **C++** — `native/third_party/easyexif/` is vendored (BSD, two files, no dependencies) for the JPEG parsing; `images::apply_orientation` does the eight index maps. `images::load` reads the file once and decodes with `stbi_load_from_memory`, since the pixels and the tag come from the same bytes.

Vendoring rather than hand-rolling was the call on the parsing — APP1 segment walking, `II`/`MM` byte order, TIFF IFD offsets and bounds-checking a hostile file are the fiddly half. TinyEXIF was the alternative; easyexif won on its memory-buffer entry point (the shape `load` needs) and on not making tinyxml2 a build-configuration question. Reasoning, including easyexif's dormancy, is recorded in `native/third_party/easyexif/README.md`.

## The divergence this nearly shipped

Pillow honours orientation in a PNG `eXIf` chunk; easyexif parses JPEG only. A tagged PNG would have rotated in Python and not in C++, silently, in the send path. `images.cpp` now locates that chunk and prepends the `Exif\0\0` signature PNG omits, handing the TIFF stream to easyexif — so TIFF parsing stays in the vendored code, and the chunk walk that is ours is a length-prefixed scan with no internal offsets.

That also made the parity comparison **exact**: PNG is lossless, so all eight orientations are compared byte for byte between the implementations. The JPEG comparison cannot be (stb is not libjpeg — an accepted above-the-modem difference), so it instead requires the intended transform to beat all seven alternatives by 4x, which a mere tolerance would not.

## Size limit

Declines any picture file above 1 GiB — before the allocation in C++, before the open in Python. Python raises `ValueError`; `_resolve_source` catches it so an oversized overlay inset draws nothing rather than taking the composition down, and the GUI already surfaces the C++ exception. `MAX_FILE_BYTES` is asserted equal across the two implementations, since nothing derives it and one refusing what the other sends is the failure worth preventing.

## Tests

- `native/tests/test_images.cpp` — 129 checks, new ctest target `images`. The oracle is a second derivation (each orientation as a composition of transpose/mirror-x/mirror-y from the EXIF table), not a restatement of the same inverse maps.
- `tests/test_images_exif.py` — 15, including the framing consequence above.
- `tests/test_native_parity.py` — 16 new, the exact PNG set and the JPEG margin set.

Three mutations verified to fail: swapping the 90° CW/CCW cases (4 checks), dropping `exif_transpose` (all 8 parity cases), stubbing the size comparison (1).

`pytest` 338 passed · `pytest --native` 338 passed · `pytest -m slow` 18 passed, 8 skipped · `ctest` 26/26 · `check_includes` and `check_layering` clean · `images.cpp` cross-compiles under mingw-w64.

## Deliberately not included

`sstvae/data.py`'s training loader and the one-off `scripts/*` that call `Image.open` directly. Rotating training inputs is a change to preprocessing, not to the send path, and shouldn't ride along with this. CLAUDE.md is not amended either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
