### PR TITLE
Make CW ID message customizable with {callsign} placeholder

### DIFF
--- a/native/core/settings/settings.cpp
+++ b/native/core/settings/settings.cpp
@@ -259,7 +259,8 @@ void read_transmit(const Reader& r, TransmitConfig& c) {
     r.get("level", c.level);
     r.get("optimize", c.optimize);
     r.get("cw_id", c.cw_id);
-    r.report_unknown({"mode", "level", "optimize", "cw_id"});
+    r.get("cw_message", c.cw_message);
+    r.report_unknown({"mode", "level", "optimize", "cw_id", "cw_message"});
 }
 
 void read_ui(const Reader& r, UiConfig& c) {
@@ -438,7 +439,8 @@ std::string to_json(const Config& c) {
          {{"mode", c.transmit.mode},
           {"level", c.transmit.level},
           {"optimize", c.transmit.optimize},
-          {"cw_id", c.transmit.cw_id}}},
+          {"cw_id", c.transmit.cw_id},
+          {"cw_message", c.transmit.cw_message}}},
         {"ui", {{"layout", c.ui.layout}, {"waterfall_height", c.ui.waterfall_height}}},
         {"version", c.version},
     };

--- a/native/core/settings/settings.hpp
+++ b/native/core/settings/settings.hpp
@@ -170,10 +170,19 @@ struct TransmitConfig {
     // matter through a plateau test that usually ends the run first.
     bool optimize = false;
 
-    // Send the configured callsign in Morse (18 wpm, 1000 Hz) 500 ms
-    // after each transmission, under the same PTT key-up. A no-op with
-    // no callsign set.
+    // Send `cw_message` in Morse (18 wpm, 1000 Hz) 500 ms after each
+    // transmission, under the same PTT key-up. A no-op with no callsign
+    // set -- there is nothing to identify with, whatever the message
+    // says.
     bool cw_id = false;
+
+    // What to send. `{callsign}` is replaced with the configured
+    // callsign; any other text is sent verbatim. The default both
+    // identifies the station and advertises the mode and software: a
+    // human who tunes across the OFDM signal with no idea what it is
+    // hears the CW ID and can go find SSTVAE and a successful decode,
+    // rather than just an unexplained tone.
+    std::string cw_message = "SSTVAE DE {callsign}";
 };
 
 // How the window arranges the receive and transmit halves.

--- a/native/core/tx/engine.cpp
+++ b/native/core/tx/engine.cpp
@@ -23,6 +23,27 @@ std::string sending_message(double duration_s) {
     return buf;
 }
 
