### PR TITLE
Parallelize FFT operations with batched transforms

### DIFF
--- a/native/core/dsp/dsp.cpp
+++ b/native/core/dsp/dsp.cpp
@@ -395,8 +395,7 @@ std::vector<cdouble> fftconvolve_valid(std::span<const cdouble> a,
     std::vector<cdouble> pa(n, cdouble{}), pv(n, cdouble{});
     std::copy(a.begin(), a.end(), pa.begin());
     std::copy(v.begin(), v.end(), pv.begin());
-    std::vector<cdouble> fa = fft(pa, true);
-    const std::vector<cdouble> fv = fft(pv, true);
+    auto [fa, fv] = fft_pair(pa, pv, true);
     for (std::size_t i = 0; i < n; ++i) fa[i] *= fv[i];
     const std::vector<cdouble> conv = fft(fa, false);
 
@@ -420,17 +419,13 @@ std::vector<double> fftconvolve_valid(std::span<const double> a,
     std::copy(a.begin(), a.end(), pa.begin());
     std::copy(v.begin(), v.end(), pv.begin());
 
-    std::vector<cdouble> fa(nc), fv(nc);
-    const pocketfft::shape_t shape{n};
-    const pocketfft::stride_t stride_r{static_cast<std::ptrdiff_t>(sizeof(double))};
-    const pocketfft::stride_t stride_c{static_cast<std::ptrdiff_t>(sizeof(cdouble))};
-    pocketfft::r2c(shape, stride_r, stride_c, pocketfft::shape_t{0}, true,
-                   pa.data(), fa.data(), 1.0);
-    pocketfft::r2c(shape, stride_r, stride_c, pocketfft::shape_t{0}, true,
-                   pv.data(), fv.data(), 1.0);
+    auto [fa, fv] = r2c_pair(pa, pv);
     for (std::size_t i = 0; i < nc; ++i) fa[i] *= fv[i];
 
     std::vector<double> conv(n);
+    const pocketfft::shape_t shape{n};
+    const pocketfft::stride_t stride_r{static_cast<std::ptrdiff_t>(sizeof(double))};
+    const pocketfft::stride_t stride_c{static_cast<std::ptrdiff_t>(sizeof(cdouble))};
     pocketfft::c2r(shape, stride_c, stride_r, pocketfft::shape_t{0}, false,
                    fa.data(), conv.data(), 1.0 / static_cast<double>(n));
 

--- a/native/core/dsp/fft.hpp
+++ b/native/core/dsp/fft.hpp
@@ -10,8 +10,11 @@
 
 #pragma once
 
+#include <algorithm>
 #include <complex>
 #include <cstddef>
+#include <thread>
+#include <utility>
 #include <vector>
 
 // Cache a handful of FFT plans (twiddle factors) instead of rebuilding
@@ -42,9 +45,31 @@ namespace sstvae::dsp {
 
 using cdouble = std::complex<double>;
 
+// Capped rather than handed hardware_concurrency() outright: this runs
+// on the live decode loop's thread, alongside audio and rig I/O that
+// also want CPU, so unbounded fan-out would rob those of headroom for
+// a transform too small to need it. 4 is enough to matter on the
+// small, fixed set of lengths this codebase's hot paths use without
+// claiming a whole big machine for one FFT.
+//
+// Only worth passing to a *batched* pocketfft call (fft_pair/r2c_pair
+// below). pocketfft parallelizes across the independent transforms
+// sharing one call, not within a single one -- its own thread_count()
+// divides the batch size by the transform length, so a lone vector
+// (batch of 1) always collapses back to 1 thread no matter what this
+// returns. Measured against pocketfft_hdronly.h's util::thread_count:
+// confirmed by inspection, not by profiling a change that cannot show
+// up in a profile.
+inline std::size_t fft_thread_count() {
+    static const std::size_t n = std::min<std::size_t>(
+        4, std::max<std::size_t>(1, std::thread::hardware_concurrency()));
+    return n;
+}
+
 // In-place-free complex FFT. `forward` selects the sign convention;
 // the inverse is scaled by 1/n so that ifft(fft(x)) == x, matching
-// numpy and scipy.
+// numpy and scipy. A lone transform, so single-threaded by construction
+// (see fft_thread_count) -- nthreads=1 here is not a missed opportunity.
 inline std::vector<cdouble> fft(const std::vector<cdouble>& x, bool forward) {
     const std::size_t n = x.size();
     std::vector<cdouble> out(n);
@@ -56,6 +81,64 @@ inline std::vector<cdouble> fft(const std::vector<cdouble>& x, bool forward) {
     pocketfft::c2c(shape, stride, stride, pocketfft::shape_t{0}, forward,
                    x.data(), out.data(), scale);
     return out;
+}
+
+// Two same-length complex transforms (both forward or both inverse) as
+// one batched pocketfft call, so there are two independent lines for
+// fft_thread_count()'s threads to actually split across -- see the note
+// there. `a` and `b` must be the same length. Used by fftconvolve_valid,
+// which always computes fft(a) and fft(b) together.
+inline std::pair<std::vector<cdouble>, std::vector<cdouble>> fft_pair(
+    const std::vector<cdouble>& a, const std::vector<cdouble>& b, bool forward) {
+    const std::size_t n = a.size();
+    std::pair<std::vector<cdouble>, std::vector<cdouble>> result{
+        std::vector<cdouble>(n), std::vector<cdouble>(n)};
+    if (n == 0) return result;
+    std::vector<cdouble> buf_in(2 * n), buf_out(2 * n);
+    std::copy(a.begin(), a.end(), buf_in.begin());
+    std::copy(b.begin(), b.end(), buf_in.begin() + static_cast<std::ptrdiff_t>(n));
+    const pocketfft::shape_t shape{2, n};
+    const pocketfft::stride_t stride{
+        static_cast<std::ptrdiff_t>(n * sizeof(cdouble)),
+        static_cast<std::ptrdiff_t>(sizeof(cdouble))};
+    const double scale = forward ? 1.0 : 1.0 / static_cast<double>(n);
+    pocketfft::c2c(shape, stride, stride, pocketfft::shape_t{1}, forward,
+                   buf_in.data(), buf_out.data(), scale, fft_thread_count());
+    std::copy(buf_out.begin(), buf_out.begin() + static_cast<std::ptrdiff_t>(n),
+              result.first.begin());
+    std::copy(buf_out.begin() + static_cast<std::ptrdiff_t>(n), buf_out.end(),
+              result.second.begin());
+    return result;
+}
+
+// Two same-length real->complex forward transforms as one batched
+// pocketfft call, for the same reason as fft_pair. `a` and `b` must be
+// the same length.
+inline std::pair<std::vector<cdouble>, std::vector<cdouble>> r2c_pair(
+    const std::vector<double>& a, const std::vector<double>& b) {
+    const std::size_t n = a.size();
+    const std::size_t nc = n / 2 + 1;
+    std::pair<std::vector<cdouble>, std::vector<cdouble>> result{
+        std::vector<cdouble>(nc), std::vector<cdouble>(nc)};
+    if (n == 0) return result;
+    std::vector<double> buf_in(2 * n);
+    std::copy(a.begin(), a.end(), buf_in.begin());
+    std::copy(b.begin(), b.end(), buf_in.begin() + static_cast<std::ptrdiff_t>(n));
+    std::vector<cdouble> buf_out(2 * nc);
+    const pocketfft::shape_t shape_in{2, n};
+    const pocketfft::stride_t stride_r{
+        static_cast<std::ptrdiff_t>(n * sizeof(double)),
+        static_cast<std::ptrdiff_t>(sizeof(double))};
+    const pocketfft::stride_t stride_c{
+        static_cast<std::ptrdiff_t>(nc * sizeof(cdouble)),
+        static_cast<std::ptrdiff_t>(sizeof(cdouble))};
+    pocketfft::r2c(shape_in, stride_r, stride_c, pocketfft::shape_t{1}, true,
+                   buf_in.data(), buf_out.data(), 1.0, fft_thread_count());
+    std::copy(buf_out.begin(), buf_out.begin() + static_cast<std::ptrdiff_t>(nc),
+              result.first.begin());
+    std::copy(buf_out.begin() + static_cast<std::ptrdiff_t>(nc), buf_out.end(),
+              result.second.begin());
+    return result;
 }
 
 }  // namespace sstvae::dsp


### PR DESCRIPTION
## Summary

Add support for batched FFT operations to enable multi-threaded parallelization of independent transforms. This improves performance in `fftconvolve_valid` by computing pairs of FFTs simultaneously rather than sequentially.

## Key Changes

- **New `fft_thread_count()` function**: Returns a capped thread count (max 4) for FFT operations. The cap prevents unbounded thread spawning on the live decode loop's thread, which also handles audio and rig I/O. Includes detailed comments explaining why batching is necessary for pocketfft's parallelization strategy.

- **New `fft_pair()` function**: Computes two same-length complex FFTs (forward or inverse) as a single batched pocketfft call. This allows pocketfft's thread pool to split work across two independent transforms rather than processing them sequentially.

- **New `r2c_pair()` function**: Computes two same-length real-to-complex FFTs as a single batched pocketfft call, following the same batching strategy as `fft_pair()`.

- **Updated `fftconvolve_valid()` implementations**: 
  - Complex version now uses `fft_pair()` to compute `fft(pa)` and `fft(pv)` together
  - Real version now uses `r2c_pair()` to compute the real-to-complex transforms together, eliminating redundant pocketfft setup code

- **Added includes**: `<algorithm>`, `<thread>`, and `<utility>` to support the new functionality.

## Implementation Details

The key insight is that pocketfft's parallelization works across independent transforms in a batch (dividing batch size by transform length), not within a single transform. A lone vector always collapses to single-threaded execution regardless of the thread count parameter. By batching the two FFTs needed in convolution, we create two independent lines of work that can actually be parallelized.

The thread count is capped at 4 to balance performance gains against resource contention with other live-path operations (audio processing, rig I/O) running on the same thread.

https://claude.ai/code/session_015VqCa1yoHi7DDqmGvywLAE