### PR TITLE
Add a receive.auto_start setting: listen when the app opens

### DIFF
--- a/native/core/settings/settings.cpp
+++ b/native/core/settings/settings.cpp
@@ -241,6 +241,7 @@ void read_folders(const Reader& r, FolderConfig& c) {
 
 void read_receive(const Reader& r, ReceiveConfig& c) {
     r.get("autosave", c.autosave);
+    r.get("auto_start", c.auto_start);
     r.get("low_cpu", c.low_cpu);
     r.get("buffer_seconds", c.buffer_seconds);
     r.get("poll_interval", c.poll_interval);
@@ -259,9 +260,10 @@ void read_receive(const Reader& r, ReceiveConfig& c) {
                                                "'; using off");
         c.drift_track = "off";
     }
-    r.report_unknown({"autosave", "low_cpu", "buffer_seconds", "poll_interval",
-                      "blind_search_seconds", "blind_wide", "drift_track", "end_grace",
-                      "save_size", "save_audio", "filename_template"});
+    r.report_unknown({"autosave", "auto_start", "low_cpu", "buffer_seconds",
+                      "poll_interval", "blind_search_seconds", "blind_wide",
+                      "drift_track", "end_grace", "save_size", "save_audio",
+                      "filename_template"});
 }
 
 void read_transmit(const Reader& r, TransmitConfig& c) {
@@ -439,6 +441,7 @@ std::string to_json(const Config& c) {
           {"template_dir", c.folders.template_dir}}},
         {"receive",
          {{"autosave", c.receive.autosave},
+          {"auto_start", c.receive.auto_start},
           {"low_cpu", c.receive.low_cpu},
           {"buffer_seconds", c.receive.buffer_seconds},
           {"poll_interval", c.receive.poll_interval},

--- a/native/core/settings/settings.hpp
+++ b/native/core/settings/settings.hpp
@@ -140,6 +140,18 @@ struct FolderConfig {
 
 struct ReceiveConfig {
     bool autosave = true;
+    // Begin listening as soon as the app is ready, without waiting for
+    // the Start button. Off by default: opening a soundcard and keying
+    // a decode thread is the sort of thing an operator should ask for
+    // once rather than discover.
+    //
+    // "Ready" means the codec has loaded, not "the window appeared" --
+    // `ReceivePanel::start` refuses without a model, so firing at
+    // construction would greet a station that asked for this with a
+    // modal telling it to try again. It is a *startup* action, so it
+    // happens once per run: a later checkpoint change reloads the model
+    // and must not restart a session the operator has since stopped.
+    bool auto_start = false;
     bool low_cpu = false;
     double buffer_seconds = 130.0;
     double poll_interval = 5.0;

--- a/native/gui/main_window.cpp
+++ b/native/gui/main_window.cpp
@@ -217,6 +217,11 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent) {
     // After the layout is chosen, since the chosen one decides the size.
     fit_to_screen();
 
+    // Read before the load starts, and acted on in `on_model_loaded` --
+    // `ReceivePanel::start` refuses without a codec, so starting here
+    // would only produce a "still loading" box on the way up.
+    auto_start_pending_ = state_->config().receive.auto_start;
+
     state_->load_model_async();
     state_->connect_rig();
     update_station_label();
@@ -606,6 +611,17 @@ void MainWindow::on_model_loaded() {
     // be armed at startup (or after a checkpoint change) is armed here
     // rather than waiting for the operator to edit something.
     tx_panel_->sync_from_config();
+
+    // The other thing that was waiting on the codec. Cleared before the
+    // attempt rather than after it: a device that will not open reports
+    // itself once, through `start()`'s own message box, and a later
+    // checkpoint change is not the place to try again.
+    if (auto_start_pending_) {
+        auto_start_pending_ = false;
+        state_->log_event("rx", log::Severity::Info,
+                          tr("starting to listen (set to start with the app)"));
+        rx_panel_->start();
+    }
 }
 
 void MainWindow::on_rig_status(const QString& text, bool error) {

--- a/native/gui/main_window.hpp
+++ b/native/gui/main_window.hpp
@@ -114,6 +114,13 @@ private:
     // Set only while an error is forcing the log dock open, so the
     // toggle that causes is not mistaken for the operator's own.
     bool auto_opening_log_ = false;
+    // `receive.auto_start`, still owed. Set once at construction and
+    // cleared the first time it is acted on, because it describes how
+    // the app *starts* -- the model also loads when the operator changes
+    // the checkpoint, and that must not restart a session they stopped.
+    // It survives a failed load, so fixing a bad model path in Settings
+    // still gets the listening station it asked for.
+    bool auto_start_pending_ = false;
     LogPane* log_pane_ = nullptr;
     QMenu* view_menu_ = nullptr;
     QAction* split_action_ = nullptr;

--- a/native/gui/settings_dialog.cpp
+++ b/native/gui/settings_dialog.cpp
@@ -814,16 +814,6 @@ QWidget* SettingsDialog::receive_tab() {
     auto_start_ = new QCheckBox(tr("Start listening when the app opens"), page);
     auto_start_->setChecked(receive.auto_start);
     form->addRow(auto_start_);
-    add_check_note(
-        form, page,
-        style::note_with_detail(
-            tr("For a station that is left monitoring — the app comes up "
-               "already receiving."),
-            tr("Listening begins once the codec has finished loading, which "
-               "on a first run includes downloading it. Stopping afterwards "
-               "does what it always did: this only decides how the app "
-               "starts, so it will not restart a session you have ended."),
-            page));
     add_gap(form);
 
     autosave_ = new QCheckBox(tr("Save every completed reception automatically"),

--- a/native/gui/settings_dialog.cpp
+++ b/native/gui/settings_dialog.cpp
@@ -811,6 +811,21 @@ QWidget* SettingsDialog::receive_tab() {
     QFormLayout* form = make_form(page);
     const settings::ReceiveConfig& receive = config_.receive;
 
+    auto_start_ = new QCheckBox(tr("Start listening when the app opens"), page);
+    auto_start_->setChecked(receive.auto_start);
+    form->addRow(auto_start_);
+    add_check_note(
+        form, page,
+        style::note_with_detail(
+            tr("For a station that is left monitoring — the app comes up "
+               "already receiving."),
+            tr("Listening begins once the codec has finished loading, which "
+               "on a first run includes downloading it. Stopping afterwards "
+               "does what it always did: this only decides how the app "
+               "starts, so it will not restart a session you have ended."),
+            page));
+    add_gap(form);
+
     autosave_ = new QCheckBox(tr("Save every completed reception automatically"),
                               page);
     autosave_->setChecked(receive.autosave);
@@ -1056,6 +1071,7 @@ void SettingsDialog::apply_to(settings::Config& config) const {
     config.transmit.cw_id = cw_id_->isChecked();
     config.transmit.cw_message = cw_message_->text().toStdString();
     config.transmit.vox_lead_s = vox_lead_->isChecked() ? dsp::VOX_LEAD_DEFAULT_S : 0.0;
+    config.receive.auto_start = auto_start_->isChecked();
     config.receive.autosave = autosave_->isChecked();
     config.receive.save_audio = save_audio_->isChecked();
     config.receive.low_cpu = low_cpu_->isChecked();

--- a/native/gui/settings_dialog.hpp
+++ b/native/gui/settings_dialog.hpp
@@ -130,6 +130,7 @@ private:
     QCheckBox* vox_lead_ = nullptr;
 
     // Receive
+    QCheckBox* auto_start_ = nullptr;
     QCheckBox* autosave_ = nullptr;
     QCheckBox* save_audio_ = nullptr;
     QCheckBox* low_cpu_ = nullptr;

--- a/native/tests/test_settings_dialog.cpp
+++ b/native/tests/test_settings_dialog.cpp
@@ -59,6 +59,7 @@ settings::Config populated() {
     c.folders.template_dir = "/srv/sstv/tpl";
 
     c.receive.autosave = false;
+    c.receive.auto_start = true;
     c.receive.save_audio = true;
     c.receive.low_cpu = true;
     c.receive.blind_wide = true;

--- a/tests/test_native_settings.py
+++ b/tests/test_native_settings.py
@@ -90,6 +90,7 @@ NON_DEFAULT = {
     },
     "receive": {
         "autosave": False,
+        "auto_start": True,
         "low_cpu": True,
         "buffer_seconds": 95.5,
         "poll_interval": 11.0,


### PR DESCRIPTION
For a station that is left monitoring, the app can now come up already receiving. Off by default; the switch is the first item in **Settings > Receive**, reading "Start listening when the app opens". No help text under it — the caption says what it does.

### Where it fires, and why not earlier

The trigger is `MainWindow::on_model_loaded`, not the window's constructor. `ReceivePanel::start` refuses without a codec, so starting at construction would greet the operator who asked for this with a *"model still loading"* box instead of a reception.

`MainWindow` holds the request as a one-shot pending flag (`auto_start_pending_`), because the model also loads when the checkpoint is changed in Settings — and that must not restart a session the operator has since stopped. The flag *does* survive a failed load, so fixing a bad model path in Settings still gets the listening station it asked for. Nothing else about Start/Stop changes: this only decides how the app starts.

### Changes

- `settings::ReceiveConfig::auto_start` — new `receive.auto_start` key, read, written and reported like its neighbours. Unknown-key reporting updated so it is not flagged as a typo.
- `SettingsDialog::receive_tab` — one checkbox, at the top of the tab.
- `MainWindow` — the pending flag and the one place it is consumed, with a log line so the status log says why the app started listening on its own.

### Verification

- `ctest`: 29/29 (Qt build, offscreen).
- `pytest`: 363 passed, 10 skipped; `pytest --native tests/test_native_settings.py` passes.
- `tools/check_layering.py` and `tools/check_includes.py` clean.
- The two round-trip fixtures that exist to stop a setting being displayed and then dropped were both extended: `tests/test_native_settings.py`'s `NON_DEFAULT` (whose guard test fails on a new field nobody adds there) and `test_settings_dialog.cpp`'s `populated()`. Checked by deleting the `apply_to` line and watching `settings_dialog` fail, then restoring it.
- Layout looked at with `sstvae-gui-shot`; the new row does not change the tab's minimum size.

Not exercised here: the app itself running to the point of auto-starting, which needs a soundcard and a model download this container has neither of.