+// Every occurrence of `{callsign}` becomes `callsign`; anything else in
+// `tmpl` is sent to the Morse generator verbatim, which is itself
+// tolerant of characters it cannot key (see dsp::generate_morse).
+std::string render_cw_message(const std::string& tmpl, const std::string& callsign) {
+    static const std::string placeholder = "{callsign}";
+    std::string out;
+    out.reserve(tmpl.size());
+    std::size_t pos = 0;
+    while (true) {
+        const std::size_t next = tmpl.find(placeholder, pos);
+        if (next == std::string::npos) {
+            out.append(tmpl, pos, std::string::npos);
+            break;
+        }
+        out.append(tmpl, pos, next - pos);
+        out += callsign;
+        pos = next + placeholder.size();
+    }
+    return out;
+}
+
 }  // namespace
 
 const char* phase_name(TxPhase p) {
@@ -129,8 +150,9 @@ std::vector<double> TxEngine::prepare(const images::Picture& image,
     if (config.cw_id && !config.callsign.empty()) {
         double peak = 0.0;
         for (double v : wave) peak = std::max(peak, std::abs(v));
+        const std::string text = render_cw_message(config.cw_message, config.callsign);
         const std::vector<double> id_tone = dsp::generate_morse(
-            config.callsign, FS, CW_ID_WPM, CW_ID_TONE_HZ, peak);
+            text, FS, CW_ID_WPM, CW_ID_TONE_HZ, peak);
         if (!id_tone.empty()) {
             wave.insert(wave.end(),
                         static_cast<std::size_t>(std::lround(CW_ID_GAP_S * FS)), 0.0);

--- a/native/core/tx/engine.hpp
+++ b/native/core/tx/engine.hpp
@@ -96,11 +96,19 @@ struct TxConfig {
     double level = 0.9;      // output peak, 0..1
     double ptt_lead_s = 0.3; // PTT up -> audio start (relay + ALC settling)
     double ptt_tail_s = 0.3; // audio end -> PTT down
-    // Send `callsign` in Morse (18 wpm, 1000 Hz) 500 ms after the
+    // Send `cw_message` in Morse (18 wpm, 1000 Hz) 500 ms after the
     // SSTVAE audio ends, under the same PTT key-up -- one continuous
     // transmission rather than a second relay click. No-op if callsign
-    // is empty; there is nothing to identify with.
+    // is empty; there is nothing to identify with, whatever the message
+    // says.
     bool cw_id = false;
+    // What to send as the CW ID. `{callsign}` is replaced with
+    // `callsign` above; any other text goes out verbatim. The default
+    // both identifies the station and advertises the mode and software:
+    // a human who tunes across the OFDM signal with no idea what it is
+    // hears the CW ID and can go find SSTVAE and a successful decode,
+    // rather than just an unexplained tone.
+    std::string cw_message = "SSTVAE DE {callsign}";
     // Exposed rather than compiled in for the same reason
     // `Modem::modulate` exposes its clip headroom: the reference's tests
     // shorten it by patching a module constant, which is unreachable

--- a/native/gui/settings_dialog.cpp
+++ b/native/gui/settings_dialog.cpp
@@ -820,9 +820,22 @@ QWidget* SettingsDialog::transmit_tab() {
     cw_id_ = new QCheckBox(tr("Send CW ID after each transmission"), page);
     cw_id_->setChecked(config_.transmit.cw_id);
     form->addRow(cw_id_);
-    form->addRow(note(tr("Sends the callsign above in Morse "
+    form->addRow(note(tr("Sends the message below in Morse "
                          "(18 wpm, 1000 Hz), 500 ms after the picture ends, "
-                         "under the same PTT key-up."),
+                         "under the same PTT key-up. No-op with no callsign "
+                         "set above, whatever the message says."),
+                      page));
+
+    cw_message_ = new QLineEdit(
+        QString::fromStdString(config_.transmit.cw_message), page);
+    cw_message_->setPlaceholderText(QStringLiteral("SSTVAE DE {callsign}"));
+    form->addRow(tr("CW message"), cw_message_);
+    form->addRow(note(tr("{callsign} is replaced with the callsign above; "
+                         "everything else is sent as typed. The default "
+                         "both identifies you and advertises the mode and "
+                         "software: someone who tunes across the signal "
+                         "with no idea what it is hears the CW ID and can "
+                         "go find SSTVAE and a successful decode."),
                       page));
 
     // The transmit level itself stays on the send bar, where it is
@@ -864,6 +877,7 @@ void SettingsDialog::apply_to(settings::Config& config) const {
 
     config.transmit.optimize = optimize_->isChecked();
     config.transmit.cw_id = cw_id_->isChecked();
+    config.transmit.cw_message = cw_message_->text().toStdString();
     config.receive.autosave = autosave_->isChecked();
     config.receive.save_audio = save_audio_->isChecked();
     config.receive.low_cpu = low_cpu_->isChecked();

--- a/native/gui/settings_dialog.hpp
+++ b/native/gui/settings_dialog.hpp
@@ -124,6 +124,7 @@ private:
     QLineEdit* callsign_ = nullptr;
     QCheckBox* optimize_ = nullptr;
     QCheckBox* cw_id_ = nullptr;
+    QLineEdit* cw_message_ = nullptr;
 
     // Receive
     QCheckBox* autosave_ = nullptr;

--- a/native/gui/tx_panel.cpp
+++ b/native/gui/tx_panel.cpp
@@ -950,6 +950,7 @@ void TransmitPanel::begin_transmit(const images::Picture& picture,
     tx_config.ptt_lead_s = config.rig.ptt_lead_s;
     tx_config.ptt_tail_s = config.rig.ptt_tail_s;
     tx_config.cw_id = config.transmit.cw_id;
+    tx_config.cw_message = config.transmit.cw_message;
 
     engine_ = std::make_unique<tx::TxEngine>(
         app_->ptt(),

--- a/native/tests/test_settings_dialog.cpp
+++ b/native/tests/test_settings_dialog.cpp
@@ -54,6 +54,8 @@ settings::Config populated() {
     c.folders.receive_dir = "/srv/sstv/in";
     c.folders.transmit_dir = "/srv/sstv/out";
     c.transmit.optimize = true;  // not the default, per this fixture's rule
+    c.transmit.cw_id = true;
+    c.transmit.cw_message = "TEST DE {callsign}";
     c.folders.template_dir = "/srv/sstv/tpl";
 
     c.receive.autosave = false;

--- a/native/tests/test_tx_engine.cpp
+++ b/native/tests/test_tx_engine.cpp
@@ -196,9 +196,14 @@ void test_cw_id_appends_after_the_transmission() {
     check::is_true(engine.transmit(test_picture(), config),
                    "tx/cwid: transmits with the ID on");
 
+    // The default message is the whole point of the feature (issue #14):
+    // it both identifies the station and advertises SSTVAE, not just the
+    // bare callsign.
+    check::equal(config.cw_message, std::string("SSTVAE DE {callsign}"),
+                "tx/cwid: the default CW message advertises the mode and software");
     const std::vector<double> id_tone = dsp::generate_morse(
-        config.callsign, config::FS, tx::CW_ID_WPM, tx::CW_ID_TONE_HZ, 1.0);
-    check::is_true(!id_tone.empty(), "tx/cwid: KC2G produces a tone");
+        "SSTVAE DE KC2G", config::FS, tx::CW_ID_WPM, tx::CW_ID_TONE_HZ, 1.0);
+    check::is_true(!id_tone.empty(), "tx/cwid: SSTVAE DE KC2G produces a tone");
     const std::size_t gap_n =
         static_cast<std::size_t>(std::lround(tx::CW_ID_GAP_S * config::FS));
 
@@ -264,6 +269,59 @@ void test_cw_id_does_nothing_with_no_callsign() {
 
     check::equal(played.size(), plain.size(),
                 "tx/cwid-none: no callsign means nothing is appended");
+}
+
+void test_cw_message_is_customizable() {
+    // issue #14: the operator can replace the default message. Every
+    // `{callsign}` in it becomes the configured callsign; the rest goes
+    // out verbatim.
+    std::vector<double> custom;
+    tx::TxEngine engine(nullptr, capturing_player(custom), good_encoder());
+    tx::TxConfig config = fast_config();
+    config.cw_id = true;
+    config.cw_message = "DE {callsign} {callsign} SSTV TEST";
+    check::is_true(engine.transmit(test_picture(), config),
+                   "tx/cwmsg: transmits with a custom message");
+
+    std::vector<double> plain;
+    tx::TxEngine baseline(nullptr, capturing_player(plain), good_encoder());
+    config.cw_id = false;
+    check::is_true(baseline.transmit(test_picture(), config),
+                   "tx/cwmsg: baseline transmits");
+
+    const std::vector<double> id_tone = dsp::generate_morse(
+        "DE KC2G KC2G SSTV TEST", config::FS, tx::CW_ID_WPM, tx::CW_ID_TONE_HZ, 1.0);
+    check::is_true(!id_tone.empty(), "tx/cwmsg: the substituted message produces a tone");
+    const std::size_t gap_n =
+        static_cast<std::size_t>(std::lround(tx::CW_ID_GAP_S * config::FS));
+    check::equal(custom.size(), plain.size() + gap_n + id_tone.size(),
+                "tx/cwmsg: every {callsign} placeholder was substituted, not just the first");
+}
+
+void test_cw_message_with_no_placeholder_is_sent_as_is() {
+    // A message with no `{callsign}` in it is still sent verbatim --
+    // useful for an operator who wants to spell the callsign into the
+    // message text themselves, or add nothing beyond a fixed phrase.
+    std::vector<double> custom;
+    tx::TxEngine engine(nullptr, capturing_player(custom), good_encoder());
+    tx::TxConfig config = fast_config();
+    config.cw_id = true;
+    config.cw_message = "SSTVAE";
+    check::is_true(engine.transmit(test_picture(), config),
+                   "tx/cwmsg-fixed: transmits");
+
+    std::vector<double> plain;
+    tx::TxEngine baseline(nullptr, capturing_player(plain), good_encoder());
+    config.cw_id = false;
+    check::is_true(baseline.transmit(test_picture(), config),
+                   "tx/cwmsg-fixed: baseline transmits");
+
+    const std::vector<double> id_tone = dsp::generate_morse(
+        "SSTVAE", config::FS, tx::CW_ID_WPM, tx::CW_ID_TONE_HZ, 1.0);
+    const std::size_t gap_n =
+        static_cast<std::size_t>(std::lround(tx::CW_ID_GAP_S * config::FS));
+    check::equal(custom.size(), plain.size() + gap_n + id_tone.size(),
+                "tx/cwmsg-fixed: the fixed message is sent with no substitution");
 }
 
 void test_no_rig_control_still_transmits() {
@@ -502,6 +560,8 @@ int main() {
         test_a_successful_transmission();
         test_cw_id_appends_after_the_transmission();
         test_cw_id_does_nothing_with_no_callsign();
+        test_cw_message_is_customizable();
+        test_cw_message_with_no_placeholder_is_sent_as_is();
         test_no_rig_control_still_transmits();
         test_a_throwing_player_still_unkeys();
         test_cancelling_during_playback_unkeys();

--- a/tests/test_native_settings.py
+++ b/tests/test_native_settings.py
@@ -104,6 +104,7 @@ NON_DEFAULT = {
         "level": 0.72,
         "optimize": True,
         "cw_id": True,
+        "cw_message": "TEST DE {callsign}",
     },
     "ui": {
         # Neither is a default: the default layout is "auto" and the


### PR DESCRIPTION
## Summary

Extends the CW ID feature to allow operators to customize the message sent after each transmission, while maintaining backward compatibility with a sensible default that advertises both the station callsign and the SSTVAE mode/software.

## Changes

- **New `cw_message` configuration field** in both `TxConfig` and `TransmitConfig` with default value `"SSTVAE DE {callsign}"` that:
  - Identifies the station (callsign)
  - Advertises the mode and software to anyone tuning across the signal
  - Allows operators to customize the message while using `{callsign}` as a placeholder for substitution

- **Message rendering logic** (`render_cw_message()` in `engine.cpp`):
  - Replaces all occurrences of `{callsign}` with the configured callsign
  - Sends any other text verbatim to the Morse generator
  - Supports messages with no placeholder (fixed phrases)

- **GUI updates** (`settings_dialog.cpp`):
  - Added `QLineEdit` for CW message configuration
  - Updated help text to explain the `{callsign}` placeholder mechanism
  - Clarified that CW ID is a no-op without a callsign, regardless of message content

- **Settings persistence**:
  - Added `cw_message` field to JSON serialization/deserialization
  - Updated settings reader to handle the new field

- **Test coverage**:
  - Updated existing CW ID test to verify the new default message format
  - Added `test_cw_message_is_customizable()` to verify placeholder substitution works for multiple occurrences
  - Added `test_cw_message_with_no_placeholder_is_sent_as_is()` to verify fixed messages work
  - Updated settings dialog test fixture to include the new field

## Implementation Details

The default message `"SSTVAE DE {callsign}"` addresses issue #14 by ensuring that someone who tunes across an SSTVAE transmission with no prior knowledge can hear the CW ID, recognize "SSTVAE" in the Morse code, and look up the software to decode the signal—rather than just hearing an unexplained tone.

The placeholder substitution is simple and tolerant: the Morse generator itself handles unknown characters gracefully, so operators can include spaces, numbers, and other text freely.

https://claude.ai/code/session_01RwdYeuf7amUN4eVdEBpmUH