### PR TITLE
fix the reception progress bar in blind mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,26 @@ rule is enforced by `tools/check_layering.py`.
   a Save button instead of writing it. `ringbuffer.py`
   adds `tail()` (cheap slice for the ~20 fps waterfall; `snapshot()`
   copies all 130 s) and `clear()`.
+
+  **The progress bar is position, not fill**: the last frame
+  successfully received over the frames expected, never latents
+  received over latents expected. Only the blind path can tell the two
+  apart — the preamble path decodes a contiguous prefix, so its
+  `frames_received` count *is* its reach — and there a fill fraction is
+  a completion percentage that is not one: the erasures that path lives
+  with (a fade, or simply not having heard the start) hold it down
+  permanently, so a reception already at the transmission's last frame
+  reported 70% and the bar never filled. `_blind_progress` returns both
+  numbers because they answer different questions — the confident
+  *count* is still what the `--end-grace` stall detector watches, since
+  retrospective decoding filling in frames behind the furthest one is
+  real progress that the reach deliberately does not move.
+  `framing.frame_of_latent()` is what makes the reach computable at all
+  (the inverse of `slot_range_for_frame`, as one cached table): the
+  interleaver scatters each frame across the whole picture, so a latent
+  count answers "how much" and only the frame index answers "how far".
+  Mirrored in `native/core/`, where `rx::blind_progress` is public for
+  the same reason `poll_wait` is.
 - `sstvae/tx/engine.py` — encode → modulate → PTT → play → unkey.
   **The invariant is that PTT always comes back down**: try/finally
   around the keyed region *plus* an independent `_PttWatchdog` thread

--- a/native/android-app/listener.cpp
+++ b/native/android-app/listener.cpp
@@ -339,8 +339,8 @@ QString Listener::plain_status() const {
     }
     // A percentage rather than a frame count. Frames are the unit the
     // modem thinks in and mean nothing to the operator; the fraction is
-    // already computed for both the header and the blind path, which
-    // are counted differently and would need two branches here.
+    // already computed for both the header and the blind path, and the
+    // blind one has no total to quote a count against anyway.
     if (p.progress_frac > 0.0) {
         out += QStringLiteral("  %1%").arg(100.0 * p.progress_frac, 0, 'f', 0);
     }

--- a/native/core/framing/framing.cpp
+++ b/native/core/framing/framing.cpp
@@ -44,6 +44,18 @@ FrameSlots slot_range_for_frame(int abs_frame) {
     return out;
 }
 
+std::span<const std::int32_t> frame_of_latent() {
+    static const std::vector<std::int32_t> table = [] {
+        std::vector<std::int32_t> out(
+            static_cast<std::size_t>(config::LATENT_GROUPS) * GROUP_LATENTS, -1);
+        for (int f = 0; f < config::LATENT_GROUPS * FRAMES_PER_GROUP; ++f)
+            for (std::int64_t i : slot_range_for_frame(f).indices)
+                out[static_cast<std::size_t>(i)] = f;
+        return out;
+    }();
+    return table;
+}
+
 std::vector<double> interleave(std::span<const double> latents,
                                const ModeSpec& mode) {
     if (latents.size() != static_cast<std::size_t>(mode.n_latents))

--- a/native/core/framing/framing.hpp
+++ b/native/core/framing/framing.hpp
@@ -41,6 +41,18 @@ struct FrameSlots {
 };
 FrameSlots slot_range_for_frame(int abs_frame);
 
+// Canonical latent index -> the absolute frame index that carries it,
+// over mode C's full range; -1 for the latents each group permanently
+// drops (never given a slot).
+//
+// The inverse of slot_range_for_frame, as one table (built once, on
+// first call). A receiver that knows only *which latents* arrived --
+// the blind path, which has no header and so no mode -- needs this to
+// say how far into the transmission it has got: a latent count answers
+// "how much", and the interleaver scatters each frame across the whole
+// picture, so only the frame index answers "how far".
+std::span<const std::int32_t> frame_of_latent();
+
 // Canonical latent vector -> on-air slot order (mode.n_tx_latents).
 std::vector<double> interleave(std::span<const double> latents,
                                const ModeSpec& mode);

--- a/native/core/rx/engine.cpp
+++ b/native/core/rx/engine.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
@@ -15,6 +16,7 @@
 #include <vector>
 
 #include "dsp/dsp.hpp"
+#include "framing/framing.hpp"
 #include "images/images.hpp"
 #include "latents/latents.hpp"
 #include "modem/modem.hpp"
@@ -47,7 +49,6 @@ private:
 
 // Mode C, the longest -- the denominator for blind progress, where the
 // real mode is unknown.
-constexpr int kTotalCLatents = config::MODES[config::N_MODES - 1].n_latents;
 constexpr int kMaxModeFrames = config::MODES[config::N_MODES - 1].n_frames;
 
 // Weight a blind-path latent must clear to count as "confidently
@@ -161,20 +162,6 @@ int count_nonzero(const std::vector<double>& v) {
                                           [](double w) { return w != 0.0; }));
 }
 
