### PR TITLE
rx: end a reception whose decodes have stopped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,40 @@ rule is enforced by `tools/check_layering.py`.
   adds `tail()` (cheap slice for the ~20 fps waterfall; `snapshot()`
   copies all 130 s) and `clear()`.
 
+  **Every completion test runs against a reception retained *across*
+  polls** (`_Pending`, and `Pending` in `native/core/rx/engine.cpp`),
+  and that is the whole point of the record rather than an
+  implementation detail. A reception stops *decoding* long before it
+  stops being real: its audio scrolls out of the ring buffer, or its
+  blind acquisition score falls back under `BLIND_SCORE_THRESHOLD` as
+  the accumulator's evidence decays once the transmission is over.
+  Every test used to be evaluated inside the branch that ran only when
+  the current poll had produced a decode, so from that moment "is this
+  finished?" was never asked again — the loop sat in "receiving"
+  indefinitely and the picture it had already decoded was never handed
+  to the sink. **The reported hang and "autosave never fires" are one
+  bug seen from two ends**, since the sink is the only thing that
+  saves. A poll that decodes nothing must therefore *count against* a
+  reception, not be skipped over. Three things ended up load-bearing.
+  The header path needs a **deadline of its own** (its known mode's
+  duration past its start, where blind uses mode C's) — it had none at
+  all, `frames_received >= n_frames_expected` and nothing else. The
+  stall test **must not be extended to the header path** while it is
+  still decoding: a spurious preamble lock in noise goes on decoding
+  the same handful of frames for as long as it is looked at, and
+  ending *that* on a stall turns a false lock into a saved picture of
+  noise (`test_noise_produces_nothing` is what catches it) — so the
+  stall clock runs on polls where the reception did not decode, plus,
+  blind only, where it decoded and did not advance. And
+  `decode_loop_low_cpu`'s "wait until the transmission should have
+  arrived" is a wait on **something outside the loop's control**, so it
+  is bounded by the audio still missing plus `end_grace`; unbounded, a
+  capture that dies mid-reception hangs it forever.
+  `tests/test_rx_watchdog.py` is the fast, stubbed-modem pin for all of
+  this — the failure under test is *decodes stopping*, and there is no
+  way to ask the real modem to stop decoding on cue, which is why the
+  slow suite cannot cover it.
+
   **The progress bar is position, not fill**: the last frame
   successfully received over the frames expected, never latents
   received over latents expected. Only the blind path can tell the two

--- a/native/core/rx/engine.cpp
+++ b/native/core/rx/engine.cpp
@@ -167,6 +167,41 @@ void remember_finished(std::deque<std::int64_t>& finished, std::int64_t pos) {
     while (finished.size() > kFinishedHistory) finished.pop_front();
 }
 
+// The reception `decode_loop` is currently tracking, retained from one
+// poll to the next.
+//
+// This exists so the three "is it finished?" tests can fire on a poll
+// that decoded *nothing*, which is the whole reason it is a record
+// rather than a handful of locals recomputed per poll. A reception stops
+// producing a decode long before it stops being real: its audio scrolls
+// out of the ring buffer, or -- much sooner -- its blind acquisition
+// score falls back under BLIND_SCORE_THRESHOLD as the accumulator's
+// evidence decays once the transmission is over. If the completion tests
+// are only asked on polls that produced a decode, then in exactly the
+// case that matters they are never asked again: the loop sits in
+// Receiving forever, the sink is never called, and the picture that
+// *was* decoded is never delivered or saved. An indefinite hang and
+// autosave never firing are that one bug seen from two ends, so a poll
+// that decodes nothing must go on counting against the reception rather
+// than being skipped over.
+//
+// `image` and the fields beside it are the last good decode, held so the
+// reception can still be delivered after its decodes have stopped.
+// `deadline_abs` is a buffer position, not a time: past it, no real
+// frame of this transmission can still be arriving (see decode_loop).
+struct Pending {
+    std::int64_t start = 0;         // absolute preamble-start position
+    std::int64_t deadline_abs = 0;  // absolute buffer position
+    int metric = 0;                 // best progress metric seen
+    // When the metric last stopped advancing; unset while it still is.
+    std::optional<Clock::time_point> stable_since;
+    std::shared_ptr<const images::Picture> image;
+    std::optional<std::string> mode_name;
+    std::optional<int> frames_received, n_frames_expected;
+    std::string callsign;
+    double snr_db = kNaN;
+};
+
 // Back to "listening", with the per-reception fields cleared.
 void reset_to_listening(SharedState& state) {
     state.update([](Progress& s) {
@@ -321,14 +356,12 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
     // rediscovered, re-decoded and re-saved on every following poll.
     std::deque<std::int64_t> finished_starts;
 
-    int last_progress_metric = -1;
-    std::optional<Clock::time_point> stable_since;
-    std::optional<std::int64_t> current_reception_start;
-    // Which reception the progress counters above describe. Progress is
+    // The reception being tracked, unset while listening. Progress is
     // per-reception: carrying a previous transmission's metric across to
     // the next one can make a brand-new reception look as though it has
-    // already stalled, and end it early.
-    std::optional<std::int64_t> tracked_reception_start;
+    // already stalled, and end it early -- so a different reception gets
+    // a fresh record rather than an updated one.
+    std::optional<Pending> pending;
     // Blind acquisition's persistent search state: a BlindAccumulator
     // folds in only the audio that is new since the last poll (see
     // sync::BlindAccumulator), so unlike the preamble path it carries
@@ -453,119 +486,163 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
                 // free_spans blocks the wrong region.
                 reception_start =
                     buf_start + *rb->frame0_start - PREAMBLE_SAMPLES - HEADER_SAMPLES;
-                if (already_finished(*reception_start, finished_starts, epsilon)) continue;
-                latents_full = std::move(rb->latents);
-                weights_full = std::move(rb->weights);
-                have_latents = true;
-                callsign = rb->callsign;
-                snr_db = rb->snr_db;
-                const BlindProgress bp = blind_progress(weights_full);
-                progress_metric = bp.metric;
-                progress_frac = bp.frac;
+                // Already handled: treat it as nothing decoded rather
+                // than skipping the rest of the poll, so that whatever
+                // reception is *currently* pending still gets its
+                // completion tests run this time round.
+                if (already_finished(*reception_start, finished_starts, epsilon)) {
+                    reception_start.reset();
+                } else {
+                    latents_full = std::move(rb->latents);
+                    weights_full = std::move(rb->weights);
+                    have_latents = true;
+                    callsign = rb->callsign;
+                    snr_db = rb->snr_db;
+                    const BlindProgress bp = blind_progress(weights_full);
+                    progress_metric = bp.metric;
+                    progress_frac = bp.frac;
+                }
             }
         }
 
         const double decode_s = seconds_since(t0);
         state.update([&](Progress& s) { s.last_decode_s = decode_s; });
 
-        if (!have_latents) {
-            state.update([](Progress& s) {
-                if (s.status != Status::Receiving) s.status = Status::Listening;
+        bool advanced = false;
+        const bool decoded = have_latents && reception_start.has_value();
+        if (decoded) {
+            // A different reception than the one being tracked: it takes
+            // over, with a fresh record. Its very first poll must not
+            // inherit the previous one's stall clock, or it can be
+            // mistaken for a reception that has already stopped
+            // advancing and be ended immediately.
+            if (!pending || std::llabs(*reception_start - pending->start) > epsilon) {
+                // The deterministic backstop. The transmission's start is
+                // known exactly -- from the header path's own acquisition,
+                // or from the beacon on the blind path, both in the same
+                // "preamble start" coordinate -- so the latest a real
+                // frame of it can possibly still be arriving is its own
+                // duration after that point, fixed the moment the start
+                // is. The blind path has no header and so no mode, and
+                // uses mode C's duration, the longest. That is unlike
+                // "progress stopped advancing" below, which rides on the
+                // decoder's own noise floor and is not guaranteed to ever
+                // settle. Once the buffer holds audio past this deadline
+                // there is provably no more real signal left to arrive
+                // for this reception, done or not.
+                const auto deadline_frames =
+                    static_cast<std::int64_t>(n_frames_expected ? *n_frames_expected
+                                                                : kMaxModeFrames);
+                Pending p;
+                p.start = *reception_start;
+                p.deadline_abs = *reception_start + PREAMBLE_SAMPLES + HEADER_SAMPLES +
+                                 deadline_frames * FRAME_SAMPLES;
+                pending = std::move(p);
+            }
+            if (progress_metric > pending->metric) {
+                pending->metric = progress_metric;
+                advanced = true;
+            }
+            pending->image = std::make_shared<const images::Picture>(
+                decode(latents_full, weights_full));
+            pending->mode_name = mode_name;
+            pending->frames_received = frames_received;
+            pending->n_frames_expected = n_frames_expected;
+            pending->callsign = callsign;
+            pending->snr_db = snr_db;
+            state.update([&](Progress& s) {
+                s.status = Status::Receiving;
+                s.mode_name = mode_name;
+                s.frames_received = frames_received;
+                s.n_frames_expected = n_frames_expected;
+                s.progress_frac = std::min(progress_frac, 1.0);
+                s.callsign = callsign;
+                s.snr_db = snr_db;
+                s.image = pending->image;
             });
-            last_progress_metric = -1;
-            stable_since.reset();
-            current_reception_start.reset();
+        }
+
+        if (!pending) {
+            state.update([](Progress& s) { s.status = Status::Listening; });
             continue;
         }
 
-        // A different reception than the one the progress counters
-        // describe: start its history fresh, or its very first poll can
-        // be mistaken for a stalled (and so finished) one.
-        if (!tracked_reception_start || !reception_start ||
-            std::llabs(*reception_start - *tracked_reception_start) > epsilon) {
-            tracked_reception_start = reception_start;
-            last_progress_metric = -1;
-            stable_since.reset();
-        }
-
-        current_reception_start = reception_start;
-        auto img = std::make_shared<const images::Picture>(
-            decode(latents_full, weights_full));
-        state.update([&](Progress& s) {
-            s.status = Status::Receiving;
-            s.mode_name = mode_name;
-            s.frames_received = frames_received;
-            s.n_frames_expected = n_frames_expected;
-            s.progress_frac = std::min(progress_frac, 1.0);
-            s.callsign = callsign;
-            s.snr_db = snr_db;
-            s.image = img;
-        });
-
-        bool done = false;
-        if (n_frames_expected) {
-            done = *frames_received >= *n_frames_expected;
+        // Two things end a reception short of its own frame count, and
+        // both are timed against end_grace.
+        //
+        // It stopped decoding. That is how a reception actually ends in
+        // the field: its audio scrolls out of the ring buffer, or its
+        // blind acquisition score falls back under
+        // BLIND_SCORE_THRESHOLD as the accumulator's evidence decays
+        // once the transmission is over. A poll that decoded nothing is
+        // not a neutral event -- it is the absence of progress, and is
+        // timed as such. Resetting the clock there instead, which is
+        // what the loop used to do from the branch that skipped the rest
+        // of the poll entirely, is why a reception in that state could
+        // never satisfy any completion test however long it sat.
+        //
+        // Or -- blind only, where there is no frame count to finish on
+        // -- its decoded progress stopped advancing. Deliberately *not*
+        // extended to the header path: a spurious preamble-shaped lock
+        // in noise goes on decoding the same handful of frames for as
+        // long as it is looked at, and ending that on a stall would turn
+        // a false lock into a reported, and autosaved, picture of noise
+        // (see test_noise_produces_nothing). The header path does not
+        // need it anyway -- frames_received climbs as the buffer grows,
+        // so a real transmission reaches its count, and the deadline
+        // below is the backstop for one that does not.
+        const bool no_progress =
+            !decoded || (!pending->n_frames_expected && !advanced);
+        if (no_progress) {
+            if (!pending->stable_since) pending->stable_since = Clock::now();
         } else {
-            // Deterministic backstop: the beacon already told us exactly
-            // where this transmission's frame 0 sits
-            // (current_reception_start, in the same "preamble start"
-            // coordinate the header path uses), so the latest a real
-            // frame of it can possibly still be arriving is mode C's own
-            // duration -- the longest mode -- after that point, fixed the
-            // moment current_reception_start is known. That is unlike
-            // "progress stopped changing" below, which rides on
-            // demodulate_blind's own noise floor and is not guaranteed to
-            // ever settle: a stuck reception was observed sitting in
-            // Receiving for many minutes, far past any mode's duration.
-            // Once the buffer holds audio past this deadline there is
-            // provably no more real signal left to arrive for this
-            // reception, done or not.
-            const std::int64_t deadline_abs = *current_reception_start + PREAMBLE_SAMPLES +
-                                              HEADER_SAMPLES +
-                                              static_cast<std::int64_t>(kMaxModeFrames) *
-                                                  FRAME_SAMPLES;
-            if (progress_metric > 0 && progress_metric == last_progress_metric) {
-                if (!stable_since) stable_since = Clock::now();
-                done = seconds_since(*stable_since) >= config.end_grace;
-            } else {
-                stable_since.reset();
-            }
-            done = done || static_cast<std::int64_t>(total) >= deadline_abs;
+            pending->stable_since.reset();
         }
-        last_progress_metric = progress_metric;
 
-        if (!(done && progress_metric > 0)) continue;
-
-        Reception rec;
-        rec.image = *img;
-        rec.mode_name = mode_name;
-        rec.callsign = callsign;
-        rec.snr_db = snr_db;
-        rec.frames_received = frames_received;
-        rec.n_frames_expected = n_frames_expected;
-        const std::optional<std::string> saved_path = sink(rec);
-
-        // Bookkeeping, not disk: this reception has been *handled*, so it
-        // must never be rediscovered while its audio is still in the
-        // buffer -- whether or not the sink chose to save it.
-        if (current_reception_start) {
-            remember_finished(finished_starts, *current_reception_start);
+        const bool complete = pending->n_frames_expected && pending->frames_received &&
+                              *pending->frames_received >= *pending->n_frames_expected;
+        const bool stalled = pending->stable_since &&
+                             seconds_since(*pending->stable_since) >= config.end_grace;
+        if (!complete && !stalled &&
+            static_cast<std::int64_t>(total) < pending->deadline_abs) {
+            continue;
         }
-        state.update([&](Progress& s) {
-            s.status = Status::Done;
-            s.saved_path = saved_path;
-        });
 
-        if (config.once) {
+        // Deliver only what has something in it. A reception that ended
+        // with no confidently-received latent at all is not a picture,
+        // and is deliberately *not* recorded in finished_starts either:
+        // there is nothing to protect against re-saving, and a real
+        // transmission that was merely weak on its first polls must stay
+        // findable rather than be blocked out for as long as its audio
+        // is in the buffer.
+        const bool delivered = pending->metric > 0 && pending->image;
+        if (delivered) {
+            Reception rec;
+            rec.image = *pending->image;
+            rec.mode_name = pending->mode_name;
+            rec.callsign = pending->callsign;
+            rec.snr_db = pending->snr_db;
+            rec.frames_received = pending->frames_received;
+            rec.n_frames_expected = pending->n_frames_expected;
+            const std::optional<std::string> saved_path = sink(rec);
+
+            // Bookkeeping, not disk: this reception has been *handled*,
+            // so it must never be rediscovered while its audio is still
+            // in the buffer -- whether or not the sink chose to save it.
+            remember_finished(finished_starts, pending->start);
+            state.update([&](Progress& s) {
+                s.status = Status::Done;
+                s.saved_path = saved_path;
+            });
+        }
+        pending.reset();
+
+        if (delivered && config.once) {
             stop.set();
             break;
         }
 
-        last_progress_metric = -1;
-        stable_since.reset();
-        current_reception_start.reset();
-        tracked_reception_start.reset();
-        stop.wait(2.0);
+        if (delivered) stop.wait(2.0);
         reset_to_listening(state);
     }
 }
@@ -642,9 +719,24 @@ void decode_loop_low_cpu(RingBuffer& ring, const Decoder& decode, SharedState& s
         // arrived -- just wait, updating the status text cheaply. The
         // reference calls snapshot() here and throws the samples away;
         // total_written() is the same number without copying 8 MB.
+        //
+        // Bounded, because this waits on something outside the loop's
+        // control: if capture stops -- the device is unplugged, the
+        // stream dies, the host stops delivering callbacks -- total_now
+        // stops advancing, and an unbounded wait here holds the receiver
+        // in Receiving forever waiting for audio that will never come,
+        // with no picture ever handed to the sink. The bound is how long
+        // the audio still missing should take to arrive, plus end_grace;
+        // past it, decode whatever did arrive.
+        const Clock::time_point wait_deadline =
+            Clock::now() +
+            std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(
+                static_cast<double>(frames_end_abs - static_cast<std::int64_t>(total)) / FS +
+                config.end_grace));
         while (!stop.is_set()) {
             const std::uint64_t total_now = ring.total_written();
             if (static_cast<std::int64_t>(total_now) >= frames_end_abs) break;
+            if (Clock::now() >= wait_deadline) break;
             state.update(
                 [&](Progress& s) { s.seconds_captured = static_cast<double>(total_now) / FS; });
             stop.wait(std::min(1.0, config.poll_interval));

--- a/native/core/rx/engine.hpp
+++ b/native/core/rx/engine.hpp
@@ -11,8 +11,13 @@
 // from-here-on.
 //
 // A reception is finished when a fully-synced decode reports all its
-// frames, or -- blind, where neither mode nor duration is known -- when
-// decoded progress stops advancing for `end_grace` seconds.
+// frames, when decoded progress stops advancing for `end_grace`
+// seconds, or when the buffer holds audio past the point where the last
+// frame of that transmission could still be arriving -- whichever comes
+// first. All three run against the tracked reception retained *across*
+// polls (`Pending`, in the .cpp), so none of them depends on the current
+// poll having produced a decode at all; see `Pending` for why that is
+// the whole ballgame.
 //
 // Headless, and knows nothing about audio devices or any UI: it reads a
 // `RingBuffer` somebody else is filling, publishes live status into a

--- a/native/tests/test_rx_engine.cpp
+++ b/native/tests/test_rx_engine.cpp
@@ -350,6 +350,111 @@ void test_low_cpu_loop_receives() {
                    "rx/lowcpu: the decoder's picture");
 }
 
+// A transmission whose tail never arrived: everything up to `keep_s`
+// seconds of it, and no more. What a reception looks like when the
+// operator unkeys early, when the band takes the signal away, or when
+// the recording simply stops.
+std::vector<double> truncated(const std::string& callsign, std::uint64_t seed,
+                              double keep_s) {
+    std::vector<double> full = transmission(callsign, seed);
+    const auto keep = static_cast<std::size_t>(keep_s * config::FS);
+    if (keep < full.size()) full.resize(keep);
+    return full;
+}
+
+void test_a_reception_whose_decodes_stop_is_still_delivered() {
+    // The watchdog regression. A partial reception is decoded, and then
+    // its decodes stop -- here because its audio ages out of the ring
+    // buffer, which is one of the two ways it happens in the field (the
+    // other is a blind lock decaying under BLIND_SCORE_THRESHOLD once
+    // the transmission is over). Nothing else can finish it: it never
+    // reports all its frames, and with only a few seconds of it in a
+    // buffer that never reaches the end of a mode-A transmission, the
+    // sample-position deadline cannot fire either.
+    //
+    // Every completion test used to be evaluated inside the branch that
+    // ran only when the current poll had produced a decode, so from the
+    // moment the decodes stopped, "is this finished?" was never asked
+    // again: the loop sat in Receiving indefinitely and the picture it
+    // had already decoded was never handed to the sink. A hang and
+    // autosave never firing are that one bug from two ends.
+    Harness h(12.0);
+    write_all(h.ring, truncated("KC2G", 61, 3.0));
+
+    std::thread loop([&] {
+        rx::decode_loop(h.ring, h.decoder(), h.state, h.config, h.stop, h.sink());
+    });
+    std::thread watcher([&] { h.poll_watcher(); });
+
+    // Let it lock and decode the fragment at least once, so what
+    // follows is a reception being abandoned rather than never found.
+    // Waited on the *status*, not on the decode count: the loop decodes
+    // before it publishes, so a decoder-side counter can be observed one
+    // step ahead of the state it is standing in for.
+    h.until([&] { return h.state.get().status == rx::Status::Receiving; },
+            "rx/watchdog: the fragment puts the loop in receiving");
+    check::equal(h.count(), std::size_t{0},
+                 "rx/watchdog: a fragment is not a finished reception yet");
+
+    // Past the ring buffer's whole length, so nothing of the
+    // transmission is left to decode.
+    write_all(h.ring, std::vector<double>(static_cast<std::size_t>(15.0 * config::FS)));
+
+    h.until([&] { return h.received.size() >= 1; },
+            "rx/watchdog: a reception whose decodes stopped is still delivered -- "
+            "otherwise it is still sitting in receiving with its picture "
+            "undelivered, which is both the hang and the autosave-never-fires "
+            "report");
+    h.stop.set();
+    loop.join();
+    watcher.join();
+
+    check::equal(h.count(), std::size_t{1}, "rx/watchdog: delivered exactly once");
+    if (h.count() != 1) return;
+    const rx::Reception& r = h.received[0];
+    check::is_true(r.mode_name.has_value() && *r.mode_name == "A",
+                   "rx/watchdog: the header's mode survived into the delivery");
+    check::is_true(r.frames_received.has_value() && *r.frames_received > 0 &&
+                       *r.frames_received < mode_a().n_frames,
+                   "rx/watchdog: delivered as the partial reception it is");
+    check::is_true(!r.image.empty() && r.image.rgb[0] == kDecoderMark,
+                   "rx/watchdog: the last good decode's picture, not an empty one");
+    check::is_true(h.state.get().status == rx::Status::Listening,
+                   "rx/watchdog: and the loop goes back to listening");
+}
+
+void test_low_cpu_does_not_wait_forever_for_audio_that_stops() {
+    // decode_loop_low_cpu locks on the preamble and then stops doing any
+    // DSP at all until the buffer holds the whole transmission. That is
+    // a wait on something outside the loop's control -- if capture stops
+    // (the device is unplugged, the stream dies, the host stops
+    // delivering callbacks) the audio it is waiting for never arrives,
+    // and unbounded it holds the receiver in Receiving forever with no
+    // picture ever handed to the sink.
+    //
+    // A second of the transmission is missing, so the bound under test
+    // is about a second plus end_grace rather than a whole mode's
+    // duration -- this is not asserting on how long that takes, only
+    // that it is finite. `once` makes the call synchronous: before the
+    // fix it simply never returned.
+    Harness h(60.0);
+    h.config.once = true;
+    const std::vector<double> full = transmission("W1AW", 62);
+    const double short_by_s = 1.0;
+    write_all(h.ring, truncated("W1AW", 62,
+                                static_cast<double>(full.size()) / config::FS - short_by_s));
+
+    rx::decode_loop_low_cpu(h.ring, h.decoder(), h.state, h.config, h.stop, h.sink());
+
+    check::equal(h.received.size(), std::size_t{1},
+                 "rx/lowcpu-watchdog: audio that stops arriving still ends the "
+                 "reception rather than waiting for it forever");
+    if (h.received.empty()) return;
+    check::is_true(h.received[0].frames_received.has_value() &&
+                       *h.received[0].frames_received < mode_a().n_frames,
+                   "rx/lowcpu-watchdog: delivered as the partial reception it is");
+}
+
 void test_fresh_session_does_not_inherit_blind_evidence_from_a_prior_one() {
     // The app's "start receiving" button and ReceivePanel::resume_after_
     // transmit both work by discarding the whole RingBuffer and calling
@@ -571,6 +676,8 @@ int main() {
         test_noise_produces_nothing();
         test_low_cpu_loop_receives();
         test_a_finished_reception_is_not_rediscovered();
+        test_a_reception_whose_decodes_stop_is_still_delivered();
+        test_low_cpu_does_not_wait_forever_for_audio_that_stops();
         test_two_transmissions_are_both_received();
         test_fresh_session_does_not_inherit_blind_evidence_from_a_prior_one();
     } catch (const std::exception& e) {

--- a/sstvae/rx/engine.py
+++ b/sstvae/rx/engine.py
@@ -10,14 +10,15 @@ history from before sync was acquired, a mid-stream lock still decodes
 the frames that arrived before it -- retrospective decoding, not just
 from-here-on.
 
-Reception is considered finished either when a fully-synced decode
-reports all its frames received, or (blind case, true mode/duration
-unknown) when decoded progress stops advancing for --end-grace seconds
--- backstopped by a hard deadline, mode C's own duration (the longest
-mode) past the transmission's start as the beacon already reported it,
-so a reception can't sit in "receiving" indefinitely if the stall
-detector's metric never settles (see PROGRESS_WEIGHT_THRESHOLD and the
-deadline computation in decode_loop's blind branch).
+Reception is considered finished when a fully-synced decode reports all
+its frames received, when decoded progress stops advancing for
+--end-grace seconds, or when the buffer holds audio past the point where
+the last frame of that transmission could possibly still be arriving --
+whichever comes first. All three tests run against `_Pending`, the
+tracked reception retained *across* polls, so that none of them depends
+on the current poll having produced a decode at all; see `_Pending` for
+why that is the whole ballgame, and PROGRESS_WEIGHT_THRESHOLD for what
+"progress" counts as on the blind path.
 
 `decode_loop_low_cpu` is a cheaper variant that drops the blind fallback
 (and with it retrospective mid-stream decoding); see its docstring.
@@ -149,6 +150,44 @@ class RxConfig:
     # gains suit different things -- see config.drift_gains and
     # docs/todo.md.
     drift_track: str = "off"
+
+
+@dataclass
+class _Pending:
+    """The reception `decode_loop` is currently tracking, retained from
+    one poll to the next.
+
+    This exists so the three "is it finished?" tests can fire on a poll
+    that decoded *nothing*, which is the whole reason it is a record
+    rather than a handful of locals recomputed per poll. A reception
+    stops producing a decode long before it stops being real: its audio
+    scrolls out of the ring buffer, or -- much sooner -- its blind
+    acquisition score falls back under BLIND_SCORE_THRESHOLD as the
+    accumulator's evidence decays once the transmission is over. If the
+    completion tests are only asked on polls that produced a decode,
+    then in exactly the case that matters they are never asked again:
+    the loop sits in "receiving" forever, the sink is never called, and
+    the picture that *was* decoded is never delivered or saved. Both
+    reported symptoms -- an indefinite hang, and autosave never firing
+    -- are that one bug, so a poll that decodes nothing must go on
+    counting against the reception rather than being skipped over.
+
+    `image` and the fields beside it are the last good decode, held so
+    the reception can still be delivered after its decodes have stopped.
+    `deadline_abs` is a buffer position, not a time: past it, no real
+    frame of this transmission can still be arriving (see decode_loop).
+    """
+
+    start: int  # absolute (ring-buffer-coordinate) preamble-start position
+    deadline_abs: int
+    metric: int = 0  # best progress metric seen; see _blind_progress
+    stable_since: float | None = None  # when the metric last stopped advancing
+    image: object = None
+    mode_name: str | None = None
+    frames_received: int | None = None
+    n_frames_expected: int | None = None
+    callsign: str = ""
+    snr_db: float = float("nan")
 
 
 @dataclass
@@ -312,14 +351,12 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
     # afterward, so without this a still-buffered transmission would be
     # rediscovered and re-decoded/re-saved on every following poll.
     finished_starts = deque(maxlen=50)
-    last_progress_metric = -1
-    stable_since = None
-    current_reception_start = None
-    # Which reception the progress counters above describe. Progress is
+    # The reception being tracked, or None while listening. Progress is
     # per-reception: carrying a previous transmission's metric across to
     # the next one can make a brand-new reception look like it has
-    # already stalled and end it early.
-    tracked_reception_start = None
+    # already stalled and end it early, so a different reception gets a
+    # fresh record rather than an updated one.
+    pending: _Pending | None = None
     # Blind acquisition's persistent search state: a BlindAccumulator
     # folds in only the audio that's new since the last poll (see
     # sync.BlindAccumulator), so unlike the preamble path it carries
@@ -423,13 +460,18 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
                 reception_start = (
                     buf_start + rb.frame0_start - PREAMBLE_SAMPLES - HEADER_SAMPLES
                 )
+                # Already handled: treat it as nothing decoded rather
+                # than skipping the rest of the poll, so that whatever
+                # reception is *currently* pending still gets its
+                # completion tests run this time round.
                 if _already_finished(reception_start, finished_starts, epsilon_samples):
-                    continue
-                latents_full = rb.latents
-                weights_full = rb.weights
-                callsign = rb.callsign
-                snr_db = rb.snr_db
-                progress_metric, progress_frac = _blind_progress(weights_full)
+                    reception_start = None
+                else:
+                    latents_full = rb.latents
+                    weights_full = rb.weights
+                    callsign = rb.callsign
+                    snr_db = rb.snr_db
+                    progress_metric, progress_frac = _blind_progress(weights_full)
             else:
                 reception_start = None
 
@@ -438,108 +480,151 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
         with state.lock:
             state.last_decode_s = decode_s
 
-        if latents_full is None:
+        advanced = False
+        decoded = latents_full is not None and reception_start is not None
+        if decoded:
+            # A different reception than the one being tracked: it takes
+            # over, with a fresh record. Its very first poll must not
+            # inherit the previous one's stall clock, or it can be
+            # mistaken for a reception that has already stopped
+            # advancing and be ended immediately.
+            if pending is None or abs(reception_start - pending.start) > epsilon_samples:
+                # The deterministic backstop. The transmission's start is
+                # known exactly -- from the header path's own acquisition,
+                # or from the beacon on the blind path, both in the same
+                # "preamble start" coordinate -- so the latest a real
+                # frame of it can possibly still be arriving is its own
+                # duration after that point, fixed the moment the start
+                # is. The blind path has no header and so no mode, and
+                # uses mode C's duration, the longest. That is unlike
+                # "progress stopped advancing" below, which rides on the
+                # decoder's own noise floor and is not guaranteed to ever
+                # settle. Once the buffer holds audio past this deadline
+                # there is provably no more real signal left to arrive
+                # for this reception, done or not.
+                n_deadline_frames = (
+                    n_frames_expected if n_frames_expected is not None
+                    else MODES["C"].n_frames
+                )
+                pending = _Pending(
+                    start=reception_start,
+                    deadline_abs=(
+                        reception_start + PREAMBLE_SAMPLES + HEADER_SAMPLES
+                        + n_deadline_frames * FRAME_SAMPLES
+                    ),
+                )
+            if progress_metric > pending.metric:
+                pending.metric = progress_metric
+                advanced = True
+            pending.image = reconstruct(model, latents_full, weights_full)
+            pending.mode_name = mode_name
+            pending.frames_received = frames_received
+            pending.n_frames_expected = n_frames_expected
+            pending.callsign = callsign
+            pending.snr_db = snr_db
             with state.lock:
-                if state.status != "receiving":
-                    state.status = "listening"
-            last_progress_metric = -1
-            stable_since = None
-            current_reception_start = None
+                state.status = "receiving"
+                state.mode_name = mode_name
+                state.frames_received = frames_received
+                state.n_frames_expected = n_frames_expected
+                state.progress_frac = min(progress_frac, 1.0)
+                state.callsign = callsign
+                state.snr_db = snr_db
+                state.image = pending.image
+
+        if pending is None:
+            with state.lock:
+                state.status = "listening"
             continue
 
-        # A different reception than the one the progress counters
-        # describe: start its progress history fresh, or its very first
-        # poll can be mistaken for a stalled (and so finished) one.
-        if (
-            tracked_reception_start is None
-            or reception_start is None
-            or abs(reception_start - tracked_reception_start) > epsilon_samples
-        ):
-            tracked_reception_start = reception_start
-            last_progress_metric = -1
-            stable_since = None
-
-        current_reception_start = reception_start
-        img = reconstruct(model, latents_full, weights_full)
-        with state.lock:
-            state.status = "receiving"
-            state.mode_name = mode_name
-            state.frames_received = frames_received
-            state.n_frames_expected = n_frames_expected
-            state.progress_frac = min(progress_frac, 1.0)
-            state.callsign = callsign
-            state.snr_db = snr_db
-            state.image = img
-
-        if n_frames_expected is not None:
-            done = frames_received >= n_frames_expected
+        # Two things end a reception short of its own frame count, and
+        # both are timed against end_grace.
+        #
+        # It stopped decoding. That is how a reception actually ends in
+        # the field: its audio scrolls out of the ring buffer, or its
+        # blind acquisition score falls back under
+        # BLIND_SCORE_THRESHOLD as the accumulator's evidence decays
+        # once the transmission is over. A poll that decoded nothing is
+        # not a neutral event -- it is the absence of progress, and is
+        # timed as such. Resetting the clock there instead, which is
+        # what the loop used to do from the branch that skipped the rest
+        # of the poll entirely, is why a reception in that state could
+        # never satisfy any completion test however long it sat.
+        #
+        # Or -- blind only, where there is no frame count to finish on
+        # -- its decoded progress stopped advancing. Deliberately *not*
+        # extended to the header path: a spurious preamble-shaped lock
+        # in noise goes on decoding the same handful of frames for as
+        # long as it is looked at, and ending that on a stall would turn
+        # a false lock into a reported, and autosaved, picture of noise.
+        # The header path does not need it anyway -- frames_received
+        # climbs as the buffer grows, so a real transmission reaches its
+        # count, and the deadline below is the backstop for one that
+        # does not.
+        no_progress = not decoded or (
+            pending.n_frames_expected is None and not advanced
+        )
+        if no_progress:
+            if pending.stable_since is None:
+                pending.stable_since = time.time()
         else:
-            # Deterministic backstop: the beacon already told us exactly
-            # where this transmission's frame 0 sits (reception_start,
-            # in the same "preamble start" coordinate the header path
-            # uses), so the latest a real frame of it can possibly still
-            # be arriving is mode C's own duration -- the longest mode --
-            # after that point, fixed the moment reception_start is
-            # known. That is unlike "progress stopped changing" below,
-            # which rides on demodulate_blind's own noise floor and is
-            # not guaranteed to ever settle: a stuck reception was
-            # observed sitting in "receiving" for many minutes, far past
-            # any mode's duration, because the buffer kept growing and
-            # touching more of the blind search's legal frame range
-            # (see PROGRESS_WEIGHT_THRESHOLD above) or some other reason
-            # the metric kept moving. Once the buffer holds audio past
-            # this deadline there is provably no more real signal left
-            # to arrive for this reception, done or not.
-            deadline_abs = (
-                current_reception_start + PREAMBLE_SAMPLES + HEADER_SAMPLES
-                + MODES["C"].n_frames * FRAME_SAMPLES
-            )
-            if progress_metric > 0 and progress_metric == last_progress_metric:
-                stable_since = stable_since or time.time()
-                done = (time.time() - stable_since) >= config.end_grace
-            else:
-                stable_since = None
-                done = False
-            done = done or total >= deadline_abs
-        last_progress_metric = progress_metric
+            pending.stable_since = None
 
-        if done and progress_metric > 0:
+        complete = (
+            pending.n_frames_expected is not None
+            and pending.frames_received is not None
+            and pending.frames_received >= pending.n_frames_expected
+        )
+        stalled = (
+            pending.stable_since is not None
+            and (time.time() - pending.stable_since) >= config.end_grace
+        )
+        if not (complete or stalled or total >= pending.deadline_abs):
+            continue
+
+        # Deliver only what has something in it. A reception that ended
+        # with no confidently-received latent at all is not a picture,
+        # and is deliberately *not* recorded in finished_starts either:
+        # there is nothing to protect against re-saving, and a real
+        # transmission that was merely weak on its first polls must stay
+        # findable rather than be blocked out for as long as its audio
+        # is in the buffer.
+        delivered = pending.metric > 0 and pending.image is not None
+        if delivered:
             saved_path = sink.on_reception(
                 Reception(
-                    image=img,
-                    mode_name=mode_name,
-                    callsign=callsign,
-                    snr_db=snr_db,
-                    frames_received=frames_received,
-                    n_frames_expected=n_frames_expected,
+                    image=pending.image,
+                    mode_name=pending.mode_name,
+                    callsign=pending.callsign,
+                    snr_db=pending.snr_db,
+                    frames_received=pending.frames_received,
+                    n_frames_expected=pending.n_frames_expected,
                 )
             )
             # Bookkeeping, not disk: this reception has been *handled*,
             # so it must never be rediscovered while its audio is still
             # in the buffer -- whether or not the sink chose to save it.
-            if current_reception_start is not None:
-                finished_starts.append(current_reception_start)
+            finished_starts.append(pending.start)
             with state.lock:
                 state.status = "done"
                 state.saved_path = saved_path
 
-            if config.once:
-                stop_event.set()
-                break
+        pending = None
 
-            last_progress_metric = -1
-            stable_since = None
-            current_reception_start = None
-            tracked_reception_start = None
+        if delivered and config.once:
+            stop_event.set()
+            break
+
+        if delivered:
             stop_event.wait(2.0)
-            with state.lock:
-                state.status = "listening"
-                state.mode_name = None
-                state.frames_received = None
-                state.n_frames_expected = None
-                state.progress_frac = 0.0
-                state.callsign = ""
-                state.snr_db = float("nan")
+        with state.lock:
+            state.status = "listening"
+            state.mode_name = None
+            state.frames_received = None
+            state.n_frames_expected = None
+            state.progress_frac = 0.0
+            state.callsign = ""
+            state.snr_db = float("nan")
 
 
 def decode_loop_low_cpu(ring: RingBuffer, model, state: SharedState, config: RxConfig,
@@ -609,9 +694,19 @@ def decode_loop_low_cpu(ring: RingBuffer, model, state: SharedState, config: RxC
 
         # No further DSP until the whole transmission should have
         # arrived -- just wait, updating the status text cheaply.
+        #
+        # Bounded, because this waits on something outside the loop's
+        # control: if capture stops -- the device is unplugged, the
+        # stream dies, the host stops delivering callbacks -- total_now
+        # stops advancing, and an unbounded wait here holds the receiver
+        # in "receiving" forever waiting for audio that will never come,
+        # with no picture ever handed to the sink. The bound is how long
+        # the audio still missing should take to arrive, plus end_grace;
+        # past it, decode whatever did arrive.
+        wait_deadline = time.time() + (frames_end_abs - total) / FS + config.end_grace
         while not stop_event.is_set():
             _, total_now = ring.snapshot()
-            if total_now >= frames_end_abs:
+            if total_now >= frames_end_abs or time.time() >= wait_deadline:
                 break
             with state.lock:
                 state.seconds_captured = total_now / FS

--- a/tests/test_rx_watchdog.py
+++ b/tests/test_rx_watchdog.py
@@ -1,0 +1,235 @@
+"""The watchdog that stops a reception sitting in "receiving" forever.
+
+These are fast tests: the modem is replaced by a stub, so nothing here
+does any DSP at all. That is deliberate, and it is what the slow tests in
+`test_listen_state_machine.py` cannot do — the failure under test is
+*decodes stopping*, and there is no way to ask the real modem to stop
+decoding on cue. The state machine's decisions are the thing being
+checked, so the state machine is the only thing left in the loop.
+
+The failure they pin: every completion test used to be evaluated inside
+the branch that ran only when the current poll had produced a decode.
+A reception stops producing a decode long before it stops being real —
+its audio scrolls out of the ring buffer, or its blind acquisition score
+falls back under BLIND_SCORE_THRESHOLD as the accumulator's evidence
+decays once the transmission is over — and from that poll onward "is
+this finished?" was simply never asked again. The loop stayed in
+"receiving" indefinitely, the sink was never called, and the picture
+that had already been decoded was never delivered. The reported hang and
+"autosave never fires" are the same bug seen from two ends.
+"""
+
+import threading
+import time
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from sstvae.config import FS, HEADER_SAMPLES, MODES, PREAMBLE_SAMPLES
+from sstvae.modem import SyncError
+from sstvae.modem.modem import DemodResult
+from sstvae.modem.sync import Acquisition
+from sstvae.rx import engine as rx_engine
+from sstvae.rx.engine import Reception, RxConfig, SharedState, decode_loop
+
+MODE_A = MODES["A"]
+
+
+class _CollectingSink:
+    def __init__(self):
+        self.receptions: list[Reception] = []
+
+    def on_reception(self, rec):
+        self.receptions.append(rec)
+        return "/dev/null/fake.png"
+
+
+def _demod_result(frames_received: int) -> DemodResult:
+    """A partial mode-A decode: the preamble and header were heard, and
+    `frames_received` of the mode's frames landed."""
+    n = MODE_A.n_latents
+    return DemodResult(
+        latents=np.zeros(n),
+        weights=np.full(n, 0.9),
+        mode=MODE_A,
+        freq_offset=0.0,
+        sync_metric=0.9,
+        frames_received=frames_received,
+        beacon=None,
+        callsign="TEST",
+        preamble_start=0,
+        snr_db=12.0,
+    )
+
+
+class _StubModem:
+    """Decodes for the first `good_polls` calls, then stops — the shape
+    of every real way a reception's decodes end (its audio ages out of
+    the ring buffer, its blind lock decays below threshold, the signal
+    was never really there). Never reports a complete transmission, so
+    the only thing that can finish it is the watchdog."""
+
+    def __init__(self, good_polls: int, frames_received: int):
+        self.good_polls = good_polls
+        self.frames_received = frames_received
+        self.calls = 0
+        self.calls_after_stop = 0
+
+    def demodulate(self, samples, search_s=None, drift_track="off"):
+        self.calls += 1
+        if self.calls > self.good_polls:
+            self.calls_after_stop += 1
+            raise SyncError("decodes have stopped")
+        return _demod_result(self.frames_received)
+
+    def demodulate_blind(self, x, search_s=None, acquisition=None, drift_track="off"):
+        raise SyncError("no blind lock either")
+
+
+@pytest.fixture
+def stub_modem(monkeypatch):
+    """Put the loop's whole signal-processing surface under control:
+    `Modem`, the module-level `sync_acquire` that `_find_new_reception`
+    vets peaks with, and `reconstruct` (so no checkpoint is needed).
+    `to_baseband` is left real — it is a cheap pure function of the
+    samples and faking it would only add a way for the test to lie."""
+
+    def install(modem):
+        monkeypatch.setattr(rx_engine, "Modem", lambda: modem)
+        monkeypatch.setattr(
+            rx_engine, "sync_acquire",
+            lambda z, **kw: Acquisition(preamble_start=0, freq_offset=0.0, metric=0.9),
+        )
+        monkeypatch.setattr(
+            rx_engine, "reconstruct",
+            lambda model, latents, weights: Image.new("RGB", (8, 8)),
+        )
+        return modem
+
+    return install
+
+
+def _run(config, sink, seconds_of_audio=6.0, timeout_s=20.0, feed_more=None):
+    """Run decode_loop against a ring buffer holding `seconds_of_audio`
+    of noise, until the sink sees a reception or `timeout_s` elapses.
+
+    The audio's *content* is irrelevant here — the stub modem ignores it
+    — but its length is not: the loop refuses to attempt a decode below
+    MIN_SECONDS_BEFORE_ATTEMPT, and the ring buffer's fill is what the
+    sample-position deadline is measured against."""
+    ring = rx_engine.RingBuffer(200.0)
+    ring.write(np.zeros(int(seconds_of_audio * FS)))
+
+    state = SharedState()
+    stop = threading.Event()
+    th = threading.Thread(
+        target=decode_loop, args=(ring, None, state, config, stop, sink), daemon=True
+    )
+    th.start()
+    try:
+        if feed_more is not None:
+            feed_more(ring)
+        deadline = time.time() + timeout_s
+        while time.time() < deadline and not sink.receptions and th.is_alive():
+            time.sleep(0.02)
+    finally:
+        stop.set()
+        th.join(timeout=10.0)
+    return state
+
+
+def test_a_reception_whose_decodes_stop_is_still_delivered(stub_modem):
+    """The core regression. A partial reception is decoded, then the
+    decodes stop. Nothing else can finish it: it never reports all its
+    frames, and the buffer never reaches its sample-position deadline.
+    Only the stall test can, and only if it is still evaluated on polls
+    that decoded nothing."""
+    modem = stub_modem(_StubModem(good_polls=2, frames_received=MODE_A.n_frames // 2))
+    sink = _CollectingSink()
+    config = RxConfig(poll_interval=0.05, end_grace=0.5)
+
+    state = _run(config, sink, timeout_s=20.0)
+
+    assert modem.calls_after_stop > 0, (
+        "the stub never got past its good polls — the test isn't exercising "
+        "the failure at all"
+    )
+    assert len(sink.receptions) == 1, (
+        "a reception whose decodes stopped was never handed to the sink: it is "
+        "still sitting in 'receiving' with its picture undelivered, which is "
+        "both the hang and the autosave-never-fires report"
+    )
+    rec = sink.receptions[0]
+    assert rec.frames_received == MODE_A.n_frames // 2
+    assert rec.mode_name == "A"
+    assert rec.callsign == "TEST"
+    assert state.status == "listening", (
+        f"status stuck at {state.status!r} after the reception ended"
+    )
+
+
+def test_the_preamble_path_has_a_deadline_too(stub_modem):
+    """A reception that goes on decoding, always partially, must still
+    end once the buffer holds audio past the last point one of its
+    frames could have arrived — mode A's own duration past its start.
+
+    end_grace is set out of reach so this isolates the sample-position
+    deadline from the stall test above. Before the fix the header path
+    had no deadline of any kind: `done` was `frames_received >=
+    n_frames_expected` and nothing else, so a transmission that was cut
+    short, or faded before its end, was re-decoded to the same partial
+    result on every poll forever."""
+    modem = stub_modem(_StubModem(good_polls=10**9, frames_received=3))
+    sink = _CollectingSink()
+    config = RxConfig(poll_interval=0.05, end_grace=1e9)
+
+    # The stub reports preamble_start 0, so the deadline sits one whole
+    # mode-A transmission from the buffer's start. Start below it, then
+    # feed past it, so a delivery can only be the deadline firing.
+    need = PREAMBLE_SAMPLES + HEADER_SAMPLES + MODE_A.n_frames * rx_engine.FRAME_SAMPLES
+
+    def feed_more(ring):
+        time.sleep(0.5)
+        assert not sink.receptions, (
+            "finished before its deadline could be reached — end_grace=1e9 was "
+            "supposed to make that impossible, so this isn't isolated"
+        )
+        ring.write(np.zeros(need))
+
+    _run(config, sink, seconds_of_audio=6.0, timeout_s=20.0, feed_more=feed_more)
+
+    assert len(sink.receptions) == 1, (
+        "a partial header-path reception never ended: past its own mode's "
+        "duration there is provably no more of it left to arrive"
+    )
+    assert sink.receptions[0].frames_received == 3
+
+
+def test_a_complete_reception_still_finishes_on_its_frame_count(stub_modem):
+    """The ordinary path, unchanged: all frames received ends it at
+    once, without waiting on end_grace or on any deadline."""
+    stub_modem(_StubModem(good_polls=10**9, frames_received=MODE_A.n_frames))
+    sink = _CollectingSink()
+    config = RxConfig(poll_interval=0.05, end_grace=1e9)
+
+    t0 = time.time()
+    _run(config, sink, timeout_s=20.0)
+
+    assert len(sink.receptions) == 1
+    assert time.time() - t0 < 5.0, "waited on a timer for an already-complete reception"
+    assert sink.receptions[0].frames_received == MODE_A.n_frames
+
+
+def test_nothing_is_delivered_when_nothing_ever_decoded(stub_modem):
+    """The watchdog must not invent receptions. A loop that never
+    decodes anything has nothing pending, so no deadline is running and
+    the sink is never called."""
+    stub_modem(_StubModem(good_polls=0, frames_received=0))
+    sink = _CollectingSink()
+    config = RxConfig(poll_interval=0.05, end_grace=0.2)
+
+    state = _run(config, sink, timeout_s=3.0)
+
+    assert sink.receptions == []
+    assert state.status == "listening"


### PR DESCRIPTION
## The bug

Every completion test in `decode_loop` was evaluated *inside* the branch that ran only when the current poll had produced a decode:

```python
if latents_full is None:
    ...
    stable_since = None          # <- the stall clock, reset
    continue                     # <- and the rest of the poll skipped
```

A reception stops decoding long before it stops being real. Its audio scrolls out of the ring buffer, or — much sooner — its blind acquisition score falls back under `BLIND_SCORE_THRESHOLD` as the accumulator's evidence decays once the transmission is over. From that moment "is this finished?" was never asked again: the loop sat in `receiving` indefinitely, the sink was never called, and the picture that *had already been decoded* was never delivered.

**The indefinite hang and autosave never firing are the same bug from two ends** — saving is the sink's job, so a loop that never finishes a reception never saves one either.

Two smaller holes fed into it:

- **The header path had no deadline of any kind.** `done = frames_received >= n_frames_expected`, and nothing else. A reception that never reached its frame count had nothing to end it.
- **`decode_loop_low_cpu` waits, unbounded, for the buffer to hold the whole transmission** before doing any further DSP. That is a wait on something outside the loop's control: if capture dies (device unplugged, stream dead, callbacks stopped) the audio never arrives and it waits forever.

## The fix

The tracked reception becomes a record retained *across* polls (`_Pending` in Python, `Pending` in `native/core/rx/engine.cpp`), holding its last good decode. Completion is then evaluated on every poll, decode or no decode, against three tests:

| test | header path | blind path |
| --- | --- | --- |
| all frames received | yes | n/a (no header, so no frame count) |
| decoded progress stalled for `end_grace` | see below | yes, as before |
| buffer past the reception's own deadline | **new** — its mode's duration past its start | as before — mode C's |

**The stall test is deliberately not extended to the header path while it is still decoding.** A spurious preamble lock in noise goes on decoding the same handful of frames for as long as it is looked at, and ending *that* on a stall would turn a false lock into a saved picture of noise — which is exactly what `test_noise_produces_nothing` exists to prevent. So the clock runs on polls where the reception **did not decode**, plus — blind only — where it decoded and did not advance. That is the discrimination that matters: "the reception is over" versus "a false lock is being re-decoded".

A reception that ends with no confidently-received latent is dropped rather than delivered, and deliberately *not* recorded in `finished_starts` either: there is nothing to protect against re-saving, and a real transmission that was merely weak on its first polls has to stay findable.

`decode_loop_low_cpu`'s wait is bounded by the audio still missing plus `end_grace`, then it decodes what did arrive.

## Tests

`tests/test_rx_watchdog.py` is new and **fast** — the modem is stubbed, so no DSP runs. That is deliberate: the failure under test is *decodes stopping*, and there is no way to ask the real modem to stop decoding on cue, which is why the existing slow suite cannot reach it. Two regression cases and two controls.

Verified locally against the pre-fix engine:

```
FAILED tests/test_rx_watchdog.py::test_a_reception_whose_decodes_stop_is_still_delivered
FAILED tests/test_rx_watchdog.py::test_the_preamble_path_has_a_deadline_too
2 failed, 2 passed
```

The two controls (a complete reception still finishes on its frame count; nothing is delivered when nothing ever decoded) pass on both, so the tests are pinning the change rather than the file.

The C++ side gets the same two in `test_rx_engine.cpp`, driven by real audio since the modem is not injectable there: a fragment whose audio is then evicted from the ring buffer, and a truncated transmission the low-CPU loop would otherwise wait on forever.

## What ran

- `pytest` — 221 passed, 156 skipped
- `pytest -m slow` — 5 passed, 12 skipped (the listener state machine, incl. both existing blind-deadline tests)
- `ctest` (`--no-codec`, no Qt in this sandbox) — 18/18, `rx engine (1430 checks)`

Not run here: `pytest --native` and anything needing the codec, Qt or pybind11 — this environment has none of them, hence leaving the rest to CI. The C++ tests' pre-fix failure is also unverified; the Python pair's is not, and they pin the same logic.


---
_Generated by [Claude Code](https://claude.ai/code/session_016FxQBgCR792LBM9L3EyrjA)_