### PR TITLE
support zooming out when composing an image

### DIFF
--- a/native/apps/sstvae_gui_shot.cpp
+++ b/native/apps/sstvae_gui_shot.cpp
@@ -351,15 +351,27 @@ int main(int argc, char** argv) {
                 source.rgb[i + 2] = static_cast<unsigned char>(y * 255 / SH);
             }
         }
-        sstvae::gui::CropDialog dialog(source, sstvae::images::Framing{});
-        dialog.resize(width > 0 ? width : 640, height > 0 ? height : 560);
-        dialog.show();
-        app.processEvents();
-        const QString path = QStringLiteral("%1/crop.png").arg(out);
-        dialog.grab().save(path);
-        std::printf("%s (min %dx%d)\n", path.toLocal8Bit().constData(),
-                    dialog.minimumSizeHint().width(),
-                    dialog.minimumSizeHint().height());
+        // Both ends of the zoom: the crop the dialog was written for,
+        // and the fully zoomed-out framing, where the window overhangs
+        // the picture and the overhang is the black that goes on the
+        // air. The second is the one worth eyes -- padding drawn as the
+        // dialog's background instead of black would look plausible and
+        // be a lie about what is transmitted.
+        sstvae::images::Framing framings[2];
+        framings[1].zoom = sstvae::images::min_zoom(SW, SH);
+        const char* names[2] = {"crop", "crop-zoomed-out"};
+        for (int i = 0; i < 2; ++i) {
+            sstvae::gui::CropDialog dialog(source, framings[i]);
+            dialog.resize(width > 0 ? width : 640, height > 0 ? height : 560);
+            dialog.show();
+            app.processEvents();
+            const QString path = QStringLiteral("%1/%2.png")
+                                     .arg(out, QLatin1String(names[i]));
+            dialog.grab().save(path);
+            std::printf("%s (min %dx%d)\n", path.toLocal8Bit().constData(),
+                        dialog.minimumSizeHint().width(),
+                        dialog.minimumSizeHint().height());
+        }
     }
 
     // The observability widgets, with representative content: the pane