-// Confidently-received latents only, not a bare nonzero count:
-// demodulate_blind assigns *some* nonzero weight to essentially every
-// legal abs_frame slot its ever-growing search range touches, real
-// signal or not (just small for noise, after the med_h fix in
-// modem.cpp), so a nonzero count keeps climbing every poll purely from
-// the buffer growing -- independent of whether any new real data has
-// arrived -- until buffer growth has mapped the *entire* legal
-// abs_frame range. That read as "stuck receiving forever": the stall
-// detector below never saw a stable metric to end_grace against.
-int count_confident(const std::vector<double>& v) {
-    return static_cast<int>(std::count_if(
-        v.begin(), v.end(), [](double w) { return w > kProgressWeightThreshold; }));
-}
-
 void remember_finished(std::deque<std::int64_t>& finished, std::int64_t pos) {
     finished.push_back(pos);
     while (finished.size() > kFinishedHistory) finished.pop_front();
@@ -194,6 +181,35 @@ void reset_to_listening(SharedState& state) {
 }
 
 }  // namespace
+
+BlindProgress blind_progress(std::span<const double> weights_full) {
+    // The metric counts confidently-received latents only, not bare
+    // nonzero ones: demodulate_blind assigns *some* nonzero weight to
+    // essentially every legal abs_frame slot its ever-growing search
+    // range touches, real signal or not (just small for noise, after
+    // the med_h fix in modem.cpp), so a nonzero count keeps climbing
+    // every poll purely from the buffer growing -- independent of
+    // whether any new real data has arrived -- until buffer growth has
+    // mapped the *entire* legal abs_frame range. That read as "stuck
+    // receiving forever": the stall detector never saw a stable metric
+    // to end_grace against.
+    //
+    // One past the highest absolute frame index any confidently-received
+    // latent belongs to, or 0 if none does. See the header for why that,
+    // and not the count, is the bar.
+    const std::span<const std::int32_t> frame_of = framing::frame_of_latent();
+    const std::size_t n = std::min(weights_full.size(), frame_of.size());
+    BlindProgress out;
+    int last = -1;
+    for (std::size_t i = 0; i < n; ++i) {
+        if (weights_full[i] > kProgressWeightThreshold) {
+            ++out.metric;
+            last = std::max(last, frame_of[i]);
+        }
+    }
+    out.frac = static_cast<double>(last + 1) / kMaxModeFrames;
+    return out;
+}
 
 double poll_wait(const RxConfig& config, double last_cost_s) {
     if (config.max_decode_duty >= 1.0 || last_cost_s <= 0.0) {
@@ -443,8 +459,9 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
                 have_latents = true;
                 callsign = rb->callsign;
                 snr_db = rb->snr_db;
-                progress_metric = count_confident(weights_full);
-                progress_frac = static_cast<double>(progress_metric) / kTotalCLatents;
+                const BlindProgress bp = blind_progress(weights_full);
+                progress_metric = bp.metric;
+                progress_frac = bp.frac;
             }
         }
 

