### PR TITLE
efficiency improvements for overlay editor and refiner

### DIFF
--- a/native/core/codec/grad_session.cpp
+++ b/native/core/codec/grad_session.cpp
@@ -54,8 +54,10 @@ struct GradSession::Impl {
     }
 };
 
-GradSession::GradSession(const std::string& artifact, const images::ImageArray& target)
-    : impl_(std::make_unique<Impl>(artifact)) {
+GradSession::GradSession(const std::string& artifact)
+    : impl_(std::make_unique<Impl>(artifact)) {}
+
+void GradSession::set_target(const images::ImageArray& target) {
     if (target.width != images::IMG_W || target.height != images::IMG_H) {
         throw std::runtime_error("latent optimization wants a full-size target picture");
     }
@@ -68,6 +70,12 @@ GradSession& GradSession::operator=(GradSession&&) noexcept = default;
 
 optimize::GradFn GradSession::fn() {
     Impl* impl = impl_.get();
+    // Refused here rather than at the first `Run()`: with no target the
+    // graph would be handed a zero-length tensor and fail somewhere
+    // inside onnxruntime, a long way from the missing call.
+    if (impl->target.empty()) {
+        throw std::runtime_error("GradSession::fn() before set_target()");
+    }
     return [impl](const std::vector<float>& latents, const std::vector<float>& weights,
                   std::vector<float>& grad, double& mse) {
         const std::size_t n = static_cast<std::size_t>(latents::N_LATENTS);

--- a/native/core/codec/grad_session.hpp
+++ b/native/core/codec/grad_session.hpp
@@ -7,12 +7,22 @@
 // tensor ops and exported (see `sstvae/models/decoder_vjp.py`) -- so
 // nothing here differentiates anything: it is one `Run()` per call.
 //
-// The MSE loss lives inside the graph, which is why the target picture
-// is bound at construction. Taking d(loss)/d(recon) as an input would
-// keep the graph loss-agnostic, but no loss of the reconstruction can
-// be evaluated before the reconstruction exists, so the caller would
-// run the graph once for `recon` and again for the gradient -- doubling
-// the cost of every step.
+// The MSE loss lives inside the graph, which is why a target picture
+// has to be bound before the gradient can be asked for. Taking
+// d(loss)/d(recon) as an input would keep the graph loss-agnostic, but
+// no loss of the reconstruction can be evaluated before the
+// reconstruction exists, so the caller would run the graph once for
+// `recon` and again for the gradient -- doubling the cost of every step.
+//
+// **The target is set separately from construction, and that split is
+// the point.** Building this loads a ~9 MB artifact from disk and
+// stands up an `Ort::Env` and an `Ort::Session`; the target is one
+// tensor. Binding the target in the constructor made the two
+// inseparable, so `Speculative`'s factory built a whole new session for
+// every picture -- and it is asked for a new one on every edit and, if
+// the composition carries a "last received" inset, on every reception.
+// One session per optimizer, re-targeted per run, is what that shape
+// should have been.
 
 #ifndef SSTVAE_CODEC_GRAD_SESSION_HPP
 #define SSTVAE_CODEC_GRAD_SESSION_HPP
@@ -30,13 +40,21 @@ public:
     // `artifact` is a path to a `*-decoder-grad-fp32.onnx`; get one from
     // `checkpoint::resolve_onnx(checkpoint::GRAD_PART, ...)`, which pins
     // the precision because fp32 is the only one published.
-    GradSession(const std::string& artifact, const images::ImageArray& target);
+    explicit GradSession(const std::string& artifact);
     ~GradSession();
     GradSession(GradSession&&) noexcept;
     GradSession& operator=(GradSession&&) noexcept;
 
+    // The picture to optimize toward. Must be called before `fn()`, and
+    // may be called again to reuse this session for another picture --
+    // which is the whole reason it is not a constructor argument.
+    void set_target(const images::ImageArray& target);
+
     // Suitable for `optimize::run`. The returned function borrows this
-    // object, so it must not outlive it.
+    // object, so it must not outlive it -- and it reads the target at
+    // call time, so re-targeting invalidates any function still in
+    // flight. Both are satisfied by the one caller, which runs the loop
+    // to completion on a single worker before asking for the next.
     optimize::GradFn fn();
 
 private:

--- a/native/core/overlay/render.cpp
+++ b/native/core/overlay/render.cpp
@@ -7,6 +7,7 @@
 #include <QImage>
 #include <QPainter>
 #include <QPainterPath>
+#include <QSize>
 #include <QString>
 #include <QStringList>
 #include <QTransform>
@@ -16,6 +17,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace sstvae::overlay {
@@ -201,14 +203,79 @@ void draw_text(QPainter& painter, const TextItem& item, int canvas_w,
 // ---------------------------------------------------------------------
 // Image insets
 
+// A file-backed inset, decoded once.
+//
+// **Keyed on the path and never invalidated**, which is the whole
+// contract: a document names an inset by path, so the only thing that
+// changes which pixels an item shows is the path changing. Watching the
+// file for content changes is deliberately not attempted -- it would
+// mean a stat on every call, on a path that runs on every mouse move,
+// to catch a case (the operator overwriting a file the composition
+// already refers to, in place, mid-session) that costs nothing to fix
+// by re-adding the inset.
+//
+// The decode used to happen on every call, and `item_bbox` is a caller:
+// `OverlayEditor::hit_test` runs it per item on **every mouse move over
+// the canvas**, and `paintEvent` runs it again. So merely moving the
+// pointer across the composer re-read and re-decoded every inset from
+// disk.
+//
+// A failed load is cached too. The alternative is retrying a missing
+// file at mouse-move rate, which is the same pathology with syscalls
+// instead of a decode.
+//
+// Returned by value: `QImage` is copy-on-write, so this is a refcount
+// bump, and it means no caller holds a reference into a cache another
+// thread could evict.
+QImage cached_file_image(const std::string& path) {
+    // Small and FIFO-bounded rather than unbounded. A source photograph
+    // is not small -- 4000x3000 is 48 MB as ARGB32 -- and this is a
+    // process-lifetime cache in an application that runs for days, so
+    // an operator cycling through a folder of pictures must not be able
+    // to grow it without limit. Eight is far more than any composition
+    // uses at once.
+    constexpr std::size_t CAPACITY = 8;
+    static std::mutex mutex;
+    static std::vector<std::pair<std::string, QImage>> cache;
+
+    const std::lock_guard<std::mutex> lock(mutex);
+    for (const auto& entry : cache) {
+        if (entry.first == path) return entry.second;
+    }
+
+    QImage loaded;
+    if (loaded.load(QString::fromStdString(path))) {
+        loaded = loaded.convertToFormat(QImage::Format_ARGB32_Premultiplied);
+    } else {
+        loaded = QImage();
+    }
+    if (cache.size() >= CAPACITY) cache.erase(cache.begin());
+    cache.emplace_back(path, loaded);
+    return loaded;
+}
+
 QImage resolve_source(const ImageItem& item, const images::Picture* last_rx) {
     if (item.source == SOURCE_LAST_RX) {
         return last_rx != nullptr ? to_qimage(*last_rx) : QImage();
     }
     if (item.source.empty()) return QImage();
-    QImage loaded;
-    if (!loaded.load(QString::fromStdString(item.source))) return QImage();
-    return loaded.convertToFormat(QImage::Format_ARGB32_Premultiplied);
+    return cached_file_image(item.source);
+}
+
+// The source's dimensions, without materializing it.
+//
+// `item_bbox` wants nothing from the source but its aspect ratio, and
+// it is the call that runs on every mouse move. For a "last_rx" item
+// the answer is already on the `Picture`, so going through
+// `resolve_source` converted a 640x480 reception into a 1.2 MB ARGB32
+// `QImage` in order to read two integers back off it.
+QSize source_size(const ImageItem& item, const images::Picture* last_rx) {
+    if (item.source == SOURCE_LAST_RX) {
+        if (last_rx == nullptr || last_rx->empty()) return QSize();
+        return QSize(last_rx->width, last_rx->height);
+    }
+    if (item.source.empty()) return QSize();
+    return cached_file_image(item.source).size();
 }
 
 // The inset at its drawn size, border included; the anchor is applied
@@ -295,10 +362,11 @@ Bbox item_bbox(int canvas_w, int canvas_h, const Item& item,
     }
 
     const ImageItem& image = std::get<ImageItem>(item);
-    const QImage src = resolve_source(image, last_rx);
+    // Dimensions only -- see `source_size`. This is the mouse-move path.
+    const QSize src = source_size(image, last_rx);
     const double aspect =
-        src.isNull() ? 0.75
-                     : static_cast<double>(src.height()) / src.width();
+        src.isEmpty() ? 0.75
+                      : static_cast<double>(src.height()) / src.width();
     const QSize size = inset_size(image, canvas_w, aspect);
     int x = static_cast<int>(std::lround(image.x * canvas_w));
     int y = static_cast<int>(std::lround(image.y * canvas_h));

--- a/native/gui/overlay_editor.cpp
+++ b/native/gui/overlay_editor.cpp
@@ -73,10 +73,42 @@ void OverlayEditor::set_base_image(const images::Picture& image) {
     emit documentChanged();
 }
 
+bool OverlayEditor::uses_last_rx() const {
+    for (const overlay::Item& item : doc_.items) {
+        const auto* image = std::get_if<overlay::ImageItem>(&item);
+        if (image != nullptr && image->source == overlay::SOURCE_LAST_RX) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void OverlayEditor::set_last_rx(const images::Picture& image) {
+    // Always stored, whether or not anything refers to it yet: the
+    // reference is late-bound, so an inset added *later* must show the
+    // newest reception rather than the one that happened to arrive
+    // while the item existed.
     last_rx_ = image;
-    // A "last_rx" item is resolved at render time, so a new reception
-    // changes what an existing item shows -- which is the point.
+
+    // **But `documentChanged` only when the composition actually
+    // depends on it.** A "last_rx" item is resolved at render time, so
+    // a new reception genuinely changes what an existing item shows --
+    // and that is worth re-rendering and re-optimizing for. With no
+    // such item, nothing about what would be transmitted has moved, and
+    // saying otherwise is expensive rather than merely untidy:
+    // `TransmitPanel` connects this signal to `schedule_optimization`,
+    // which abandons any speculative run in flight and starts a fresh
+    // one on a 120 s budget across four onnxruntime threads.
+    //
+    // Measured on the panel, fifteen receptions arriving over 65 s:
+    // **205 s of CPU with this emitted unconditionally against 0.30 s
+    // with refinement off**, on a composition no item of which used the
+    // received picture. Runs plateau at 40-100 s and pictures on a net
+    // arrive every 32-95 s, so each arrival discarded the previous
+    // run's work and restarted -- the optimizer never reached idle and
+    // the only way back was to restart the application, which is
+    // exactly what operators reported.
+    if (!uses_last_rx()) return;
     composed_valid_ = false;
     update();
     emit documentChanged();

--- a/native/gui/overlay_editor.hpp
+++ b/native/gui/overlay_editor.hpp
@@ -70,6 +70,10 @@ public:
     void set_last_rx(const images::Picture& image);
     bool has_last_rx() const { return last_rx_.has_value(); }
 
+    // Whether anything in the document resolves to the last reception.
+    // Public so a test can state the condition `set_last_rx` turns on.
+    bool uses_last_rx() const;
+
     void add_text(const std::string& text);
     void add_image_inset(const std::string& path);
     void add_last_rx_inset();

--- a/native/gui/tx_panel.cpp
+++ b/native/gui/tx_panel.cpp
@@ -97,6 +97,15 @@ TransmitPanel::TransmitPanel(AppState* state, QWidget* parent)
         begin_transmit(picture, optimizer_->take_result());
     });
 
+    // Coalesces edits before the composite is rebuilt. See
+    // `EDIT_DEBOUNCE_MS`, and `send()` for why it has to be flushable.
+    edit_timer_ = new QTimer(this);
+    edit_timer_->setObjectName(QStringLiteral("edit_debounce"));
+    edit_timer_->setSingleShot(true);
+    edit_timer_->setInterval(EDIT_DEBOUNCE_MS);
+    connect(edit_timer_, &QTimer::timeout, this,
+            &TransmitPanel::schedule_optimization);
+
     rebuild_optimizer();
 }
 
@@ -149,15 +158,37 @@ void TransmitPanel::rebuild_optimizer() {
 
     optimize::SpeculativeConfig cfg;
     const std::string model_path = app_->config().model_path;
+    // **One session for the life of this optimizer, not one per run.**
+    // Building a `GradSession` loads a ~9 MB artifact from disk and
+    // stands up an `Ort::Env` and an `Ort::Session`; only the target
+    // changes between runs, and the factory is asked for one on every
+    // edit -- per mouse-move burst, after the debounce -- and on every
+    // reception if the composition carries a "last received" inset.
+    //
+    // Held through a shared slot rather than a mutable capture:
+    // `Speculative` *copies* the factory before calling it, so anything
+    // assigned to a by-value capture would be written into the copy and
+    // thrown away, and the cache would silently never hit. A fresh slot
+    // per optimizer is also what makes a checkpoint change take effect
+    // -- `rebuild_optimizer` is what runs on one.
+    //
+    // Not a data race despite being shared: the factory is called only
+    // from `Speculative`'s single worker, and `optimizer_.reset()`
+    // above joined the previous one before this line could run.
+    auto session_slot = std::make_shared<std::shared_ptr<codec::GradSession>>();
     optimizer_ = std::make_unique<optimize::Speculative>(
-        [model_path](const images::ImageArray& target) {
-            // Resolved per run rather than cached: the artifact is only
-            // fetched when the feature is actually used, and
-            // `resolve_onnx` pins it to fp32 whatever the codec's
-            // precision is.
-            const std::string path = checkpoint::resolve_onnx(
-                std::string(checkpoint::GRAD_PART), model_path);
-            auto session = std::make_shared<codec::GradSession>(path, target);
+        [model_path, session_slot](const images::ImageArray& target) {
+            if (!*session_slot) {
+                // Resolved on first use rather than at startup: the
+                // artifact is only fetched when the feature is actually
+                // used, and `resolve_onnx` pins it to fp32 whatever the
+                // codec's precision is.
+                const std::string path = checkpoint::resolve_onnx(
+                    std::string(checkpoint::GRAD_PART), model_path);
+                *session_slot = std::make_shared<codec::GradSession>(path);
+            }
+            std::shared_ptr<codec::GradSession> session = *session_slot;
+            session->set_target(target);
             optimize::GradFn fn = session->fn();
             // Keep the session alive for as long as the gradient
             // function that borrows it.
@@ -171,7 +202,18 @@ void TransmitPanel::rebuild_optimizer() {
     schedule_optimization();
 }
 
+void TransmitPanel::schedule_optimization_debounced() {
+    // `start()` on a running single-shot timer restarts it, so a drag
+    // rebuilds the composite once after the pointer stops rather than
+    // once per mouse move.
+    edit_timer_->start();
+}
+
 void TransmitPanel::schedule_optimization() {
+    // Whatever brought us here, the pending edit is now being handled.
+    // Leaving the timer armed would rebuild the same composite again a
+    // fraction of a second later.
+    edit_timer_->stop();
     if (optimizer_ == nullptr) {
         // The model may have finished loading since the last attempt.
         if (app_->config().transmit.optimize && app_->model() != nullptr) {
@@ -301,8 +343,10 @@ void TransmitPanel::build_ui() {
     editor_ = new OverlayEditor(this);
     connect(editor_, &OverlayEditor::selectionChanged, this,
             &TransmitPanel::on_selection);
+    // The debounced form: this signal is emitted per mouse move during
+    // a drag, and the slot behind it renders the whole composite.
     connect(editor_, &OverlayEditor::documentChanged, this,
-            &TransmitPanel::schedule_optimization);
+            &TransmitPanel::schedule_optimization_debounced);
     // Tools *under* the canvas, not beside it. Beside it they cost the
     // composer ~195 px of width that the receive preview does not pay,
     // so the two pictures could never be the same size however the
@@ -1005,6 +1049,22 @@ bool TransmitPanel::transmitting() const { return running_.load(); }
 
 void TransmitPanel::send() {
     if (transmitting()) return;
+
+    // **Flush any edit still sitting in the debounce, first.** The
+    // generation counter inside `Speculative` is what guarantees the
+    // latents that go on the air describe the picture that goes on the
+    // air, and it can only know about an edit that reached it. An edit
+    // made within `EDIT_DEBOUNCE_MS` of the click has not: without this,
+    // `request_send()` below would wait on the *previous* generation,
+    // find a result ready for it, and transmit the current composition
+    // with latents refined for the one before it -- which is precisely
+    // the failure the whole speculative design exists to prevent, and
+    // it would look like nothing at all, because refined latents for
+    // the wrong picture still decode to a picture.
+    //
+    // Synchronous on purpose: it is one composite render, and Send is
+    // already a moment where a few milliseconds are invisible.
+    if (edit_timer_->isActive()) schedule_optimization();
 
     const std::optional<images::Picture> image = editor_->composed_image();
     if (!image) {

--- a/native/gui/tx_panel.hpp
+++ b/native/gui/tx_panel.hpp
@@ -52,6 +52,23 @@ inline constexpr double LEVEL_STEP_DB = 0.5;
 // once the operator settles.
 inline constexpr int LEVEL_SAVE_DELAY_MS = 500;
 
+// How long to let edits settle before rebuilding the composite for the
+// optimizer.
+//
+// **Not the same debounce as `SpeculativeConfig::debounce_s`, and not a
+// duplicate of it.** That one keeps the *worker* from starting a run
+// per edit; it cannot help the GUI thread, which had already done the
+// expensive part by the time it was consulted --
+// `schedule_optimization` renders the whole 640x480 composite and
+// converts it to float before handing it over. Measured at **6.37 ms**
+// for a three-item composition, and `OverlayEditor::documentChanged` is
+// emitted on every mouse move of a drag.
+//
+// Short enough to be imperceptible against the second of debounce that
+// follows it downstream, long enough that a drag produces one rebuild
+// rather than one per mouse move.
+inline constexpr int EDIT_DEBOUNCE_MS = 200;
+
 double level_to_db(double level);
 double db_to_level(double db);
 
@@ -76,9 +93,16 @@ public slots:
     // take effect at once rather than at the next edit.
     void sync_from_config();
     // Re-arm speculative optimization for the current composition.
-    // Cheap and idempotent: the debounce inside `Speculative` is what
-    // keeps a drag from starting a run per mouse move.
+    // **Not cheap**: it renders the composite and converts it to float
+    // on the calling thread, which is the GUI thread. Call it from
+    // discrete events (a mode change, settings, the end of a send).
+    // Anything that can repeat at mouse-move rate must go through
+    // `schedule_optimization_debounced` instead.
     void schedule_optimization();
+
+    // The coalescing form, connected to `OverlayEditor::documentChanged`.
+    // Restarts a short timer; the real work happens once it settles.
+    void schedule_optimization_debounced();
     void cancel();
     void choose_image();
     void load_image(const QString& path);
@@ -197,6 +221,9 @@ private:
     // `wait_timer_`, which is the only thing that may start the
     // transmission in that window.
     QTimer* wait_timer_ = nullptr;
+    // Coalesces `documentChanged` -- see `EDIT_DEBOUNCE_MS`. Named so a
+    // test can find it among this panel's other timers.
+    QTimer* edit_timer_ = nullptr;
     bool awaiting_optimizer_ = false;
     // The composition as it was when Send was pressed. Send commits to
     // that picture: editing during the wait (or during transmission)

--- a/native/tests/test_overlay_editor.cpp
+++ b/native/tests/test_overlay_editor.cpp
@@ -299,6 +299,87 @@ void test_an_added_item_can_be_nudged_without_clicking_first() {
                    "nudge: the editor is reachable by keyboard after an add");
 }
 
+// A reception is a document change only when the document uses it.
+//
+// **This is the guard for a runaway, not a tidiness rule.**
+// `set_last_rx` used to invalidate and emit `documentChanged`
+// unconditionally, and `TransmitPanel` connects that signal to
+// `schedule_optimization`, which abandons any speculative refinement in
+// flight and starts a fresh one on a 120 s budget across four
+// onnxruntime threads. So every picture that arrived restarted a full
+// optimization of the transmit composition -- on stations whose
+// composition did not contain a "last received" inset at all, and which
+// were not about to transmit.
+//
+// Measured on the panel, fifteen receptions over 65 s: **205 s of CPU
+// against 0.30 s with refinement off.** Runs plateau at 40-100 s and
+// pictures on a net arrive every 32-95 s, so each arrival discarded the
+// previous run's work and the optimizer never reached idle. Operators
+// reported it as CPU that climbed until the application had to be
+// restarted, which is exactly what it was: nothing leaked, and nothing
+// could bring it down again either.
+//
+// Counted rather than asserted-once, because the failure is "it fires
+// when it should not" and a boolean cannot tell one emission from
+// twenty.
+void test_a_reception_is_a_change_only_if_an_item_uses_it() {
+    std::unique_ptr<gui::OverlayEditor> editor(make_editor());
+    int changes = 0;
+    QObject::connect(editor.get(), &gui::OverlayEditor::documentChanged,
+                     [&changes] { ++changes; });
+
+    // Nothing in the document at all.
+    editor->set_last_rx(grey(64, 48));
+    check::equal(changes, 0, "an empty composition ignores a reception");
+
+    // Items, but none of them referring to the reception. The file
+    // inset matters: an `ImageItem` is not automatically a `last_rx`
+    // one, and a check on the item's *type* rather than its `source`
+    // would pass every other test in this file and still fire here.
+    editor->add_text("N0CALL");
+    editor->add_image_inset("/nonexistent/inset.png");
+    changes = 0;
+    editor->set_last_rx(grey(64, 48));
+    check::equal(changes, 0,
+                 "a composition with no last_rx item ignores a reception");
+    check::is_true(!editor->uses_last_rx(), "and says it does not use one");
+
+    // And now one that does.
+    editor->add_last_rx_inset();
+    changes = 0;
+    editor->set_last_rx(grey(64, 48));
+    check::equal(changes, 1, "a composition with a last_rx item follows it");
+    check::is_true(editor->uses_last_rx(), "and says it uses one");
+}
+
+// The reception is still *stored* when nothing refers to it yet.
+//
+// The late-binding guarantee is what a "last_rx" item means: it resolves
+// at render time, so an inset added after a reception must show that
+// reception rather than nothing. Skipping the *emit* must not become
+// skipping the assignment -- which is the obvious way to write this fix
+// and is wrong.
+void test_a_reception_is_kept_even_with_nothing_to_show_it() {
+    std::unique_ptr<gui::OverlayEditor> editor(make_editor());
+
+    images::Picture received(64, 48);
+    std::fill(received.rgb.begin(), received.rgb.end(), std::uint8_t{255});
+    editor->set_last_rx(received);
+    check::is_true(editor->has_last_rx(),
+                   "the reception is kept though nothing showed it");
+
+    // Added afterwards: the composite must be the renderer's output for
+    // *that* picture, which it cannot be if the assignment was skipped.
+    editor->add_last_rx_inset();
+    const std::optional<images::Picture> composed = editor->composed_image();
+    check::is_true(composed.has_value(), "there is a composite");
+    if (!composed) return;
+    const images::Picture expected = overlay::render(
+        grey(overlay::CANVAS_W, overlay::CANVAS_H), editor->doc(), &received);
+    check::is_true(composed->rgb == expected.rgb,
+                   "an inset added later shows the reception that preceded it");
+}
+
 // The editor must not pin a window height to its own width.
 //
 // It used to: `setFixedHeight(width * 3/4)` in `resizeEvent`, which is
@@ -368,6 +449,8 @@ int main(int argc, char** argv) {
     test_arrows_nudge_by_a_fixed_fraction();
     test_delete_removes_the_selection();
     test_an_added_item_can_be_nudged_without_clicking_first();
+    test_a_reception_is_a_change_only_if_an_item_uses_it();
+    test_a_reception_is_kept_even_with_nothing_to_show_it();
     test_it_pins_no_window_height();
 
     return check::report("overlay editor");

--- a/native/tests/test_overlay_render.cpp
+++ b/native/tests/test_overlay_render.cpp
@@ -10,7 +10,11 @@
 // the editor positions its selection handles with the former and the
 // operator judges them against the latter.
 
+#include <QFile>
 #include <QGuiApplication>
+#include <QImage>
+#include <QString>
+#include <QTemporaryDir>
 
 #include <algorithm>
 #include <cstdlib>
@@ -293,6 +297,74 @@ void test_items_draw_back_to_front() {
                    "render/order: and does not erase the rest of it");
 }
 
+// A file-backed inset is decoded once per path.
+//
+// `item_bbox` is called by `OverlayEditor::hit_test` on every mouse
+// move over the canvas and again by every paint, and it used to run
+// `QImage::load()` on the item's path each time -- so moving the
+// pointer across the composer re-read and re-decoded every inset from
+// disk.
+//
+// **Deleting the file is how "cached" is made observable.** There is no
+// counter to assert on, and adding one would be a test-only hook on a
+// hot path; but a decode that does not happen cannot notice that its
+// source is gone. The stale answer this pins is the documented
+// contract, not an accident: an inset is identified by its path, and
+// content changes behind that path are deliberately not watched (a stat
+// per mouse move to catch a case an operator fixes by re-adding the
+// item).
+void test_a_file_inset_is_decoded_once() {
+    // **`QTemporaryDir`, not `$TMPDIR` and not a fixed name.** The first
+    // version of this reached for `getenv("TMPDIR")` with `/tmp` as the
+    // fallback, which on Windows is neither set nor a directory -- so
+    // `save()` failed, the item fell back to the 0.75 aspect a missing
+    // source gets, and the test failed on one platform and nowhere
+    // else. A unique directory also keeps the cache honest: it is keyed
+    // on the path and lives for the process, so a fixed name shared
+    // with another test would serve one test's pixels to another.
+    QTemporaryDir dir;
+    check::is_true(dir.isValid(), "cache: a temporary directory was made");
+    if (!dir.isValid()) return;
+    const QString qpath = dir.filePath(QStringLiteral("inset.png"));
+    const std::string path = qpath.toStdString();
+
+    // Deliberately not 4:3, so the aspect it reports could only have
+    // come from this file.
+    {
+        QImage source(80, 20, QImage::Format_RGB888);
+        source.fill(Qt::magenta);
+        check::is_true(source.save(qpath), "cache: the fixture file was written");
+    }
+
+    overlay::ImageItem item;
+    item.source = path;
+    item.width = 0.25;
+    item.border = 0.0;
+    item.anchor = "la";
+    const overlay::Item boxed = item;
+
+    const overlay::Bbox first = overlay::item_bbox(200, 150, boxed, nullptr);
+    // 50 px wide at 80x20 -> 12 or 13 px tall; whatever it is, it is
+    // this file's aspect and not the 0.75 fallback a failed load gives.
+    check::is_true(first.h < first.w / 2,
+                   "cache: the source's own aspect was used");
+
+    check::is_true(QFile::remove(qpath), "cache: the fixture file was removed");
+
+    const overlay::Bbox second = overlay::item_bbox(200, 150, boxed, nullptr);
+    check::equal(second.w, first.w, "cache: width unchanged after the file went");
+    check::equal(second.h, first.h,
+                 "cache: and height -- so it was not re-read from disk");
+
+    // And the drawing path shares the cache, not just the measuring one.
+    const images::Picture base = solid(200, 150, 0, 0, 0);
+    overlay::Doc doc;
+    doc.items.push_back(item);
+    const images::Picture out = overlay::render(base, doc, nullptr);
+    check::is_true(painted(out, base) > 0,
+                   "cache: render still draws it after the file went");
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -313,6 +385,7 @@ int main(int argc, char** argv) {
     test_text_is_drawn_and_bounded_where_predicted();
     test_empty_text_still_has_a_handle();
     test_items_draw_back_to_front();
+    test_a_file_inset_is_decoded_once();
 
     return check::report("overlay rendering");
 }

--- a/native/tests/test_tx_panel.cpp
+++ b/native/tests/test_tx_panel.cpp
@@ -33,6 +33,7 @@
 #include <QPushButton>
 #include <QSize>
 #include <QSlider>
+#include <QTimer>
 #include <QWidget>
 
 #include <string>
@@ -157,6 +158,89 @@ void test_the_level_controls_are_one_flow_item() {
                    "their container does not wrap between them");
 }
 
+// Editing defers the composite rebuild instead of doing it inline.
+//
+// `schedule_optimization` renders the whole 640x480 composite and
+// converts it to float **on the GUI thread** -- measured at 6.37 ms for
+// a three-item composition -- and `OverlayEditor::documentChanged` is
+// emitted on every mouse move of a drag. The debounce inside
+// `Speculative` does not help with that: it keeps the *worker* from
+// starting a run per edit, and by the time it is consulted the
+// expensive part has already happened.
+//
+// Asserted on the timer rather than on elapsed time: what is being
+// checked is that the work was deferred and coalesced, which is a
+// structural property. A stopwatch here would be a latency test
+// pretending to be a correctness one.
+void test_an_edit_defers_the_rebuild() {
+    AppState state;
+    QWidget host;
+    host.resize(900, 700);
+    auto* panel = new TransmitPanel(&state, &host);
+    host.show();
+    QCoreApplication::processEvents();
+
+    auto* debounce = panel->findChild<QTimer*>(QStringLiteral("edit_debounce"));
+    check::is_true(debounce != nullptr, "the panel has an edit debounce");
+    if (debounce == nullptr) return;
+    check::is_true(debounce->isSingleShot(),
+                   "the debounce is single-shot, so a burst is one rebuild");
+    check::is_true(debounce->interval() > 0,
+                   "and has an interval, so it actually defers");
+
+    auto* editor = panel->findChild<OverlayEditor*>();
+    check::is_true(editor != nullptr, "the panel has an overlay editor");
+    if (editor == nullptr) return;
+
+    // A burst, as a drag produces. Every one of these restarts the same
+    // timer; none of them may rebuild.
+    for (int i = 0; i < 20; ++i) editor->refresh_item();
+    check::is_true(debounce->isActive(),
+                   "a burst of edits leaves one deferred rebuild, not none");
+}
+
+// A rebuild consumes the pending edit rather than leaving it queued.
+//
+// This is the primitive `send()` uses to flush, and the reason it must
+// exist. The generation counter in `Speculative` is what guarantees the
+// latents on the air describe the picture on the air, and it can only
+// know about an edit that reached it. An edit made within the debounce
+// window of a Send click has not -- so unless Send rebuilds first,
+// `request_send()` waits on the *previous* generation, finds a result
+// already ready for it, and transmits the current composition with
+// latents refined for the one before it. That failure is invisible by
+// construction: refined latents for the wrong picture still decode to a
+// picture.
+//
+// **What this does not cover, deliberately: that `send()` calls it.**
+// Driving `send()` here would open a modal message box -- no picture
+// chosen, and no codec loaded -- and a modal in a headless test is a
+// hang, which this suite treats as worse than a gap. The call is the
+// first statement of `send()` and carries the reasoning above beside
+// it. A test for it belongs wherever a panel is driven with a real
+// codec, which this file is not.
+void test_a_rebuild_consumes_the_pending_edit() {
+    AppState state;
+    QWidget host;
+    host.resize(900, 700);
+    auto* panel = new TransmitPanel(&state, &host);
+    host.show();
+    QCoreApplication::processEvents();
+
+    auto* debounce = panel->findChild<QTimer*>(QStringLiteral("edit_debounce"));
+    auto* editor = panel->findChild<OverlayEditor*>();
+    check::is_true(debounce != nullptr && editor != nullptr,
+                   "the panel has a debounce and an editor");
+    if (debounce == nullptr || editor == nullptr) return;
+
+    editor->refresh_item();
+    check::is_true(debounce->isActive(), "an edit is pending");
+
+    panel->schedule_optimization();
+    check::is_true(!debounce->isActive(),
+                   "a rebuild clears the pending edit rather than repeating it");
+}
+
 // The colour button's size never moves.
 //
 // **This is the platform-independent form of a Windows-only CI
@@ -217,5 +301,7 @@ int main(int argc, char** argv) {
     test_the_strip_height_survives_a_selection();
     test_the_level_controls_are_one_flow_item();
     test_the_colour_button_does_not_change_size();
+    test_an_edit_defers_the_rebuild();
+    test_a_rebuild_consumes_the_pending_edit();
     return check::report("transmit panel");
 }


### PR DESCRIPTION
The overlay editor now doesn't trigger an "edited" event (and restart the optimizer) every time you receive an image, unless your overlay actually contains the "last received image" element. Plus some small efficiency gains to the refiner itself and to the way the overlay editor loads images from disk.