### PR TITLE
Fix race condition in rig polling test with bounded wait

### DIFF
--- a/native/tests/test_rig.cpp
+++ b/native/tests/test_rig.cpp
@@ -170,6 +170,22 @@ struct Published {
         }
         return false;
     }
+    // Frequency and status are two separate, unsynchronized callbacks
+    // from the worker thread (`RigSession::publish_frequency` then
+    // `publish_status`) -- waiting on the former is not a guarantee the
+    // latter has landed yet. Bounded rather than an unconditional
+    // `cv.wait`, so a status that never arrives is a ctest TIMEOUT
+    // failure with a clear predicate rather than a silent hang.
+    bool wait_for_status_containing(const std::string& needle,
+                                    double timeout_s = 5.0) {
+        std::unique_lock<std::mutex> lock(m);
+        return cv.wait_for(lock, std::chrono::duration<double>(timeout_s), [&] {
+            for (const std::string& s : statuses) {
+                if (s.find(needle) != std::string::npos) return true;
+            }
+            return false;
+        });
+    }
 };
 
 // --- backoff ----------------------------------------------------------------
@@ -330,7 +346,7 @@ void test_polling_publishes_frequency_and_status() {
     pub.wait_for_frequency();
     check::is_true(controller.frequency_hz().has_value(),
                    "rig/poll: the cached frequency is available to read");
-    check::is_true(pub.saw_status_containing("14.2300 MHz"),
+    check::is_true(pub.wait_for_status_containing("14.2300 MHz"),
                    "rig/poll: the status text carries the dial frequency");
     check::is_true(pub.saw_status_containing("Fake Rig"),
                    "rig/poll: and the rig announces itself on connecting");


### PR DESCRIPTION
## Summary
Fix a race condition in `test_polling_publishes_frequency_and_status` where the test could pass prematurely without verifying that the status callback had actually been received. The worker thread publishes frequency and status through separate, unsynchronized callbacks, so waiting for frequency is not a guarantee that status has arrived yet.

## Changes
- **Added `wait_for_status_containing()` method** to the `Published` test helper struct that uses a bounded `cv.wait_for()` with a 5-second timeout instead of an unconditional check. This ensures:
  - The test actually waits for the status to arrive before asserting
  - A missing status results in a clear ctest TIMEOUT failure rather than a silent hang
  - The predicate is checked repeatedly until the timeout expires
  
- **Updated test assertion** from `pub.saw_status_containing("14.2300 MHz")` to `pub.wait_for_status_containing("14.2300 MHz")` to properly synchronize on the status callback arrival

## Implementation Details
The new method mirrors the existing `wait_for_frequency()` pattern but searches through the accumulated `statuses` vector for a substring match. The bounded wait is essential because `RigSession::publish_frequency` and `publish_status` are independent callbacks from the worker thread with no synchronization between them.

https://claude.ai/code/session_01X9sCegGn2LHoT8kx7NaeCd