--- a/native/core/rx/engine.hpp
+++ b/native/core/rx/engine.hpp
@@ -124,6 +124,31 @@ struct RxConfig {
 // asserting on latency instead of on the decision.
 double poll_wait(const RxConfig& config, double last_cost_s);
 
+// (stall metric, progress fraction) for one blind decode. Exposed for
+// the same reason `poll_wait` is: it is arithmetic, and the alternative
+// is inferring it from a whole decode run.
+//
+// Two different questions, deliberately answered by two different
+// numbers. The metric is the count of confidently-received latents (see
+// count_confident in the .cpp for why confidence is what makes it
+// usable as a stall detector). The fraction is how far *into* the
+// transmission we have got -- the last frame that decoded, over the
+// frames expected -- and is not that count over the total. A count
+// reads as a completion percentage and is not one: the erasures this
+// path lives with (a fade, or simply not having heard the start) hold
+// it down permanently, so a reception already at the transmission's
+// last frame reports 70% and the bar never fills. The interleaver is
+// why the two differ at all -- each frame's latents are scattered
+// across the whole picture, so only the frame index says "how far".
+//
+// The denominator is mode C's frame count, the longest: the blind path
+// has no header, so the real mode is unknown.
+struct BlindProgress {
+    int metric = 0;
+    double frac = 0.0;
+};
+BlindProgress blind_progress(std::span<const double> weights_full);
+
 // The `threading.Event` the reference stops on. Shared with the
 // transmitter, which needs the same primitive for its cancel flag and
 // its watchdog; the name stays because "stop flag" is what it is here.

--- a/native/gui/rx_panel.cpp
+++ b/native/gui/rx_panel.cpp
@@ -499,7 +499,7 @@ void ReceivePanel::refresh_status() {
                        .arg(*progress.n_frames_expected)
                        .arg(100.0 * progress.progress_frac, 0, 'f', 0);
         } else {
-            text = tr("Receiving (blind sync): %1% of latents")
+            text = tr("Receiving (blind sync): %1%")
                        .arg(100.0 * progress.progress_frac, 0, 'f', 0);
         }
         text += SEP + style::fmt_snr_db(progress.snr_db);

--- a/native/tests/test_rx_engine.cpp
+++ b/native/tests/test_rx_engine.cpp
@@ -34,6 +34,7 @@
 
 #include "check.hpp"
 #include "config.hpp"
+#include "framing/framing.hpp"
 #include "modem/modem.hpp"
 #include "rx/engine.hpp"
 
@@ -473,11 +474,98 @@ void test_poll_backoff() {
                  "rx/backoff: the duty floor bounds the wait");
 }
 