--- a/native/core/images/images.cpp
+++ b/native/core/images/images.cpp
@@ -34,6 +34,15 @@ Picture resize(const Picture& img, int width, int height) {
 
 Picture fit(const Picture& img) { return fit(img, Framing{}); }
 
+double min_zoom(int width, int height) {
+    if (width <= 0 || height <= 0) return 1.0;
+    const double src = static_cast<double>(width) / height;
+    const double target = static_cast<double>(IMG_W) / IMG_H;
+    // contain / cover, which is the ratio of the two aspects whichever
+    // way round they are.
+    return std::min(src, target) / std::max(src, target);
+}
+
 Picture fit(const Picture& img, const Framing& framing) {
     // The identity short-circuit only applies to the default framing:
     // an operator who has zoomed or panned an already-4:3 picture means
@@ -45,15 +54,23 @@ Picture fit(const Picture& img, const Framing& framing) {
         throw std::runtime_error("cannot fit an empty picture");
     }
 
-    // Scale to *cover* the target, then crop -- the same shape of
-    // operation as images.py, though not the same filter. Zoom below 1
-    // would expose edges with no picture behind them.
-    const double zoom = std::max(1.0, framing.zoom);
+    // Scale relative to *cover* the target, then crop -- the same shape
+    // of operation as images.py, though not the same filter. Below
+    // `min_zoom` there is nothing left to reveal, only more black.
+    const double zoom =
+        std::max(min_zoom(img.width, img.height), framing.zoom);
     const double scale = std::max(static_cast<double>(IMG_W) / img.width,
                                   static_cast<double>(IMG_H) / img.height) *
                          zoom;
-    const int sw = std::max(IMG_W, static_cast<int>(std::lround(img.width * scale)));
-    const int sh = std::max(IMG_H, static_cast<int>(std::lround(img.height * scale)));
+    // At zoom 1 and above the scaled picture covers the target, and the
+    // floor of IMG_W/IMG_H is the old guard against rounding a pixel
+    // short of it. Below 1 an axis is *meant* to come up short, so the
+    // guard would be exactly the bug -- it would silently cancel the
+    // padding the operator asked for.
+    const int floor_w = zoom >= 1.0 ? IMG_W : 1;
+    const int floor_h = zoom >= 1.0 ? IMG_H : 1;
+    const int sw = std::max(floor_w, static_cast<int>(std::lround(img.width * scale)));
+    const int sh = std::max(floor_h, static_cast<int>(std::lround(img.height * scale)));
 
     const Picture scaled = resize(img, sw, sh);
 
@@ -66,20 +83,34 @@ Picture fit(const Picture& img, const Framing& framing) {
     // pins this against the old formula written out; the Python parity
     // suite cannot, since it deliberately skips `fit_image` wherever
     // resampling is involved (PIL LANCZOS vs stb).
+    //
+    // The two clamp bounds are `0` and `scaled - target` in whichever
+    // order they come: when the scaled picture is the larger the window
+    // must stay inside it (the original rule), and when it is the
+    // smaller the same expression keeps the *picture* inside the
+    // window, so the padding never lands all on one side with the
+    // photograph half off the canvas.
     const auto offset = [](double center, int scaled_size, int target) {
         const double raw = center * scaled_size - target / 2.0;
-        const int limit = scaled_size - target;
-        return std::clamp(static_cast<int>(std::floor(raw)), 0, limit);
+        const int slack = scaled_size - target;
+        return std::clamp(static_cast<int>(std::floor(raw)), std::min(0, slack),
+                          std::max(0, slack));
     };
     const int left = offset(framing.center_x, sw, IMG_W);
     const int top = offset(framing.center_y, sh, IMG_H);
 
+    // Zero-initialized, which is the black the uncovered part is padded
+    // with -- so the copy below only has to skip what it cannot fill.
     Picture out(IMG_W, IMG_H);
+    const int x0 = std::max(0, -left);            // first covered column
+    const int x1 = std::min(IMG_W, sw - left);    // one past the last
     for (int y = 0; y < IMG_H; ++y) {
+        const int sy = y + top;
+        if (sy < 0 || sy >= sh || x1 <= x0) continue;
         const std::uint8_t* src =
-            scaled.rgb.data() + (static_cast<std::size_t>(y + top) * sw + left) * 3;
-        std::copy(src, src + static_cast<std::size_t>(IMG_W) * 3,
-                  out.rgb.begin() + static_cast<std::size_t>(y) * IMG_W * 3);
+            scaled.rgb.data() + (static_cast<std::size_t>(sy) * sw + (x0 + left)) * 3;
+        std::copy(src, src + static_cast<std::size_t>(x1 - x0) * 3,
+                  out.rgb.begin() + (static_cast<std::size_t>(y) * IMG_W + x0) * 3);
     }
     return out;
 }

--- a/native/core/images/images.hpp
+++ b/native/core/images/images.hpp
@@ -35,16 +35,20 @@ Picture resize(const Picture& img, int width, int height);
 // How a picture is framed into the target rectangle.
 //
 // The pictures the codec sends are 4:3, and anything else has to lose
-// something. The default here is what this function has always done
-// silently -- scale to cover, crop the centre -- expressed as data so
-// the operator can move it. There is no letterbox option: padding
-// would spend airtime on black, and the decision (2026-08-01) was that
-// an operator who wants the whole frame pads the file themselves.
+// something -- or pad. The default here is what this function has
+// always done silently -- scale to cover, crop the centre -- expressed
+// as data so the operator can move it. Zooming *out* past cover is
+// allowed and letterboxes: the earlier "no letterbox" decision
+// (2026-08-01) was reversed, because spending a little airtime on black
+// is the operator's call to make and the alternative was editing the
+// file outside the app.
 struct Framing {
     // Multiplier on the *cover* scale -- the smallest scale that fills
     // the target. 1.0 is the tightest framing that keeps the picture
-    // full-bleed; above 1.0 crops in further. Below 1.0 would expose
-    // edges with nothing behind them, so callers clamp there.
+    // full-bleed; above 1.0 crops in further; below 1.0 shows more of
+    // the source than the target rectangle can fill, and the rest is
+    // black. `min_zoom` is the floor, where the whole source is
+    // visible; callers clamp there.
     double zoom = 1.0;
     // Centre of the crop window in normalized source coordinates.
     // (0.5, 0.5) is the middle of the picture, which is what the
@@ -53,8 +57,18 @@ struct Framing {
     double center_y = 0.5;
 };
 
-// Any picture -> exactly IMG_W x IMG_H RGB, by scaling to cover the
-// target and cropping. Deterministic and aspect-preserving.
+// The smallest useful zoom for a source of this size: the one at which
+// the crop window is exactly the whole picture. Always <= 1, and
+// exactly 1 for a 4:3 source, where cover and contain are the same
+// scale. Zooming further out would only add black, so `fit` clamps to
+// this and the framing dialog's slider stops here -- one function so
+// the preview and the transmitted picture cannot disagree about where
+// the end of the travel is.
+double min_zoom(int width, int height);
+
+// Any picture -> exactly IMG_W x IMG_H RGB, by scaling and cropping.
+// Deterministic and aspect-preserving. Below zoom 1 the scaled picture
+// no longer fills the target and what it does not cover is black.
 //
 // Already-correct input is returned untouched, which is the path the
 // parity tests use.

--- a/native/gui/crop_dialog.cpp
+++ b/native/gui/crop_dialog.cpp
@@ -23,13 +23,20 @@ namespace {
 // Zoom is exposed as integer slider steps because QSlider is integral;
 // 100 steps is 1.00x (exactly cover) and the top is a 4x crop, which is
 // tighter than anyone sensibly wants and still leaves the arithmetic
-// well away from the single-pixel end.
-constexpr int ZOOM_MIN = 100;
+// well away from the single-pixel end. The *bottom* is not a constant:
+// it depends on the source's aspect, since that is what decides how far
+// out the window can go before it is showing the whole picture.
 constexpr int ZOOM_MAX = 400;
 
 double steps_to_zoom(int steps) { return steps / 100.0; }
 int zoom_to_steps(double zoom) {
-    return std::clamp(static_cast<int>(std::lround(zoom * 100.0)), ZOOM_MIN, ZOOM_MAX);
+    return std::clamp(static_cast<int>(std::lround(zoom * 100.0)), 1, ZOOM_MAX);
+}
+// One step below the exact minimum, floored: the slider's bottom
+// position must be *reachable* as the full-picture framing, and
+// `CropView` clamps whatever it is handed up to the exact value.
+int min_steps_for(double min_zoom) {
+    return std::max(1, static_cast<int>(std::floor(min_zoom * 100.0)));
 }
 
 QPixmap to_pixmap(const images::Picture& picture) {
@@ -66,23 +73,15 @@ void CropView::set_framing(const images::Framing& framing) {
     update();
 }
 
-QRectF CropView::source_rect() const {
-    if (source_.empty()) return {};
-    const double sw = source_.width;
-    const double sh = source_.height;
-    const double scale = std::min(width() / sw, height() / sh);
-    const double w = sw * scale;
-    const double h = sh * scale;
-    return {(width() - w) / 2.0, (height() - h) / 2.0, w, h};
+double CropView::min_zoom() const {
+    return images::min_zoom(source_.width, source_.height);
 }
 
-QRectF CropView::crop_rect() const {
-    const QRectF area = source_rect();
-    if (area.isEmpty()) return {};
-
-    // The crop window's size as a *fraction of the source*, which is
-    // what the framing means: at zoom 1 the window is the largest 4:3
-    // rectangle that fits, and zoom shrinks it from there.
+QSizeF CropView::crop_fractions(double zoom) const {
+    // At zoom 1 the window is the largest 4:3 rectangle that fits
+    // inside the source; zoom shrinks it from there, and zooming out
+    // grows it past the source's short axis -- which is exactly the
+    // black `images::fit` pads with.
     const double src_aspect =
         static_cast<double>(source_.width) / source_.height;
     const double target_aspect =
@@ -95,31 +94,60 @@ QRectF CropView::crop_rect() const {
     } else {
         frac_h = src_aspect / target_aspect;  // taller: lose height
     }
-    const double zoom = std::max(1.0, framing_.zoom);
-    frac_w /= zoom;
-    frac_h /= zoom;
+    const double z = std::max(1e-6, zoom);
+    return {frac_w / z, frac_h / z};
+}
 
-    const double w = area.width() * frac_w;
-    const double h = area.height() * frac_h;
+QRectF CropView::source_rect() const {
+    if (source_.empty()) return {};
+    const double sw = source_.width;
+    const double sh = source_.height;
+    // Room is reserved for the widest window the zoom can reach, at a
+    // fixed size rather than one that changes with the zoom: the
+    // picture must not slide around under the operator while they are
+    // sizing a window over it, and a window drawn past the widget's
+    // edge would hide the very padding it is there to show.
+    const QSizeF widest = crop_fractions(min_zoom());
+    const double scale = std::min(width() / (sw * std::max(1.0, widest.width())),
+                                  height() / (sh * std::max(1.0, widest.height())));
+    const double w = sw * scale;
+    const double h = sh * scale;
+    return {(width() - w) / 2.0, (height() - h) / 2.0, w, h};
+}
+
+QRectF CropView::crop_rect() const {
+    const QRectF area = source_rect();
+    if (area.isEmpty()) return {};
+
+    const QSizeF frac = crop_fractions(framing_.zoom);
+    const double w = area.width() * frac.width();
+    const double h = area.height() * frac.height();
     const double cx = area.left() + area.width() * framing_.center_x;
     const double cy = area.top() + area.height() * framing_.center_y;
     return {cx - w / 2.0, cy - h / 2.0, w, h};
 }
 
 void CropView::clamp_center() {
-    framing_.zoom = std::clamp(framing_.zoom, steps_to_zoom(ZOOM_MIN),
-                               steps_to_zoom(ZOOM_MAX));
+    framing_.zoom =
+        std::clamp(framing_.zoom, min_zoom(), steps_to_zoom(ZOOM_MAX));
     if (source_.empty()) return;
     const QRectF area = source_rect();
     if (area.isEmpty()) return;
     const QRectF crop = crop_rect();
-    // Half the window's size, as a fraction of the source: the centre
-    // cannot come closer to an edge than that without the window
-    // hanging over nothing.
+    // Half the window's size, as a fraction of the source. While the
+    // window is the smaller of the two this keeps it inside the
+    // picture; once it overhangs, `half` passes 0.5 and the two bounds
+    // swap, which keeps the *picture* inside the window instead -- the
+    // same rule `images::fit` clamps its pixel offsets by, so the
+    // preview cannot promise a framing the transmitted picture will not
+    // have. std::clamp is UB with its bounds the wrong way round, hence
+    // the explicit min/max rather than passing them straight through.
     const double half_w = crop.width() / area.width() / 2.0;
     const double half_h = crop.height() / area.height() / 2.0;
-    framing_.center_x = std::clamp(framing_.center_x, half_w, 1.0 - half_w);
-    framing_.center_y = std::clamp(framing_.center_y, half_h, 1.0 - half_h);
+    framing_.center_x = std::clamp(framing_.center_x, std::min(half_w, 1.0 - half_w),
+                                   std::max(half_w, 1.0 - half_w));
+    framing_.center_y = std::clamp(framing_.center_y, std::min(half_h, 1.0 - half_h),
+                                   std::max(half_h, 1.0 - half_h));
 }
 
 void CropView::paintEvent(QPaintEvent* event) {
@@ -137,14 +165,21 @@ void CropView::paintEvent(QPaintEvent* event) {
     painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
     painter.drawPixmap(area, pixmap_, QRectF(pixmap_.rect()));
 
-    // Everything outside the window is dimmed rather than hidden, so
-    // the operator can see what is being given up -- which is the whole
-    // complaint this dialog answers.
     const QRectF crop = crop_rect();
     QPainterPath outside;
     outside.addRect(area);
     QPainterPath inside;
     inside.addRect(crop);
+
+    // Whatever the window covers that the picture does not is drawn as
+    // the black it will actually be sent as -- opaque, and not the
+    // dialog's background, so what the operator sees inside the window
+    // is the transmitted frame.
+    painter.fillPath(inside.subtracted(outside), QColor(0, 0, 0));
+
+    // Everything outside the window is dimmed rather than hidden, so
+    // the operator can see what is being given up -- which is the whole
+    // complaint this dialog answers.
     painter.fillPath(outside.subtracted(inside), QColor(0, 0, 0, 140));
 
     // A two-tone border, the same idiom the overlay editor's selection
@@ -226,7 +261,8 @@ CropDialog::CropDialog(const images::Picture& source,
 
     summary_ = new QLabel(this);
     summary_->setText(tr("%1x%2 source, sent as %3x%4. Drag to reposition; "
-                         "the wheel or the slider zooms.")
+                         "the wheel or the slider zooms. Zoom all the way "
+                         "out to send the whole picture, padded with black.")
                           .arg(source.width)
                           .arg(source.height)
                           .arg(images::IMG_W)
@@ -243,7 +279,11 @@ CropDialog::CropDialog(const images::Picture& source,
     auto* zoom_row = new QHBoxLayout();
     zoom_row->addWidget(new QLabel(tr("Zoom:"), this));
     zoom_ = new QSlider(Qt::Horizontal, this);
-    zoom_->setRange(ZOOM_MIN, ZOOM_MAX);
+    // The bottom of the range is the source's own full-picture zoom,
+    // asked of the view rather than recomputed here: two copies of that
+    // arithmetic would let the slider stop somewhere the framing does
+    // not.
+    zoom_->setRange(min_steps_for(view_->min_zoom()), ZOOM_MAX);
     zoom_->setValue(zoom_to_steps(view_->framing().zoom));
     connect(zoom_, &QSlider::valueChanged, this, &CropDialog::on_zoom_changed);
     zoom_row->addWidget(zoom_, 1);

--- a/native/gui/crop_dialog.hpp
+++ b/native/gui/crop_dialog.hpp
@@ -11,9 +11,16 @@
 // So: when a chosen picture is not 4:3, this dialog opens on top of
 // the original with an aspect-locked window over it. Accepting the
 // default is exactly the old behaviour, one keypress away, which is
-// what keeps it out of the way of an operator in a hurry. There is no
-// letterbox alternative (decided 2026-08-01): padding spends airtime
-// on black, and anyone who wants the whole frame can pad the file.
+// what keeps it out of the way of an operator in a hurry.
+//
+// The zoom travels *out* as well as in, down to the point where the
+// window covers the whole source and the parts of the canvas the
+// picture cannot fill go out black. That reverses the 2026-08-01 "no
+// letterbox" decision -- it is airtime spent on black, but which
+// trade-off is right belongs to the operator, and the alternative was
+// padding the file in another program. The end of the travel is
+// `images::min_zoom`, shared with `images::fit` so the preview and the
+// transmitted picture agree about where it is.
 //
 // The dialog owns no picture data beyond the source it is handed; what
 // it returns is a `images::Framing`, so the caller keeps the original
@@ -49,6 +56,9 @@ public:
     void set_source(const images::Picture& source);
     void set_framing(const images::Framing& framing);
     const images::Framing& framing() const { return framing_; }
+    // The end of the outward travel for the current source, which the
+    // dialog needs to size its slider.
+    double min_zoom() const;
 
     QSize sizeHint() const override;
 
@@ -64,8 +74,15 @@ protected:
 
 private:
     // Where the whole source picture is drawn inside this widget,
-    // letterboxed to preserve its aspect.
+    // letterboxed to preserve its aspect -- and shrunk far enough that
+    // the *widest* crop window still fits, so the window's edges never
+    // leave the widget and the operator can see the black it is
+    // enclosing.
     QRectF source_rect() const;
+    // The crop window's size as a fraction of the source, at a given
+    // zoom. Above 1 in an axis means the window overhangs the picture,
+    // which is what `fit` pads.
+    QSizeF crop_fractions(double zoom) const;
     // The crop window in widget coordinates, derived from `framing_` --
     // never stored, so what is drawn cannot disagree with what is
     // returned.

--- a/native/gui/tx_panel.cpp
+++ b/native/gui/tx_panel.cpp
@@ -755,7 +755,12 @@ void TransmitPanel::apply_framing() {
     caption += tr("\n%1x%2").arg(source_->width).arg(source_->height);
     const bool four_by_three =
         source_->width * images::IMG_H == source_->height * images::IMG_W;
-    if (!four_by_three || framing_.zoom > 1.0) {
+    // Zoomed out, nothing is cropped -- the canvas is padded instead,
+    // and saying "cropped" there would be exactly as misleading as the
+    // bare filename this replaced.
+    if (framing_.zoom < 1.0) {
+        caption += tr(", padded to 4:3");
+    } else if (!four_by_three || framing_.zoom > 1.0) {
         caption += tr(", cropped to 4:3");
     }
     image_label_->setText(caption);

--- a/native/tests/test_crop_view.cpp
+++ b/native/tests/test_crop_view.cpp
@@ -141,9 +141,55 @@ void test_zoom_is_bounded() {
     wheel(view, 120, 200);
     check::is_true(view.framing().zoom <= 4.0 + 1e-9,
                    "crop/wheel: zoom stops at the ceiling");
+    // 1600x900 is 16:9, so the whole picture fits the 4:3 canvas at
+    // (640/1600)/(480/900) = 0.75 -- and the floor is that, not 1.
+    // Asserting the named value rather than "< 1" is what catches a
+    // floor that stops early or one that keeps going into pure black.
     wheel(view, -120, 400);
-    check::is_true(view.framing().zoom >= 1.0 - 1e-9,
-                   "crop/wheel: and never below cover");
+    check::is_true(std::abs(view.framing().zoom - 0.75) < 1e-9,
+                   "crop/wheel: out to exactly the whole-picture zoom");
+    check::is_true(std::abs(view.min_zoom() - 0.75) < 1e-12,
+                   "crop/wheel: which is what the view reports as its floor");
+}
+
+void test_a_four_by_three_source_cannot_zoom_out() {
+    // Cover and contain are the same scale here, so there is no
+    // outward travel at all and zooming out must not letterbox a
+    // picture that already fits.
+    CropView view;
+    view.resize(W, H);
+    view.set_source(flat(1600, 1200));
+    view.set_framing(Framing{});
+
+    wheel(view, -120, 20);
+    check::is_true(std::abs(view.framing().zoom - 1.0) < 1e-9,
+                   "crop/wheel: a 4:3 source stays at cover");
+}
+
+void test_zoomed_out_panning_is_bounded_by_the_window() {
+    // Zoomed all the way out on a 16:9 source the window is taller than
+    // the picture, so the rule inverts: the picture stays inside the
+    // window rather than the other way round. Dragging must not shove
+    // the photograph off the canvas.
+    CropView view;
+    view.resize(W, H);
+    Framing wide;
+    wide.zoom = 0.75;
+    view.set_source(flat(1600, 900));
+    view.set_framing(wide);
+
+    drag(view, W / 2.0, H / 2.0, 0, 5000);
+    const double down = view.framing().center_y;
+    drag(view, W / 2.0, H / 2.0, 0, -5000);
+    const double up = view.framing().center_y;
+    // The legal range is [1 - half, half] with half = 2/3, i.e.
+    // [0.333, 0.667]: symmetric about the centre and strictly inside
+    // the picture's own coordinates.
+    check::is_true(std::abs(down - 2.0 / 3.0) < 1e-6,
+                   "crop/drag: zoomed out, downward travel stops where the "
+                   "picture reaches the window's bottom");
+    check::is_true(std::abs(up - 1.0 / 3.0) < 1e-6,
+                   "crop/drag: and upward travel stops symmetrically");
 }
 
 void test_an_empty_source_is_harmless() {
@@ -172,6 +218,8 @@ int main(int argc, char** argv) {
     test_drag_stops_at_the_edges();
     test_a_trackpad_gesture_does_not_slam_the_zoom();
     test_zoom_is_bounded();
+    test_a_four_by_three_source_cannot_zoom_out();
+    test_zoomed_out_panning_is_bounded_by_the_window();
     test_an_empty_source_is_harmless();
 
     return check::report("crop view");

--- a/native/tests/test_framing.cpp
+++ b/native/tests/test_framing.cpp
@@ -22,6 +22,7 @@
 #include "images/images.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <string>
@@ -205,13 +206,128 @@ void test_zoom_crops_both_axes_equally() {
                    "framing/zoom: the output is exactly the centre 640x480 "
                    "of a 2x-zoomed 1280x960 source");
 
-    // Below 1 would expose edges with nothing behind them.
+    // A 4:3 source has nowhere to zoom out to -- cover and contain are
+    // the same scale -- so below 1 is clamped back to it and no black
+    // appears.
     Framing under;
     under.zoom = 0.25;
     check::is_true(
         sstvae::images::fit(src, under).rgb ==
             sstvae::images::fit(src, Framing{}).rgb,
-        "framing/zoom: below 1 is clamped to cover");
+        "framing/zoom: on a 4:3 source, below 1 is clamped to cover");
+    check::is_true(std::abs(sstvae::images::min_zoom(1280, 960) - 1.0) < 1e-12,
+                   "framing/zoom: min_zoom of a 4:3 source is exactly 1");
+}
+
+void test_zooming_out_shows_the_whole_source_and_pads() {
+    // 1280x480 is twice as wide as 4:3. The cover scale is 1.0, so at
+    // min zoom the whole 1280 wide source is squeezed into the 640 wide
+    // canvas -- exactly half height, 240 rows, with 120 black rows above
+    // and below.
+    const Picture src = ramp(1280, 480);
+    const double mz = sstvae::images::min_zoom(1280, 480);
+    check::is_true(std::abs(mz - 0.5) < 1e-12,
+                   "framing/out: min_zoom of a 2:1 source is 0.5");
+
+    Framing wide;
+    wide.zoom = mz;
+    const Picture out = sstvae::images::fit(src, wide);
+
+    const int W = sstvae::images::IMG_W;
+    const int H = sstvae::images::IMG_H;
+    const int band = (H - 240) / 2;  // 120 rows of padding, top and bottom
+    auto pixel = [&](int x, int y) {
+        const std::size_t i = (static_cast<std::size_t>(y) * W + x) * 3;
+        return std::array<int, 3>{out.rgb[i], out.rgb[i + 1], out.rgb[i + 2]};
+    };
+
+    // Named rows rather than "some black exists": a padding that landed
+    // all on one side, or a picture drawn at the wrong offset, both
+    // still produce black somewhere.
+    for (const int y : {0, band - 1, H - band, H - 1}) {
+        const auto p = pixel(W / 2, y);
+        check::is_true(p[0] == 0 && p[1] == 0 && p[2] == 0,
+                       "framing/out: row " + std::to_string(y) + " is black");
+    }
+    // And the picture itself fills every column of the band between
+    // them -- the whole width of the source is on the canvas, which is
+    // the thing zooming out is for. `ramp` has a black pixel only at
+    // (0,0), so a lit pixel anywhere in the row proves coverage; the
+    // corners are the columns a one-sided error would drop.
+    for (const int x : {0, 1, W / 2, W - 1}) {
+        const auto p = pixel(x, H / 2);
+        check::is_true(p[0] != 0 || p[1] != 0 || p[2] != 0,
+                       "framing/out: column " + std::to_string(x) +
+                           " of the middle band carries picture");
+    }
+    // The green channel encodes the source row, so the top of the
+    // picture band must be near source row 0 and the bottom near 479 --
+    // a vertically flipped or half-height fit fails this.
+    check::is_true(pixel(W / 2, band + 2)[1] < 20,
+                   "framing/out: the band starts at the top of the source");
+    // (source row 474 is green 474 % 256 = 218)
+    check::is_true(pixel(W / 2, H - band - 3)[1] > 200,
+                   "framing/out: and ends at the bottom of it");
+
+    // Below the minimum is clamped to it, not honoured: there is
+    // nothing further to reveal, only more black.
+    Framing further;
+    further.zoom = mz / 4.0;
+    check::is_true(sstvae::images::fit(src, further).rgb == out.rgb,
+                   "framing/out: below min_zoom is clamped to min_zoom");
+}
+
+void test_zoomed_out_panning_moves_the_padding_not_the_picture() {
+    // A portrait source, so the overhang is horizontal: 480x640 fits
+    // the canvas at 360x480, leaving 280 columns of black to place.
+    // The centre still means something -- an operator may want the
+    // picture against one edge -- but it may never cost a column of it.
+    const Picture src = ramp(480, 640);
+    const int W = sstvae::images::IMG_W;
+    const int H = sstvae::images::IMG_H;
+
+    // `ramp`'s green channel is the row, so on the middle row every
+    // source column is non-black and the black ones are padding.
+    auto span = [&](const Picture& out) {
+        const std::size_t row = static_cast<std::size_t>(H / 2) * W * 3;
+        int first = -1;
+        int last = -1;
+        for (int x = 0; x < W; ++x) {
+            const std::size_t i = row + static_cast<std::size_t>(x) * 3;
+            const bool black =
+                out.rgb[i] == 0 && out.rgb[i + 1] == 0 && out.rgb[i + 2] == 0;
+            if (black) continue;
+            if (first < 0) first = x;
+            last = x;
+        }
+        return std::pair<int, int>{first, last};
+    };
+
+    struct Case {
+        double center_x;
+        int want_first;
+        const char* what;
+    };
+    // left = clamp(floor(cx*360 - 320), -280, 0), and the picture then
+    // starts at column -left.
+    const Case cases[] = {
+        {0.0, 280, "hard left: the picture sits against the right edge"},
+        {0.5, 140, "centred: the padding splits evenly"},
+        {1.0, 0, "hard right: the picture sits against the left edge"},
+    };
+    for (const Case& c : cases) {
+        Framing f;
+        f.zoom = sstvae::images::min_zoom(480, 640);
+        f.center_x = c.center_x;
+        const auto [first, last] = span(sstvae::images::fit(src, f));
+        check::equal(first, c.want_first, std::string("framing/out: ") + c.what);
+        // The whole 360 columns are there whatever the centre does --
+        // this is the assertion that fails if a pan can slide the
+        // photograph off the edge of the canvas.
+        check::equal(last - first + 1, 360,
+                     std::string("framing/out: all 360 columns survive, ") +
+                         c.what);
+    }
 }
 
 void test_out_of_range_centres_are_clamped() {
@@ -255,6 +371,10 @@ int main() {
     test_panning_selects_the_named_columns();
     check::current_step.store("zoom");
     test_zoom_crops_both_axes_equally();
+    check::current_step.store("zoom_out");
+    test_zooming_out_shows_the_whole_source_and_pads();
+    check::current_step.store("zoom_out_pan");
+    test_zoomed_out_panning_moves_the_padding_not_the_picture();
     check::current_step.store("clamp");
     test_out_of_range_centres_are_clamped();
     check::current_step.store("identity");


### PR DESCRIPTION
the first cut only supported zooming in, but sometimes you really do want a black border around a wrong-aspect-ratio image.