### PR TITLE
Conditionally compile PulseAudio note on Unix platforms

### DIFF
--- a/native/gui/settings_dialog.cpp
+++ b/native/gui/settings_dialog.cpp
@@ -28,6 +28,7 @@
 #include <QThread>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <QtGlobal>
 
 #include <exception>
 #include <memory>
@@ -401,6 +402,15 @@ QWidget* SettingsDialog::audio_tab() {
     auto* refresh = new QPushButton(tr("Refresh"), page);
     connect(refresh, &QPushButton::clicked, this, &SettingsDialog::refresh_devices);
     form->addRow(QString(), style::row(page, {refresh}));
+    // The note is about PulseAudio/PipeWire and its detail is a pair of
+    // `pactl` commands, so it is advice only where those exist. On macOS
+    // and Windows it is not merely irrelevant, it points at tooling the
+    // operator does not have -- and a loopback there is a different
+    // product entirely (BlackHole, WASAPI loopback), not this recipe with
+    // the names changed. Compiled out rather than hidden at runtime: the
+    // condition is a property of the build, and `tr()` on text no one can
+    // reach is work for translators as well.
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     form->addRow(QString(),
                  style::note_with_detail(
                      tr("Qt does not list PulseAudio/PipeWire monitor sources, "
@@ -411,6 +421,7 @@ QWidget* SettingsDialog::audio_tab() {
                         "source_name=sstvae_loop master=null-sink.monitor "
                         "channels=1"),
                      page));
+#endif
     add_gap(form);
 
     // Labelled rather than left floating in the field column: it is a


### PR DESCRIPTION
Hide the PulseAudio/PipeWire loopback setup instructions behind a platform-specific preprocessor guard, as they are only relevant on Linux and other Unix systems.

## Summary

The audio settings dialog includes a note with detailed instructions for setting up a PulseAudio/PipeWire loopback device. This guidance is specific to Unix-like systems (Linux, etc.) and is not applicable on macOS or Windows, where loopback devices are implemented differently (BlackHole on macOS, WASAPI loopback on Windows). Rather than hiding this at runtime, it is now compiled out entirely on non-Unix platforms.

## Changes

- Added `#include <QtGlobal>` to access Qt platform detection macros
- Wrapped the PulseAudio/PipeWire note UI code with `#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)` preprocessor guards
- Added detailed comment explaining the rationale: the condition is a build-time property, and compiling out unreachable translatable strings avoids unnecessary work for translators

## Implementation Details

The guard uses Qt's standard platform detection macros to target Unix systems excluding macOS. This approach is cleaner than runtime visibility checks because:
- The applicability of the instructions is determined at build time, not runtime
- Translators won't spend effort on strings that are unreachable on certain platforms
- The compiled binary is slightly smaller on non-Unix platforms

https://claude.ai/code/session_01FyVEkapPBcCwq662hQ2KEa