+// The progress bar is position, not fill: the last frame successfully
+// received over the frames expected, never latents-received over
+// latents-expected. Only the blind path can tell the two apart -- it
+// decodes whatever frames it can place, with holes where the signal
+// faded or where the transmission started before the buffer did -- and
+// a fill fraction there is a completion percentage that is not one.
+//
+// Arithmetic, so it is checked as arithmetic (see `blind_progress`'s
+// header comment), rather than inferred from a whole decode run.
+void test_blind_progress_is_the_last_frame_reached() {
+    const int total = config::MODES[config::N_MODES - 1].n_frames;
+    const auto n_latents =
+        static_cast<std::size_t>(config::MODES[config::N_MODES - 1].n_latents);
+
+    auto weights_for = [&](const std::vector<int>& frames, double w) {
+        std::vector<double> out(n_latents, 0.0);
+        for (const int f : frames)
+            for (const std::int64_t i : framing::slot_range_for_frame(f).indices)
+                out[static_cast<std::size_t>(i)] = w;
+        return out;
+    };
+
+    const rx::BlindProgress none = rx::blind_progress(std::vector<double>(n_latents, 0.0));
+    check::is_true(none.metric == 0 && none.frac == 0.0,
+                   "rx/progress: nothing received is zero progress");
+
+    // At the threshold, not over it: a latent that only ties does not
+    // count, the same cutoff the stall metric has always used.
+    const rx::BlindProgress tied = rx::blind_progress(weights_for({0}, 0.5));
+    check::is_true(tied.metric == 0 && tied.frac == 0.0,
+                   "rx/progress: a weight at the threshold does not count");
+
+    // Every other frame of mode B's range plus its last: half the
+    // latents, but the transmission has been followed all the way to its
+    // end. The old count-based fraction reported ~50% here.
+    const int reach = config::MODES[1].n_frames;
+    std::vector<int> sparse;
+    for (int f = 0; f < reach; f += 2) sparse.push_back(f);
+    sparse.push_back(reach - 1);
+    const rx::BlindProgress half = rx::blind_progress(weights_for(sparse, 1.0));
+    check::is_true(std::abs(half.frac - static_cast<double>(reach) / total) < 1e-12,
+                   "rx/progress: half the latents, all the way to mode B's last frame");
+    check::is_true(half.metric == static_cast<int>(sparse.size()) * config::LATENTS_PER_FRAME,
+                   "rx/progress: the stall metric is still the confident count");
+
+    // Tuned in at frame 400 of mode C and heard the rest: two thirds of
+    // the latents are gone for good and the bar must still read full.
+    std::vector<int> late;
+    for (int f = 400; f < total; ++f) late.push_back(f);
+    check::is_true(std::abs(rx::blind_progress(weights_for(late, 1.0)).frac - 1.0) < 1e-12,
+                   "rx/progress: a late join reports where it is, not how much it has");
+
+    // Retrospective decoding filling in frames *behind* the furthest one
+    // is progress in quality but not in position; the bar must not move.
+    const double reached = rx::blind_progress(weights_for({0, 300}, 1.0)).frac;
+    check::is_true(std::abs(reached - 301.0 / total) < 1e-12,
+                   "rx/progress: the furthest frame sets the bar");
+    std::vector<int> filled;
+    for (int f = 0; f <= 300; ++f) filled.push_back(f);
+    check::is_true(
+        std::abs(rx::blind_progress(weights_for(filled, 1.0)).frac - reached) < 1e-12,
+        "rx/progress: backfill behind the furthest frame does not move it");
+}
+
+// `frame_of_latent` is the inverse of `slot_range_for_frame`, and the
+// latents that never get a slot belong to no frame at all -- defaulting
+// those to 0 rather than -1 would hand frame 0 thousands of latents
+// that are never transmitted.
+void test_frame_of_latent_inverts_slot_range_for_frame() {
+    const std::span<const std::int32_t> table = framing::frame_of_latent();
+    check::is_true(table.size() == static_cast<std::size_t>(
+                                       config::MODES[config::N_MODES - 1].n_latents),
+                   "framing/frame_of_latent: covers mode C's canonical range");
+    for (const int f : {0, 1, 219, 220, 437, 659})
+        for (const std::int64_t i : framing::slot_range_for_frame(f).indices)
+            check::is_true(table[static_cast<std::size_t>(i)] == f,
+                           "framing/frame_of_latent: inverts slot_range_for_frame");
+    const auto dropped = std::count_if(table.begin(), table.end(),
+                                       [](std::int32_t f) { return f < 0; });
+    check::is_true(dropped == static_cast<std::ptrdiff_t>(config::LATENT_GROUPS) *
+                                  config::DROPPED_LATENTS_PER_GROUP,
+                   "framing/frame_of_latent: exactly the never-transmitted latents "
+                   "belong to no frame");
+}
+
 }  // namespace
 
 int main() {
     try {
         test_poll_backoff();
+        test_frame_of_latent_inverts_slot_range_for_frame();
+        test_blind_progress_is_the_last_frame_reached();
         test_stop_interrupts_a_wait_in_progress();
         test_a_clean_transmission_is_received_once();
         test_noise_produces_nothing();

--- a/sstvae/modem/framing.py
+++ b/sstvae/modem/framing.py
@@ -13,6 +13,7 @@ TRANSMIT_LATENTS_PER_GROUP entries of each group's permutation get a
 slot; the rest are permanently erased (weight 0), never transmitted.
 """
 
+import functools
 from pathlib import Path
 
 import numpy as np
@@ -21,6 +22,7 @@ from ..config import (
     NC,
     NC_LATENT,
     DATA_SYMS_PER_FRAME,
+    LATENT_GROUPS,
     LATENTS_PER_FRAME,
     GROUP_LATENTS,
     TRANSMIT_LATENTS_PER_GROUP,
@@ -86,6 +88,26 @@ def slot_range_for_frame(abs_frame: int) -> tuple[int, np.ndarray]:
     slo = fg * LATENTS_PER_FRAME
     shi = slo + LATENTS_PER_FRAME
     return g, g * GROUP_LATENTS + _TX_PERMS[g][slo:shi]
+
+
+@functools.lru_cache(maxsize=1)
+def frame_of_latent() -> np.ndarray:
+    """Canonical latent index -> the absolute frame index that carries
+    it, over mode C's full range; -1 for the latents each group
+    permanently drops (never given a slot, see the module docstring).
+
+    The inverse of `slot_range_for_frame`, as one array. A receiver that
+    knows only *which latents* arrived -- the blind path, which has no
+    header and so no mode -- needs this to say how far into the
+    transmission it has got: a latent count answers "how much", and the
+    interleaver scatters each frame across the whole picture, so only
+    the frame index answers "how far"."""
+    out = np.full(LATENT_GROUPS * GROUP_LATENTS, -1, dtype=np.int32)
+    for f in range(LATENT_GROUPS * FRAMES_PER_GROUP):
+        _, idx = slot_range_for_frame(f)
+        out[idx] = f
+    out.setflags(write=False)
+    return out
 
 
 def interleave(latents: np.ndarray, mode: ModeSpec) -> np.ndarray:

--- a/sstvae/rx/engine.py
+++ b/sstvae/rx/engine.py
@@ -50,7 +50,7 @@ from ..config import (
     MODES,
     PREAMBLE_SAMPLES,
 )
-from ..modem import Modem, SyncError
+from ..modem import Modem, SyncError, framing
 from ..modem.dsp import to_baseband, to_baseband_at
 from ..modem.sync import acquire as sync_acquire
 from ..modem.sync import BlindAccumulator
@@ -74,6 +74,46 @@ SAME_RECEPTION_EPSILON_S = 1.0
 # received" for the stall-detection progress metric -- see its use
 # below. Matches the "good" cutoff tests already judge latents by.
 PROGRESS_WEIGHT_THRESHOLD = 0.5
+
+
+def _blind_progress(weights_full: np.ndarray) -> tuple[int, float]:
+    """(stall metric, progress fraction) for one blind decode.
+
+    Two different questions, deliberately answered by two different
+    numbers.
+
+    The **metric** is the count of confidently-received latents, and
+    confidence is what makes it usable: demodulate_blind assigns *some*
+    nonzero weight to essentially every legal abs_frame slot its
+    ever-growing search range touches, real signal or not (just small
+    for noise, after the med_h fix in modem.py), so a nonzero count
+    keeps climbing every poll purely from the buffer growing --
+    independent of whether any new real data has arrived -- until buffer
+    growth has mapped the *entire* legal abs_frame range, which can take
+    a whole mode's duration after the real transmission already ended.
+    That read as "stuck receiving forever": the stall detector never saw
+    a stable value to end_grace against. PROGRESS_WEIGHT_THRESHOLD
+    matches the "good" cutoff already used to judge latents elsewhere
+    (see tests/test_blind_acquisition.py); only real frames clear it, so
+    the count stops climbing exactly when the real data does.
+
+    The **fraction** is how far *into* the transmission we have got --
+    the last frame that decoded, over the frames expected -- and is not
+    that count over the total. A count reads as a completion percentage
+    and is not one: the erasures this path lives with (a fade, or simply
+    not having heard the start) hold it down permanently, so a reception
+    already at the transmission's last frame still shows 70%, and the
+    bar never fills. The interleaver is why the two differ at all --
+    each frame's latents are scattered across the whole picture, so only
+    the frame index says "how far".
+
+    The denominator is mode C's frame count, the longest: the blind path
+    has no header, so the real mode is unknown.
+    """
+    good = weights_full > PROGRESS_WEIGHT_THRESHOLD
+    frames = framing.frame_of_latent()[good]
+    last_frame = int(frames.max()) + 1 if frames.size else 0
+    return int(np.count_nonzero(good)), last_frame / MODES["C"].n_frames
 
 
 @dataclass
@@ -265,7 +305,6 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
     if sink is None:
         sink = SaveToDirSink(config.out_dir, config.size)
     modem = Modem()
-    total_c_latents = MODES["C"].n_latents
     epsilon_samples = SAME_RECEPTION_EPSILON_S * FS
     # Absolute (ring-buffer-coordinate) transmission-start sample position
     # of every reception already saved this run. The ring buffer keeps
@@ -390,25 +429,7 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
                 weights_full = rb.weights
                 callsign = rb.callsign
                 snr_db = rb.snr_db
-                # Confidently-received latents only, not a bare nonzero
-                # count: demodulate_blind assigns *some* nonzero weight
-                # to essentially every legal abs_frame slot its ever-
-                # growing search range touches, real signal or not (just
-                # small for noise, after the med_h fix above), so a
-                # nonzero count keeps climbing every poll purely from
-                # the buffer growing -- independent of whether any new
-                # real data has arrived -- until buffer growth has
-                # mapped the *entire* legal abs_frame range, which can
-                # take up to a whole mode's duration after the real
-                # transmission already ended. That read as "stuck
-                # receiving forever": the stall detector below never saw
-                # a stable metric to end_grace against. PROGRESS_WEIGHT_
-                # THRESHOLD matches the "good" cutoff already used to
-                # judge latents elsewhere (see tests/test_blind_
-                # acquisition.py); only real frames clear it, so the
-                # count stops climbing exactly when the real data does.
-                progress_metric = int(np.count_nonzero(weights_full > PROGRESS_WEIGHT_THRESHOLD))
-                progress_frac = progress_metric / total_c_latents
+                progress_metric, progress_frac = _blind_progress(weights_full)
             else:
                 reception_start = None
 

--- a/sstvae_listen.py
+++ b/sstvae_listen.py
@@ -74,7 +74,7 @@ def _status_line(state: SharedState) -> str:
                 f"{frames_received}/{n_frames_expected} ({100 * progress_frac:.0f}%)"
             )
         else:
-            line = f"receiving (blind sync): {100 * progress_frac:.0f}% of latents"
+            line = f"receiving (blind sync): {100 * progress_frac:.0f}%"
         line += fmt_snr(snr_db)
         if callsign:
             line += f"  de {callsign}"

--- a/tests/test_rx_progress.py
+++ b/tests/test_rx_progress.py
@@ -1,0 +1,91 @@
+"""The reception progress bar: position, not fill.
+
+The bar is `last frame successfully received / frames expected`, never
+`latents received / latents expected`. The blind path is the one where
+the two differ -- it decodes whatever frames it can place, with holes
+where the signal faded or where the transmission started before the
+buffer did -- and a fill fraction there is a completion percentage that
+is not one: a reception already at the transmission's last frame reports
+70% and never fills.
+"""
+
+import numpy as np
+
+from sstvae.config import (
+    DROPPED_LATENTS_PER_GROUP,
+    LATENT_GROUPS,
+    MODES,
+)
+from sstvae.modem import framing
+from sstvae.rx.engine import PROGRESS_WEIGHT_THRESHOLD, _blind_progress
+
+TOTAL_FRAMES = MODES["C"].n_frames
+
+
+def _weights_for_frames(frames, weight=1.0):
+    """Canonical weight vector with exactly `frames` received."""
+    w = np.zeros(MODES["C"].n_latents)
+    for f in frames:
+        _, idx = framing.slot_range_for_frame(f)
+        w[idx] = weight
+    return w
+
+
+def test_frame_of_latent_inverts_slot_range_for_frame():
+    table = framing.frame_of_latent()
+    assert table.shape == (MODES["C"].n_latents,)
+    for f in (0, 1, 219, 220, 437, 659):
+        _, idx = framing.slot_range_for_frame(f)
+        assert np.all(table[idx] == f)
+
+
+def test_frame_of_latent_marks_exactly_the_dropped_latents():
+    # The latents each group never gets a slot for (the beacon carrier's
+    # capacity cost) belong to no frame at all. Getting this wrong by
+    # defaulting to 0 instead of -1 would silently claim frame 0 for
+    # thousands of latents that are never transmitted.
+    table = framing.frame_of_latent()
+    assert np.count_nonzero(table < 0) == LATENT_GROUPS * DROPPED_LATENTS_PER_GROUP
+
+
+def test_no_confident_latents_is_zero_progress():
+    assert _blind_progress(np.zeros(MODES["C"].n_latents)) == (0, 0.0)
+
+
+def test_weights_at_the_threshold_do_not_count():
+    w = _weights_for_frames([0], weight=PROGRESS_WEIGHT_THRESHOLD)
+    assert _blind_progress(w) == (0, 0.0)
+
+
+def test_progress_is_the_last_frame_reached_not_the_count():
+    # Every other frame of mode B's range: half the latents, but the
+    # transmission has been followed all the way to its end. The old
+    # count-based fraction reported ~50% here.
+    reach = MODES["B"].n_frames
+    w = _weights_for_frames([*range(0, reach, 2), reach - 1])
+    metric, frac = _blind_progress(w)
+    assert frac == reach / TOTAL_FRAMES
+    # The stall metric is still the count -- a different question, and
+    # the one --end-grace watches.
+    assert metric == np.count_nonzero(w > PROGRESS_WEIGHT_THRESHOLD)
+
+
+def test_a_late_join_reports_where_it_is_not_how_much_it_has():
+    # Tuned in at frame 400 of mode C and heard the rest: two thirds of
+    # the latents are gone for good, and the bar must still read 100%.
+    w = _weights_for_frames(range(400, TOTAL_FRAMES))
+    _, frac = _blind_progress(w)
+    assert frac == 1.0
+
+
+def test_progress_advances_with_reach_and_ignores_backfill():
+    reached = _weights_for_frames([0, 300])
+    _, frac_reached = _blind_progress(reached)
+    assert frac_reached == 301 / TOTAL_FRAMES
+
+    # Retrospective decoding filling in frames *behind* the furthest one
+    # is real progress in quality but not in position, and the bar must
+    # not jump backwards or forwards for it.
+    backfilled = _weights_for_frames(range(0, 301))
+    _, frac_backfilled = _blind_progress(backfilled)
+    assert frac_backfilled == frac_reached


### PR DESCRIPTION
it now updates based on how far the last-decoded frame is in the sequence, instead of the percentage of frames that were successfully decoded.