### PR TITLE
Add rig control (CAT and PTT) support on Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,12 @@ jobs:
       # forgive and MSVC does not.
       - name: Standard-library includes
         run: python tools/check_includes.py
+      # Same shape, different expensive platform: a `--` inside an XML
+      # comment is illegal, and only an Android Gradle build says so --
+      # against a copy of the file under build/intermediates/, which is
+      # not a path anyone can edit.
+      - name: XML comments
+        run: python tools/check_xml_comments.py
       - name: Show the diff if anything is stale
         if: failure()
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -996,11 +996,27 @@ the SPP UUID). Six things are settled and worth not re-deriving:
   unauthenticated path to a transmitter; the bind is `127.0.0.1` and the
   port is ephemeral. One thread per direction, so an idle link costs no
   wakeups.
-- **`Session` owns the `RigController`, not the UI.** An over is 32-95 s
-  of committed airtime and the thing that brings PTT back down cannot be
-  destroyed by a rotation. `TxEngine` needed no change: it takes a
-  `Ptt`, which is the shape `docs/android.md` predicted CAT would arrive
+- **`Session` owns the `RigController`, and never destroys it.** An
+  over is 32-95 s of committed airtime and the thing that brings PTT
+  back down cannot be destroyed by a rotation -- nor by the operator
+  switching rig control off mid-over, which is what `stop_rig()`
+  destroying the controller used to do: `ptt_function()` captures the
+  *controller*, so the engine was left calling into freed memory at
+  unkey. Created once, `stop()`ped, never destroyed. That is also what
+  makes reconnection safe, since `start()` supersedes a session in place
+  and a `Ptt` handed out earlier keys the new backend
+  (`test_rig.cpp`, mutation-tested). `TxEngine` needed no change: it
+  takes a `Ptt`, the shape `docs/android.md` predicted CAT would arrive
   in.
+- **Reconnection is app-level, and "is the device back?" is why.**
+  `RigControl::maybe_reconnect` rebuilds the session when the radio
+  stops answering and `has_permission(device)` says it is reachable
+  again -- false for a device that is not there, so one call answers
+  both halves. An absent device does not spend the backoff, so
+  replugging is immediate; the backoff is for attempts that reached the
+  radio and failed. **A published frequency is the only proof the radio
+  answered**: `RigController::running()` means a session is configured
+  and said "Connected" with the cable out.
 
 **The Hamlib NDK cross-build and the Android Java have never been
 compiled** (`native/cmake/hamlib.cmake`, `SerialBridge.java`) -- written
@@ -1860,15 +1876,18 @@ on its USB input).
 cost a transport and a socket rather than a fork of Hamlib. Three
 connection kinds — USB serial, Bluetooth RFCOMM, and a network host
 handed straight to Hamlib (which covers both `rigctld` and a
-ser2net-style server, one code path in Hamlib and one here). The whole
-mechanism is tested on a desktop against fakes plus one real Kenwood
-backend; **nothing about it has been compiled for Android or run on a
-phone**, because the session that wrote it had no NDK. The first thing
-to settle on hardware is not the software: most rig USB interfaces
-present audio and CDC serial on one composite device and this app needs
-both at once. That works for FT8CN on at least some devices and there
-is an open report of it failing on others; Bluetooth and the network
-kind are unaffected either way.
+ser2net-style server, one code path in Hamlib and one here).
+
+**USB works on hardware** (Andrew, 2026-08-23): CAT and both
+control-line keying methods, on a phone, over a composite USB
+interface — which settles the one question that could have sunk the
+whole approach, since the app needs the audio and the serial half of
+that device at the same time. **Bluetooth is untested for want of a
+device** and goes to beta on the strength of the shared code beneath
+it. Unplug/replug recovery and the "Connected with the cable out"
+reading were found the same day and fixed;
+`native/android-app/README.md` has the three separate mistakes behind
+that one symptom.
 
 Next, in whatever order: further UI work, the rest of Tier 2, or
 the Play internal test. **A signed upload bundle exists** as of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -963,6 +963,57 @@ through is `struct rig_caps` — which has no pthread members. The result
 is that no struct layout is relied on at all, which is what makes the
 shim safe rather than a gamble.
 
+**Rig control on Android: Hamlib over a loopback socket** (2026-08-22).
+`core/rig/transport.hpp` is the byte pipe a phone can open, `bridge.*`
+presents it to Hamlib as `127.0.0.1:<ephemeral>`, and `bridged.*`
+composes the two behind a `BackendFactory` seam -- all three in
+`sstvae_core`, so the mechanism is tested with fakes in a `--no-rig`
+build. `core/rig/android/` is the JNI half over `SerialBridge.java`
+(USB host API + vendored `usb-serial-for-android`; Bluetooth RFCOMM on
+the SPP UUID). Six things are settled and worth not re-deriving:
+
+- **The presence of a transport selects a bridge, never the device
+  string.** A USB id like `usb:1a86:7523` has no slash and does not
+  start with `com`, so Hamlib's own rules read it as a *hostname* -- the
+  first draft branched on that and skipped the bridge for exactly the
+  devices it exists for. `is_network_device` survives as validation of a
+  typed host and matches `parse_hoststr` case for case.
+- **DTR/RTS keying cannot go through Hamlib here.** `ser_set_dtr` is a
+  `TIOCMSET` ioctl on what is now a socket, so it fails at the moment
+  somebody presses transmit. The line is driven on the transport and
+  Hamlib is set to `ptt_type` "None" (`PttMethod::Vox`). RFCOMM has no
+  modem lines at all, so those methods are not offered over Bluetooth.
+- **`Default` line settings stop meaning anything by themselves.**
+  Hamlib applies per-rig defaults in `serial_open`, which a network port
+  never reaches, so `rig::serial_defaults(model)` reads them out of
+  `struct rig_caps` -- `serial_rate_max` included, whose own `rig_init`
+  comment says "fastest !" -- and `resolve_serial_params` fills them in.
+- **Hamlib's three control-line conflict checks are unreachable** (they
+  sit inside `if (rp->type.rig == RIG_PORT_SERIAL)`) and are re-derived,
+  or a config a desktop refuses at connect time becomes a radio that
+  will not key on a phone.
+- **Loopback only, as a security property.** The far end is an
+  unauthenticated path to a transmitter; the bind is `127.0.0.1` and the
+  port is ephemeral. One thread per direction, so an idle link costs no
+  wakeups.
+- **`Session` owns the `RigController`, not the UI.** An over is 32-95 s
+  of committed airtime and the thing that brings PTT back down cannot be
+  destroyed by a rotation. `TxEngine` needed no change: it takes a
+  `Ptt`, which is the shape `docs/android.md` predicted CAT would arrive
+  in.
+
+**The Hamlib NDK cross-build and the Android Java have never been
+compiled** (`native/cmake/hamlib.cmake`, `SerialBridge.java`) -- written
+in a session with no NDK and no reachable `dl.google.com`. Two guards
+make a first failure diagnosable: the configure step names the missing
+compiler wrapper, and the install step **refuses a versioned SONAME**,
+because Android's packager takes only files named exactly `lib*.so` and
+would drop `libhamlib.so.4` from the APK without comment, leaving a
+`dlopen` failure before `main` -- no output on any stream, and
+indistinguishable from a deadlock. `-DSSTVAE_ANDROID_RIG=OFF` drops CAT
+and keeps the app; the transport, the rig screen and the settings still
+build, so it is one flag rather than a fork.
+
 **Hamlib's own poll thread is turned off** (`poll_interval` = 0).
 `rig_open` otherwise starts one, defaulting to 1000 ms, that issues CAT
 commands for transceive emulation — which directly contradicts what
@@ -1387,7 +1438,11 @@ need when `--native` fails and you want to know *where*.
   uncommon, plenty of radios do offer VOX on the USB input, and a USB
   soundcard into a radio's *microphone* input keys on VOX regardless —
   so "RX+TX without rig control" remains the right shape for Android
-  and this is not an argument for pulling CAT forward. Four other
+  and this is not an argument for pulling CAT forward. (CAT was pulled
+  forward anyway, 2026-08-22, for an unrelated reason — it turned out to
+  cost a socket rather than a Hamlib fork. This judgement stands on its
+  own terms: VOX is still the shape for a station with no cable to the
+  radio.) Four other
   things it
   settled that are not obvious from the design. **No overlay, not even
   an automatic callsign caption** (Andrew): the beacon carrier
@@ -1521,11 +1576,21 @@ need when `--native` fails and you want to know *where*.
   glitch reports — and enumeration needs Java either way. That design is
   also the blocking-read architecture the desktop app wanted and could
   not have, since PortAudio's blocking API corrupts the heap on JACK.
-  And rig control drops for a **structural** reason, not a scoping one:
-  Hamlib's serial layer opens a path and Android gives an unprivileged
-  app no `/dev/ttyUSB`, which is what makes "RX+TX without rig control"
-  the natural shape rather than a compromise. `rig::Backend` is still a
-  seam, so NET rigctl over wifi is ~200 lines whenever it is wanted.
+  **Rig control was written up as dropping for a structural reason and
+  that was wrong** (corrected 2026-08-22, and the doc keeps the error
+  rather than deleting it). The premise held -- Hamlib's serial layer
+  opens a path and Android gives an unprivileged app no `/dev/ttyUSB` --
+  but the conclusion did not, because **Hamlib does not require a serial
+  port**: `rig_open()` puts the pathname through `parse_hoststr()`,
+  which rejects `/dev/...` and `COM*` and accepts `host:port`, and on a
+  match sets `RIG_PORT_NETWORK` for *any* model. That is the mechanism
+  behind `rigctld -m <native model> -r <ser2net host>:4001`, so a socket
+  is a first-class transport for every backend Hamlib has. CAT and PTT
+  are therefore in (see "Rig control on Android" under "The native
+  port"), the radio list
+  on a phone is the desktop's, and the two hedges the old section ended
+  on both held: `rig::Backend` was a seam and `RigController` ported
+  unchanged.
   **The UI is explicitly not a port of the desktop's** (Andrew,
   2026-08-08) — the desktop layout history in this file is a record of
   QtWidgets on a desktop, and reaching for it there would be inheriting
@@ -1542,7 +1607,10 @@ need when `--native` fails and you want to know *where*.
   diagnostic, since with no CAT there is no frequency readout at all —
   which is also why `spectrum.cpp`'s peak-hold matters more there, a
   ragged comb from point-sampling being the worst available lie on a
-  display whose whole job is "are you tuned right".
+  display whose whole job is "are you tuned right". **CAT since
+  2026-08-22 adds a dial readout, and changes none of this**: every
+  session without a cable still has only the waterfall, so it keeps its
+  height and the readout is one line above it.
 - `docs/todo.md` — open work items with the reasoning behind them.
   Completed items keep only a short summary there; the full measurement
   records moved to `docs/todo-done.md` (2026-08-12).
@@ -1786,7 +1854,23 @@ found the `FindClass` bug above.
 in both directions, which retires the caveat this section used to
 carry. What is still unmeasured: battery over a multi-hour session,
 and the VOX leader against a real VOX circuit (the test radio has none
-on its USB input). Next, in whatever order: further UI work, Tier 2, or
+on its USB input).
+
+**CAT and PTT landed 2026-08-22** and are not Tier 2 after all: they
+cost a transport and a socket rather than a fork of Hamlib. Three
+connection kinds — USB serial, Bluetooth RFCOMM, and a network host
+handed straight to Hamlib (which covers both `rigctld` and a
+ser2net-style server, one code path in Hamlib and one here). The whole
+mechanism is tested on a desktop against fakes plus one real Kenwood
+backend; **nothing about it has been compiled for Android or run on a
+phone**, because the session that wrote it had no NDK. The first thing
+to settle on hardware is not the software: most rig USB interfaces
+present audio and CDC serial on one composite device and this app needs
+both at once. That works for FT8CN on at least some devices and there
+is an open report of it failing on others; Bluetooth and the network
+kind are unaffected either way.
+
+Next, in whatever order: further UI work, the rest of Tier 2, or
 the Play internal test. **A signed upload bundle exists** as of
 2026-08-10 — `tools/build_android.sh --aab`, version code 1, both
 ABIs — so the Android half of "store signing" is no longer waiting on

--- a/docs/android.md
+++ b/docs/android.md
@@ -383,7 +383,7 @@ driver. Build both ABIs; the x86_64 Qt kit is 176 MB.
 | Model download | `core/checkpoint/qt_fetcher.cpp`, QtNetwork, behind a `Fetcher` seam | **Keep it.** QtNetwork is in the module set anyway now that Qt Quick is the UI, so this is free. The manual-redirect requirement is unchanged — the client must not auto-follow, or the `x-linked-etag` checksum on the 302 is lost. |
 | Overlay rendering | `core/overlay/render.cpp`, 329 lines, QtGui only | **Not ported, and not planned.** Assumed here to be a Tier 1 item; Tier 1 shipped without it, because the beacon and the CW ID identify the station and a caption in the pixels does not. See the Tier 1 section. |
 | UI | 6,170 lines of QtWidgets | Rewritten in Qt Quick; see below. |
-| Rig control | `core/rig/hamlib.cpp` + libhamlib | Dropped. See below. |
+| Rig control | `core/rig/hamlib.cpp` + libhamlib | Ported, over a socket. See below. |
 
 ### Paths: cheaper than it looks
 
@@ -418,30 +418,110 @@ that gap is a decision someone has to make.
 None of this is difficult. All of it is new code with no desktop
 counterpart, and it is where an app that "just works" is won or lost.
 
-### Rig control drops for a structural reason, not a scoping one
+### Rig control was said to be structurally impossible. It is not.
 
-`sstvae_rig` links libhamlib, which opens `/dev/ttyUSB*`. Android hands
-an unprivileged app no such node: USB serial goes through the Java USB
-host API, where `usb-serial-for-android` is the standard library
-(FTDI/CDC/CP210x/PL2303, **no root**). Hamlib's serial layer opens a
-*path* and has no way to be handed an already-open descriptor, so using
-it would mean patching Hamlib — a fork of a pinned dependency, in the
-one area where "which radios work" is already a per-platform property we
-went to some trouble to avoid.
+**Superseded 2026-08-22.** What this section said for months, and why it
+was wrong, is worth keeping rather than deleting -- it is a good example
+of a correct premise carrying a conclusion it does not support.
 
-**So: VOX for PTT, no CAT, in any transmitting version.** That is what
-"RX+TX without rig control" actually costs — the operator arms VOX and
-reads the frequency off the radio's own display.
+The premise: `sstvae_rig` links libhamlib, which opens `/dev/ttyUSB*`,
+and Android hands an unprivileged app no such node. USB serial goes
+through the Java USB host API, where `usb-serial-for-android` is the
+standard library (FTDI/CDC/CP210x/CH34x/PL2303, no root). Hamlib's
+serial layer opens a *path* and has no way to be handed an already-open
+descriptor. All of that is still true.
 
-Two things make this less final than it sounds. `rig::Backend` is a
-seam, and `RigController`'s threading design (one worker, PTT as
-priority work, `stop()` detaches) has no external dependency and ports
-unchanged — so a CAT backend can be added later without restructuring
-anything. And **Hamlib model 2 (NET rigctl) needs no USB at all**: a
-phone on the same wifi as a station running `rigctld` gets full CAT over
-TCP. Since the wire format is trivial ASCII, that is roughly 200 lines
-of `rig::Backend` that does not link Hamlib — which on Android is a much
-better trade than cross-compiling an autotools tarball for four ABIs.
+The conclusion drawn from it was **"VOX for PTT, no CAT, in any
+transmitting version"**, on the grounds that the alternative was
+patching a pinned dependency in the one area where "which radios work"
+is already a per-platform property. That step is where it went wrong,
+because **Hamlib does not require a serial port.** `rig_open()` runs the
+configured pathname through `parse_hoststr()` -- which explicitly
+rejects `/dev/...` and `COM*` and accepts `host:port` -- and on a match
+sets `type.rig = RIG_PORT_NETWORK` for **any** model, not just model 2.
+`port_open()` then dispatches to `network_open()`. That is the mechanism
+behind the well-worn `rigctld -m <native model> -r <ser2net host>:4001`
+recipe, and it makes a socket a first-class transport for every backend
+Hamlib has.
+
+So the shape is: a Java transport (USB or Bluetooth), a loopback socket
+in front of it, and Hamlib pointed at that socket's address. Nothing is
+patched, no backend is reimplemented, and the radio list on a phone is
+the radio list on the desktop -- which is the property that made the
+original objection worth taking seriously, and is the one this preserves
+rather than trades away.
+
+The two hedges the old section ended on both held, and are worth noting
+because they were the right things to hedge on. `rig::Backend` was a
+seam and `RigController`'s threading design -- one worker, PTT as
+priority work, `stop()` that detaches -- **ported unchanged**; nothing
+about either had to move to accept a CAT backend. And model 2 over the
+network needed no USB at all, which is now one of three connection kinds
+in the same picker rather than the only one.
+
+#### What the pieces are
+
+- `core/rig/transport.hpp` -- `SerialTransport`, the byte pipe. Its
+  threading contract is load-bearing: `read` and `write` are called
+  concurrently from two threads, and `close` must wake a blocked read.
+  Both Android transports satisfy that naturally, which is the only
+  reason it is allowed to be a requirement.
+- `core/rig/bridge.*` -- the loopback socket. **127.0.0.1 only, and that
+  is a security property rather than a default**: the far end is an
+  unauthenticated path to somebody's transmitter. One thread per
+  direction, so an idle link costs no wakeups on a device where a
+  session is measured in hours of battery.
+- `core/rig/bridged.*` -- the composition, behind a `BackendFactory`
+  seam so it builds and tests with no libhamlib.
+- `core/rig/android/` -- the JNI shim and `SerialBridge.java`.
+- `third_party/usb-serial-for-android/` -- vendored, MIT.
+
+All of the first three are in `sstvae_core`, so the mechanism is tested
+on a desktop with fakes; `native/tests/test_rig_hamlib.cpp` holds the
+one claim that needs the real library, a Kenwood TS-2000 backend reading
+frequency and keying PTT through the bridge against a fake radio.
+
+#### Three things that are not obvious
+
+**DTR and RTS keying cannot go through Hamlib on this path.**
+`ser_set_dtr` is a `TIOCMSET` ioctl and the descriptor Hamlib is holding
+is a socket, so the call fails -- at the moment somebody presses
+transmit, which is the worst time to find out. The line is driven on the
+transport instead and Hamlib is configured not to key at all
+(`ptt_type` "None", which is what `PttMethod::Vox` maps to). Over
+Bluetooth there are no modem control lines at all, so those two methods
+are not offered rather than offered and failing.
+
+**"Leave the backend's own value" stops working by itself.** On the
+desktop a `Default` line setting means *do not set the token*, and
+Hamlib applies its per-rig default in `serial_open`. A network port
+never reaches `serial_open`, so a transport given nothing would run at
+whatever the USB chip powered up with. `rig::serial_defaults(model)`
+reads those defaults out of `struct rig_caps` -- including the
+deliberate choice of `serial_rate_max`, whose own comment in `rig_init`
+says "fastest !" -- and `resolve_serial_params` fills them in.
+
+**Hamlib's control-line conflict checks are unreachable here.**
+`rig_open` refuses `-RIG_ECONF` for RTS held with hardware handshaking,
+RTS held while PTT keys by RTS, and DTR held while PTT keys by DTR --
+and all three sit inside `if (rp->type.rig == RIG_PORT_SERIAL)`. They
+are re-derived in `resolve_serial_params`, because losing them means a
+configuration a desktop rejects at connect time silently producing a
+radio that will not key on a phone.
+
+#### What is unverified
+
+The Hamlib cross-build for the NDK (`native/cmake/hamlib.cmake`) and the
+Java half have **never been compiled**: the session that wrote them had
+no NDK and no reachable `dl.google.com`. Treat a first failure there as
+expected work. Two guards exist so the first attempt is diagnosable:
+the configure step fails with a named path if the NDK compiler wrapper
+for the requested API level is missing, and the install step refuses a
+versioned SONAME -- Android's packager takes only files named exactly
+`lib*.so`, so `libhamlib.so.4` would be dropped from the APK without
+comment and the app would die at `dlopen` before `main`, which is the
+same shape of pre-main, no-output failure as the Windows import-library
+trap and just as hard to tell from a deadlock.
 
 ## The front end
 
@@ -517,6 +597,13 @@ With no CAT there is no frequency readout, no rig chip, nothing to say
 where the radio is pointed. The waterfall with band markers is the only
 tuning feedback the operator has, which makes it *more* important here
 than on the desktop, where it competes with a rig panel.
+
+**Still true in the case that matters, after CAT landed** (2026-08-22).
+A rig session adds a dial readout above the waterfall, but every session
+without a cable — acoustic coupling, a handheld, anything Bluetooth is
+not paired to — has exactly what this paragraph describes. So the
+waterfall keeps its height and the readout is one line above it rather
+than a panel beside it.
 
 Two things follow. It gets real vertical extent, which portrait suits
 better than any desktop arrangement did — the desktop squashed it into a
@@ -713,7 +800,14 @@ Two things this needed that had no Tier 0 counterpart:
   RECORD_AUDIO, and from API 34 asking anyway throws, so a
   transmit-only station that denied the microphone drops it.
 
-### Tier 2 — CAT, overlay editing, the refiner
+### Tier 2 — overlay editing and the refiner (CAT landed early)
+
+**CAT is done and is not Tier 2 any more** (2026-08-22): it turned out to
+cost a transport and a socket rather than a fork of Hamlib, so it landed
+with Tier 1's transmit path rather than after it. See "Rig control was
+said to be structurally impossible" above. What is left of this tier is
+the two items below.
+
 
 `core/optimize/` is portable and needs only the fp32 gradient graph as a
 third download. The cost is CPU and battery: the desktop default budget

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -118,6 +118,43 @@ static calibrated quantisation was tried and is *worse* — do not retry
 it without new information. The finding that outlived it — the model
 had never seen non-photographic content — became the item below.
 
+## Android rig control: everything on hardware
+
+Landed 2026-08-22 (`docs/android.md`, "Rig control was said to be
+structurally impossible"). The mechanism is covered by desktop tests --
+the loopback bridge, the composition, the PTT routing, the line-setting
+resolution, and a real Kenwood TS-2000 backend reading frequency and
+keying through the bridge. **None of it has been compiled for Android or
+run against a radio**, because the session that wrote it had no NDK and
+no reachable `dl.google.com`.
+
+In the order that answers the most per attempt:
+
+1. **Does the phone hold USB audio and USB serial on one composite
+   device?** Most rig USB interfaces present both, and this app needs
+   both at once. It works for FT8CN on at least some devices, and
+   mik3y/usb-serial-for-android#477 is an open report of it failing on
+   others. If the answer is no for a given radio, that is the radio's
+   answer and not a bug to fix -- Bluetooth and the network kind are
+   unaffected. Settle it before anything else, because a bad answer
+   changes what the rest of the list is worth.
+2. **The Hamlib NDK cross-build.** Expect to fix something. The two
+   guards in `native/cmake/hamlib.cmake` (a named missing compiler
+   wrapper, and a refused versioned SONAME) exist so the first failure
+   is diagnosable in one round.
+3. **CAT against a real radio**, model 1 first -- Hamlib's dummy opens
+   and keys with nothing attached, so it separates "the bridge works"
+   from "this backend works".
+4. **PTT timing against a physical radio**, which is the *same*
+   outstanding item the desktop has and has never had: `ptt_lead_s` is
+   0.3 s of guess. A phone into a radio is now a way to measure it.
+5. **DTR/RTS keying**, which is the path Hamlib cannot take here and
+   ours is the only implementation of.
+6. **Battery over a multi-hour session with a rig session open.** The
+   poll is 10 s rather than the desktop's 5, and the bridge's idle cost
+   is meant to be two wakeups a second on one thread; both are claims,
+   not measurements.
+
 ## Non-photographic content: evaluate, then train on it
 
 **Andrew, 2026-07-28.** Two related pieces of work, promoted out of the

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -262,6 +262,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Android")
   set(SSTVAE_ANDROID_USBSERIAL_JAVA_DIR
       "${CMAKE_CURRENT_SOURCE_DIR}/third_party/usb-serial-for-android/java"
       CACHE INTERNAL "")
+  # One class Gradle would have generated for the library's own module and
+  # does not generate when its sources are compiled into an app. Kept out
+  # of `java/` so that tree stays a byte-for-byte drop of the release; see
+  # the shim's own comment for why DEBUG is false.
+  set(SSTVAE_ANDROID_USBSERIAL_SHIM_DIR
+      "${CMAKE_CURRENT_SOURCE_DIR}/third_party/usb-serial-for-android/shim"
+      CACHE INTERNAL "")
 endif()
 
 # --- Overlay rendering ------------------------------------------------------

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -110,6 +110,8 @@ add_library(sstvae_core STATIC
   core/util/event.cpp
   core/rx/ringbuffer.cpp
   core/rig/controller.cpp
+  core/rig/bridge.cpp
+  core/rig/bridged.cpp
   core/rx/engine.cpp
   core/tx/engine.cpp
   core/settings/settings.cpp
@@ -131,6 +133,14 @@ target_include_directories(sstvae_core SYSTEM PUBLIC third_party/stb
 # Position-independent so the static core can be linked into the
 # pybind11 shared module.
 set_target_properties(sstvae_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# `core/rig/bridge.cpp` presents a serial transport to Hamlib as a
+# loopback socket, which is what lets a phone -- where there is no
+# `/dev/ttyUSB0` to give Hamlib -- still drive every radio Hamlib knows.
+# POSIX puts the sockets API in libc; Windows needs Winsock named.
+if(WIN32)
+  target_link_libraries(sstvae_core PUBLIC ws2_32)
+endif()
 
 # --- codec ------------------------------------------------------------------
 if(SSTVAE_BUILD_CODEC)

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -238,6 +238,30 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Android")
   set(SSTVAE_ANDROID_AUDIO_JAVA_DIR
       "${CMAKE_CURRENT_SOURCE_DIR}/core/audio/android/java" CACHE INTERNAL "")
   message(STATUS "Android audio: ${ANDROID_ABI}")
+
+  # --- Android serial (USB / Bluetooth) -------------------------------------
+  # The transport a phone can actually open, behind `rig::SerialTransport`.
+  # Separate from sstvae_core for the same reason the audio layer is: the
+  # bridge, the composition and the PTT routing are all in the core and are
+  # tested against fakes on a desktop, and only the code that talks to the
+  # platform is here.
+  #
+  # It does *not* depend on sstvae_rig: a transport is a byte pipe and knows
+  # nothing about Hamlib, which is what lets the whole rig feature be built
+  # and reasoned about in pieces.
+  add_library(sstvae_rig_android STATIC core/rig/android/androidrig.cpp)
+  set_target_properties(sstvae_rig_android PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  target_include_directories(sstvae_rig_android PUBLIC core)
+  target_link_libraries(sstvae_rig_android PUBLIC sstvae_core PRIVATE android log)
+
+  # Two Java trees, both staged into the app's package source dir. The
+  # second is vendored rather than a Gradle coordinate -- see
+  # third_party/usb-serial-for-android/README.md for why.
+  set(SSTVAE_ANDROID_RIG_JAVA_DIR
+      "${CMAKE_CURRENT_SOURCE_DIR}/core/rig/android/java" CACHE INTERNAL "")
+  set(SSTVAE_ANDROID_USBSERIAL_JAVA_DIR
+      "${CMAKE_CURRENT_SOURCE_DIR}/third_party/usb-serial-for-android/java"
+      CACHE INTERNAL "")
 endif()
 
 # --- Overlay rendering ------------------------------------------------------

--- a/native/android-app/CMakeLists.txt
+++ b/native/android-app/CMakeLists.txt
@@ -71,17 +71,49 @@ qt_standard_project_setup(REQUIRES 6.8)
 set(SSTVAE_BUILD_GUI OFF CACHE STRING "" FORCE)
 set(SSTVAE_BUILD_QTAUDIO OFF CACHE STRING "" FORCE)
 set(SSTVAE_BUILD_OVERLAY OFF CACHE STRING "" FORCE)
-set(SSTVAE_BUILD_RIG OFF CACHE BOOL "" FORCE)
+# **On since 2026-08-22.** docs/android.md had this off because Hamlib
+# opens a device path and Android gives an app none -- but Hamlib takes a
+# socket for any backend (core/rig/transport.hpp records the mechanism),
+# so the radio list on a phone is the radio list on the desktop.
+#
+# It is still a switch rather than a given: this is the only part of the
+# app that cross-compiles an autotools tarball, so a build environment
+# without a working NDK toolchain can turn it off and lose CAT rather
+# than lose the app.
+option(SSTVAE_ANDROID_RIG "Build CAT/PTT rig control (needs a Hamlib cross-build)" ON)
+if(SSTVAE_ANDROID_RIG)
+    set(SSTVAE_BUILD_RIG ON CACHE BOOL "" FORCE)
+else()
+    set(SSTVAE_BUILD_RIG OFF CACHE BOOL "" FORCE)
+endif()
 set(SSTVAE_BUILD_PYMODULE OFF CACHE BOOL "" FORCE)
 add_subdirectory(.. sstvae_native EXCLUDE_FROM_ALL)
 
 qt_add_executable(sstvae_android main.cpp listener.cpp session.cpp service_jni.cpp java_fetcher.cpp
-    assets.cpp waterfall.cpp pictures.cpp composition.cpp transmitter.cpp)
+    assets.cpp waterfall.cpp pictures.cpp composition.cpp transmitter.cpp rigcontrol.cpp)
 qt_add_qml_module(sstvae_android URI SSTVAE VERSION 1.0
-    QML_FILES Main.qml LevelMeter.qml CropView.qml TransmitPane.qml)
+    QML_FILES Main.qml LevelMeter.qml CropView.qml TransmitPane.qml RigPane.qml)
 target_link_libraries(sstvae_android PRIVATE Qt6::Quick Qt6::Gui sstvae_core
                                              sstvae_audio_android
                                              sstvae_codec)
+# The transport is always linked: it is a byte pipe to a USB or
+# Bluetooth device and knows nothing about Hamlib, so the rig screen,
+# the device pickers and the settings all build even in the one
+# configuration that has no CAT.
+target_link_libraries(sstvae_android PRIVATE sstvae_rig_android)
+
+if(TARGET sstvae_rig)
+    target_link_libraries(sstvae_android PRIVATE sstvae_rig)
+    target_compile_definitions(sstvae_android PRIVATE SSTVAE_ANDROID_HAVE_RIG=1)
+
+    # libhamlib is a SHARED IMPORTED target, so androiddeployqt cannot
+    # find it by walking dependencies -- exactly the onnxruntime case
+    # below, with the same invisible failure: the APK builds, installs,
+    # and dies at `dlopen` before main.
+    get_target_property(_hamlib_so sstvae_hamlib IMPORTED_LOCATION)
+    set_property(TARGET sstvae_android APPEND PROPERTY
+        QT_ANDROID_EXTRA_LIBS "${_hamlib_so}")
+endif()
 
 # **androiddeployqt only packages libraries it knows about.** Qt's own
 # and the app's are found by walking dependencies; a third-party
@@ -119,6 +151,13 @@ function(sstvae_stage_package_dir from into)
 endfunction()
 sstvae_stage_package_dir("${CMAKE_CURRENT_SOURCE_DIR}/android" "${_pkg_dir}")
 sstvae_stage_package_dir("${SSTVAE_ANDROID_AUDIO_JAVA_DIR}" "${_pkg_dir}/src")
+if(TARGET sstvae_rig_android)
+    # The rig layer's Java half, and the vendored USB serial library it
+    # calls. Both go under src/ with the audio layer's, so androiddeployqt
+    # compiles them into the one app.
+    sstvae_stage_package_dir("${SSTVAE_ANDROID_RIG_JAVA_DIR}" "${_pkg_dir}/src")
+    sstvae_stage_package_dir("${SSTVAE_ANDROID_USBSERIAL_JAVA_DIR}" "${_pkg_dir}/src")
+endif()
 
 # **The model artifacts ship inside the APK** (assets.hpp says why: the
 # model is part of the on-air contract, and first run has to work with
@@ -240,3 +279,31 @@ qt_add_android_permission(sstvae_android
 # session, which is why the service never treats it as fatal.
 qt_add_android_permission(sstvae_android
     NAME android.permission.POST_NOTIFICATIONS)
+
+if(TARGET sstvae_rig_android)
+    # Rig control over Bluetooth. `BLUETOOTH_CONNECT` is a runtime
+    # permission from API 31; the two legacy ones below it are
+    # install-time and are what API 29 and 30 use instead -- the app's
+    # minSdk is 29, so dropping them would silently cost Bluetooth CAT
+    # on Android 10 and 11.
+    #
+    # **No `maxSdkVersion 30` on the legacy pair**, which is what they
+    # would carry on a hand-written manifest. `qt_add_android_permission`
+    # only grew `ATTRIBUTES` in Qt 6.9 and this app floors at 6.8, so
+    # using it would trade a tidy manifest for a build that fails on the
+    # minimum supported Qt. An unbounded legacy permission is ignored
+    # from API 31 up; it costs a line in the app's permission list and
+    # nothing else.
+    #
+    # **No BLUETOOTH_SCAN and no location permission**, deliberately:
+    # `SerialBridge` lists only *bonded* devices, so discovery never
+    # happens. Pairing is the system's job. Asking for location access to
+    # show a picker of already-paired radios is the kind of request that
+    # gets an app uninstalled.
+    qt_add_android_permission(sstvae_android
+        NAME android.permission.BLUETOOTH_CONNECT)
+    qt_add_android_permission(sstvae_android
+        NAME android.permission.BLUETOOTH)
+    qt_add_android_permission(sstvae_android
+        NAME android.permission.BLUETOOTH_ADMIN)
+endif()

--- a/native/android-app/CMakeLists.txt
+++ b/native/android-app/CMakeLists.txt
@@ -157,6 +157,7 @@ if(TARGET sstvae_rig_android)
     # compiles them into the one app.
     sstvae_stage_package_dir("${SSTVAE_ANDROID_RIG_JAVA_DIR}" "${_pkg_dir}/src")
     sstvae_stage_package_dir("${SSTVAE_ANDROID_USBSERIAL_JAVA_DIR}" "${_pkg_dir}/src")
+    sstvae_stage_package_dir("${SSTVAE_ANDROID_USBSERIAL_SHIM_DIR}" "${_pkg_dir}/src")
 endif()
 
 # **The model artifacts ship inside the APK** (assets.hpp says why: the

--- a/native/android-app/Main.qml
+++ b/native/android-app/Main.qml
@@ -146,23 +146,27 @@ ApplicationWindow {
                 Layout.rightMargin: 12
                 Layout.topMargin: 4
                 visible: rigControl.running
+                // The dial, when the radio is actually answering.
                 Label {
-                    text: rigControl.frequency !== "" ? rigControl.frequency : "—"
+                    text: rigControl.frequency
+                    visible: rigControl.frequency !== ""
                     font.pixelSize: 18
                 }
-                Item { Layout.fillWidth: true }
+                // ...and what is wrong when it is not. This replaced a
+                // bare "—" beside a screen that still said Connected:
+                // with the cable pulled out the operator got a dash and
+                // no account of it. A healthy rig says nothing here,
+                // because a line that is present every second is one
+                // the eye learns to skip.
                 Label {
-                    // The status only when it is bad news. A healthy rig
-                    // saying "connected" every second is a line the eye
-                    // learns to skip, which is the last thing a warning
-                    // line should be.
-                    text: rigControl.failed ? rigControl.status : ""
-                    visible: text !== ""
+                    text: rigControl.connectionState
+                    visible: rigControl.frequency === ""
                     color: "#c62828"
-                    font.pixelSize: 12
+                    font.pixelSize: 13
                     elide: Text.ElideRight
-                    Layout.maximumWidth: parent.width * 0.6
+                    Layout.fillWidth: true
                 }
+                Item { Layout.fillWidth: true; visible: rigControl.frequency !== "" }
             }
 
             // The tuning instrument. First, and given room: without a

--- a/native/android-app/Main.qml
+++ b/native/android-app/Main.qml
@@ -20,6 +20,14 @@ ApplicationWindow {
     Listener { id: listener }
     Transmitter { id: transmitter }
     PictureList { id: pictures }
+    // Owns nothing: the rig session lives in `Session`, so keying
+    // survives a rotation in the middle of an over.
+    // **`rigControl`, not `rig`.** A `RigPane` declares `required
+    // property var rig`, so inside its binding block the name `rig`
+    // resolves to that property rather than to an outer id -- `rig: rig`
+    // is a binding loop, not a hand-off. Naming the id differently is
+    // what makes the two unambiguous.
+    RigControl { id: rigControl }
 
     // **Back closes the picture viewer instead of the app.**
     //
@@ -121,10 +129,46 @@ ApplicationWindow {
         ColumnLayout {
             spacing: 8
 
-            // The tuning instrument. First, and given room: with no CAT
-            // there is no frequency readout at all, so this is the only
-            // feedback the operator has about where the radio is
-            // pointed.
+            // The dial frequency, when there is a rig session to read it
+            // from.
+            //
+            // **This is new, and the comment below it used to be the
+            // whole story.** "With no CAT there is no frequency readout
+            // at all" was true until Hamlib turned out to take a socket
+            // (core/rig/transport.hpp), and the waterfall was the only
+            // thing telling an operator where the radio was pointed.
+            // It still is when this is absent, which is every session
+            // without a cable — so the waterfall keeps its height and
+            // this is one line above it rather than a panel beside it.
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: 12
+                Layout.rightMargin: 12
+                Layout.topMargin: 4
+                visible: rigControl.running
+                Label {
+                    text: rigControl.frequency !== "" ? rigControl.frequency : "—"
+                    font.pixelSize: 18
+                }
+                Item { Layout.fillWidth: true }
+                Label {
+                    // The status only when it is bad news. A healthy rig
+                    // saying "connected" every second is a line the eye
+                    // learns to skip, which is the last thing a warning
+                    // line should be.
+                    text: rigControl.failed ? rigControl.status : ""
+                    visible: text !== ""
+                    color: "#c62828"
+                    font.pixelSize: 12
+                    elide: Text.ElideRight
+                    Layout.maximumWidth: parent.width * 0.6
+                }
+            }
+
+            // The tuning instrument. First, and given room: without a
+            // rig session there is no frequency readout at all, so this
+            // is the only feedback the operator has about where the
+            // radio is pointed.
             Waterfall {
                 Layout.fillWidth: true
                 // Taller while there is no picture, which is both when
@@ -614,6 +658,11 @@ ApplicationWindow {
                 Layout.leftMargin: 12
                 Layout.rightMargin: 12
                 wrapMode: Text.Wrap
+            }
+
+            RigPane {
+                rig: rigControl
+                Layout.fillWidth: true
             }
 
             Label {

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -32,6 +32,13 @@ demonstrated rather than argued. And the level readout earns its keep:
 and it is distinguishable at a glance from merely quiet, which a mean
 level is not.
 
+**Rig control is in as of 2026-08-22** — CAT and PTT over USB serial,
+Bluetooth RFCOMM, or a network host. `docs/android.md` said that was
+structurally impossible; it is not, because Hamlib takes a socket for
+any backend. See "Rig control" below for what to know before touching
+it, and note that its build and its Java have **never been compiled** —
+they were written in a session with no NDK.
+
 **Three of this port's bugs were bugs in its own instruments**, and
 they are worth reading before trusting a number from here: the drift
 meter charging in-flight audio as lost, the `-O0` build that made the
@@ -909,6 +916,86 @@ app away loses the picked picture and its framing. A rotation does not,
 which is what the process-wide singleton is for. Persisting the source
 path and framing in `QSettings` would fix it and is a few lines; it has
 not been done because nothing has asked for it yet.
+
+## Rig control
+
+CAT and PTT, added 2026-08-22. `docs/android.md` has the design record
+and the reasoning; this is the operational half.
+
+**How it reaches the radio.** Hamlib's `rig_open()` turns any backend
+into a network client when its pathname parses as `host:port`, so a
+`SerialTransport` (USB or Bluetooth, from Java) is presented to it as a
+loopback socket. Nothing is patched and no CAT protocol is
+reimplemented, which is why the radio picker here lists the same several
+hundred rigs the desktop does.
+
+**Three connection kinds, and the kind is what decides the plumbing —
+never the device string.** USB and Bluetooth open a transport and get a
+bridge; Network hands the host straight to Hamlib with no bridge at all,
+covering both a station PC running `rigctld` (model 2) and a
+serial-over-TCP server with a native backend. An earlier draft branched
+on the *shape* of the device string and got it exactly backwards: a USB
+identifier like `usb:1a86:7523` has no slash and does not start with
+`com`, so Hamlib's own `parse_hoststr` rules read it as a hostname, and
+the bridge was skipped for precisely the devices it exists to serve.
+
+**Building it.** `-DSSTVAE_ANDROID_RIG=ON` is the default and pulls in
+an NDK cross-build of Hamlib's autotools tarball, per ABI.
+`-DSSTVAE_ANDROID_RIG=OFF` drops CAT and keeps the app — the rig screen,
+the transport and the settings all still build, so it is one flag rather
+than a second code path. **That cross-build has never been run**: it was
+written from the NDK's documented layout in a session with no NDK and no
+reachable `dl.google.com`. Expect to fix something. Two guards make the
+first attempt diagnosable rather than mysterious:
+
+- The configure step fails naming the exact compiler wrapper it looked
+  for, because the NDK ships one per API level and an unsupported level
+  is *missing* rather than wrong.
+- The install step refuses a versioned SONAME. libtool would produce
+  `libhamlib.so.4.0.7`; Android's packager takes only files named
+  exactly `lib*.so`, so that library is dropped from the APK without
+  comment and the app dies at `dlopen` **before `main`** — no output on
+  any stream, indistinguishable from a deadlock. `-avoid-version` in
+  `LDFLAGS` is what prevents it and the check is what proves it worked.
+
+**Testing it without a radio.** Hamlib model 1 is the dummy: it opens,
+keys and reports a frequency with nothing attached, so the whole path
+above the transport can be exercised on a phone with no cable. The
+transport itself needs hardware; the closest thing to a substitute is
+the desktop suite, where `test_rig_bridge`, `test_rig_bridged` and
+`test_rig_hamlib` cover the bridge, the composition, the PTT routing and
+a real Kenwood backend talking through it to a fake radio.
+
+**USB permission is granted per attach, and Android forgets it on
+detach.** `UsbAttach` plus `res/xml/device_filter.xml` is what makes the
+grant stick: an app that can handle `USB_DEVICE_ATTACHED` is authorised
+automatically when the user answers "always open with this app". It is
+its own no-display activity rather than a filter on `QtActivity`,
+because the filter matches four whole vendor ranges and every CDC-ACM
+device — plugging in an Arduino must not open a radio app.
+
+**Bluetooth lists bonded devices only.** Discovery would need
+`BLUETOOTH_SCAN` and, before API 31, location permission, which is a
+large ask for a picker whose entire content is the radio the operator
+already paired in system Settings. Pairing is the system's job.
+RFCOMM has no modem control lines, so DTR and RTS keying are not offered
+there at all.
+
+**The keying method changes the waveform.** With the rig keyed directly
+the VOX leader is skipped — a swept tone into an already-keyed radio
+only delays the picture — and the airtime estimate on the Send screen
+follows. The Send screen says which one is in force, but only when it is
+rig keying: saying "VOX" every time when VOX is the only option trains
+the eye to skip the line.
+
+**What is not tested on hardware.** Everything in this section. The
+composite-device question in particular is worth settling first with the
+actual radio: most rig USB interfaces present audio and CDC serial
+together, and this app needs both at once. FT8CN does it successfully on
+at least some devices, and mik3y/usb-serial-for-android#477 is an open
+report of a composite device where claiming the CDC interface fails
+while the platform holds the audio interfaces. If that turns out badly
+for a given radio, Bluetooth and the network kind are unaffected.
 
 ## `core/audio/android/`
 

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -32,12 +32,15 @@ demonstrated rather than argued. And the level readout earns its keep:
 and it is distinguishable at a glance from merely quiet, which a mean
 level is not.
 
-**Rig control is in as of 2026-08-22** — CAT and PTT over USB serial,
-Bluetooth RFCOMM, or a network host. `docs/android.md` said that was
-structurally impossible; it is not, because Hamlib takes a socket for
-any backend. See "Rig control" below for what to know before touching
-it, and note that its build and its Java have **never been compiled** —
-they were written in a session with no NDK.
+**Rig control is in as of 2026-08-22, and USB works on hardware**
+(2026-08-23): CAT and both control-line keying methods, on a phone,
+over a composite USB interface — which is the question that could have
+sunk the approach, since the app needs the audio and the serial half of
+that device at once. `docs/android.md` said this was structurally
+impossible; it is not, because Hamlib takes a socket for any backend.
+**Bluetooth is untested for want of a device.** See "Rig control" below
+before touching any of it: the build-level traps and the runtime ones
+are written up there, and every one of them cost a round.
 
 **Three of this port's bugs were bugs in its own instruments**, and
 they are worth reading before trusting a number from here: the drift
@@ -1113,6 +1116,51 @@ query answers, an action reports.** `has_permission` returns false when
 it cannot ask — the truthful answer to "may the app open this right
 now" — while the enumerators throw, because their caller catches and has
 somewhere to show it.
+
+**Unplugging the USB cable, and getting back.** Verified on hardware
+2026-08-23: CAT and both control-line keying methods work; pulling the
+cable used to leave the screen saying "Connected" with no way back.
+
+Three things were wrong and they are worth separating. `running()` means
+*a session is configured*, not that the radio is answering — the
+desktop's distinction, correct there, but on a phone it was the only
+thing the UI showed. `connectionState` is the property to display now,
+and the signal it rests on is that **a published frequency is the only
+proof the radio answered**: `failed` alone cannot tell "still opening
+the port" from "the cable is out".
+
+Reconnection is app-level (`RigControl::maybe_reconnect`, once per 1 Hz
+tick) rather than in `RigController`, because the question it has to
+answer — *is the device back?* — is a platform one. For USB and
+Bluetooth that is `has_permission(device)`, which is false for a device
+that is not there, so one cheap call covers both "is it back" and "may
+we open it". **A device that is simply absent does not spend the
+backoff**, so replugging reconnects on the next tick rather than
+somewhere in the next 30 seconds; the 2/4/8/16/32 s backoff is only for
+attempts that reached the radio and failed. Never while transmitting: an
+over is committed airtime and swapping the link underneath it buys
+nothing.
+
+**The rig controller is immortal, and that fixed a bug rather than
+tidying one.** `ptt_function()` captures the *controller*, and
+`TxEngine` holds that for a whole over — so `stop_rig()` destroying the
+controller left the engine calling into freed memory to bring PTT back
+down, which is what turning rig control off mid-over used to do. It is
+created once and `stop()`ped, never destroyed. The same property makes
+reconnection safe: `RigController::start()` supersedes a session in
+place, so a `Ptt` handed out before a reconnect still keys the new
+backend. `test_rig.cpp` pins it, mutation-tested — binding the lambda to
+the session instead of the controller sends the key to the *superseded*
+backend and none to the new one, a failure with no symptom until
+somebody transmits.
+
+**The VOX leader is sent whatever keys the radio** (Andrew, on
+hardware). An earlier version zeroed it whenever PTT was not VOX, on the
+theory that a swept tone into an already-keyed radio only delays the
+picture. That is the app second-guessing the operator: the leader is
+also a settling period for an interface that wants audio flowing before
+the radio is properly in transmit, and `ptt_lead_s` is a different
+quantity doing a different job. Set it to zero if it is not wanted.
 
 **What is not tested on hardware.** Everything in this section. The
 composite-device question in particular is worth settling first with the

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1084,6 +1084,36 @@ follows. The Send screen says which one is in force, but only when it is
 rig keying: saying "VOX" every time when VOX is the only option trains
 the eye to skip the line.
 
+**The platform layer needs an explicit init, and forgetting it looked
+like two unrelated bugs.** `rig::android::set_java_vm` and
+`SerialBridge.init(Context)` were never called — `init_rig_bridge` in
+`rigcontrol.cpp` does it now, from `RigControl`'s constructor, which is
+on the UI thread for the `FindClass` reason `core/audio/android/`
+records. `listener.cpp`'s `init_audio_bridge` is the same four lines for
+the audio layer.
+
+What made it cost a round was not the missing call. The layer threw a
+perfectly good message — "set_java_vm() was never called" — and two
+things ate it:
+
+- `refreshDevices()` caught every exception and cleared the list, so the
+  screen said "Nothing plugged in. Connect the radio…", which was a
+  confident lie with a radio attached. **An enumeration that threw is
+  not one that came back empty**, and it shows the message now.
+  "Nothing connected" and "Bluetooth not granted" are still ordinary
+  empty lists with no error.
+- `bluetoothReady()` did *not* catch, and it is read from a QML property
+  binding — where an exception terminates the process. It crashed on
+  switching to Bluetooth, then at every launch, because the connection
+  kind is persisted and the binding is evaluated on load. **Nothing
+  reaching JNI may throw from a getter.**
+
+The rule that came out of it, now written into `androidrig.cpp`: **a
+query answers, an action reports.** `has_permission` returns false when
+it cannot ask — the truthful answer to "may the app open this right
+now" — while the enumerators throw, because their caller catches and has
+somewhere to show it.
+
 **What is not tested on hardware.** Everything in this section. The
 composite-device question in particular is worth settling first with the
 actual radio: most rig USB interfaces present audio and CDC serial

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -998,6 +998,37 @@ first attempt diagnosable rather than mysterious:
   arguments produce a single unversioned `libhamlib.so` whose
   `readelf -d` SONAME is `libhamlib.so`, with the tools still linking.
 
+- **`CC` alone is not enough, and the failure waits until late.**
+  Setting only `CC` leaves configure to find C++ on its own, and it
+  finds the *host* `g++`. Most of Hamlib is C, so the build gets most of
+  the way through before reaching `rotators/androidsensor` — the one C++
+  directory — and dying on `-stdlib=libc++`, which configure adds for
+  every Android host and the host g++ has never heard of. A host
+  compiler quietly standing in for a cross one is the shape of this
+  bug; `CXX` is set now even though, after the next point, there should
+  be no C++ left to compile.
+
+- **The Android sensor rotator is skipped.** It points an antenna using
+  the phone's accelerometer, which this app has no use for, and it is
+  the only C++ in the tree we build. There is no
+  `--without-androidsensor`: upstream gates it on whether
+  `android/sensor.h` exists (`configure.ac:171`), so the lever is
+  autoconf's own cache, pre-seeded with
+  `ac_cv_header_android_sensor_h=no` exactly as the two malloc answers
+  are. `src/rot_reg.c:87` guards the registration with
+  `#if HAVE_ANDROID_SENSOR`, so it drops out of the library rather than
+  leaving a dangling reference. The cache mechanism was checked against
+  this configure with a proxy header: `checking for linux/ppdev.h...
+  (cached) no`, and `/* #undef HAVE_LINUX_PPDEV_H */` in the generated
+  `config.h`.
+
+  Note that `-lc++` still goes into `LDFLAGS` for every Android build,
+  unconditionally, whether or not any C++ is compiled
+  (`configure.ac:178`). The NDK sysroot ships `libc++.so` as an implicit
+  linker script so it resolves, but it does mean `libhamlib.so` carries
+  a `DT_NEEDED` on `libc++_shared.so` — which Qt for Android packages
+  anyway, because Qt itself needs it.
+
 **Testing it without a radio.** Hamlib model 1 is the dummy: it opens,
 keys and reports a frequency with nothing attached, so the whole path
 above the transport can be exercised on a phone with no cable. The

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -972,8 +972,31 @@ first attempt diagnosable rather than mysterious:
   `libhamlib.so.4.0.7`; Android's packager takes only files named
   exactly `lib*.so`, so that library is dropped from the APK without
   comment and the app dies at `dlopen` **before `main`** — no output on
-  any stream, indistinguishable from a deadlock. `-avoid-version` in
-  `LDFLAGS` is what prevents it and the check is what proves it worked.
+  any stream, indistinguishable from a deadlock.
+
+  **`-avoid-version` is a libtool flag, not a linker one**, and putting
+  it in configure's `LDFLAGS` is the second thing that went wrong on a
+  real NDK build. configure's very first link test runs the compiler
+  directly, clang rejects an argument it has never heard of, and the
+  build stops at `C compiler cannot create executables` — with the
+  actual reason two layers down in `config.log`, which is a long way
+  from a flag we chose. It is applied at *make* time now, overriding
+  `libhamlib_la_LDFLAGS` (`src/Makefile.am:24`, the one variable
+  upstream puts `-version-info` in) and carrying `-no-undefined` over
+  from the same line.
+
+  Not plain `LDFLAGS=-avoid-version` at make time, which would also have
+  worked as far as libtool is concerned — it copes with `-version-info`
+  and `-avoid-version` together and strips the version
+  (`build-aux/ltmain.sh:9488`). The reasons are elsewhere: a
+  command-line `LDFLAGS` *replaces* the tree's, discarding whatever
+  configure computed, and it reaches every link in the tree including
+  the fifteen tool executables, where the flag means nothing.
+
+  Verified natively on a desktop, which is possible because the
+  mechanism is libtool's and not the NDK's: the same configure and make
+  arguments produce a single unversioned `libhamlib.so` whose
+  `readelf -d` SONAME is `libhamlib.so`, with the tools still linking.
 
 **Testing it without a radio.** Hamlib model 1 is the dummy: it opens,
 keys and reports a frequency with nothing attached, so the whole path

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -950,7 +950,24 @@ first attempt diagnosable rather than mysterious:
 
 - The configure step fails naming the exact compiler wrapper it looked
   for, because the NDK ships one per API level and an unsupported level
-  is *missing* rather than wrong.
+  is *missing* rather than wrong. **This is the one that fired on the
+  first real run**, and it fired for the wrong reason: the API level was
+  being read from `CMAKE_SYSTEM_VERSION`, which CMake defaults to `1`
+  when cross-compiling and nothing sets it, so the wrapper it looked for
+  was `x86_64-linux-android1-clang`. The guard written to catch exactly
+  that was `if(NOT _hl_api)` — and `1` is *true* in CMake, so it never
+  ran. A guard whose condition cannot fire is not a guard. The level now
+  comes from whichever of `SSTVAE_ANDROID_API`, `CMAKE_ANDROID_API`,
+  `ANDROID_NATIVE_API_LEVEL`, `ANDROID_PLATFORM_LEVEL`, `ANDROID_PLATFORM`
+  or `CMAKE_SYSTEM_VERSION` first gives a plausible answer, falls back to
+  21, says which source it used, and repairs upward to the lowest wrapper
+  the NDK actually ships if the chosen level has none.
+
+  `-DSSTVAE_ANDROID_API=<level>` overrides all of it. Building Hamlib at
+  a level *below* the app's minSdk is fine and is why 21 is the fallback:
+  a library built against an older libc loads on a newer one, never the
+  reverse, so guessing low fails on nobody's phone and guessing high
+  fails on somebody else's.
 - The install step refuses a versioned SONAME. libtool would produce
   `libhamlib.so.4.0.7`; Android's packager takes only files named
   exactly `lib*.so`, so that library is dropped from the APK without

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1008,26 +1008,51 @@ first attempt diagnosable rather than mysterious:
   bug; `CXX` is set now even though, after the next point, there should
   be no C++ left to compile.
 
-- **The Android sensor rotator is skipped.** It points an antenna using
-  the phone's accelerometer, which this app has no use for, and it is
-  the only C++ in the tree we build. There is no
-  `--without-androidsensor`: upstream gates it on whether
-  `android/sensor.h` exists (`configure.ac:171`), so the lever is
-  autoconf's own cache, pre-seeded with
-  `ac_cv_header_android_sensor_h=no` exactly as the two malloc answers
-  are. `src/rot_reg.c:87` guards the registration with
-  `#if HAVE_ANDROID_SENSOR`, so it drops out of the library rather than
-  leaving a dangling reference. The cache mechanism was checked against
-  this configure with a proxy header: `checking for linux/ppdev.h...
-  (cached) no`, and `/* #undef HAVE_LINUX_PPDEV_H */` in the generated
-  `config.h`.
+- **The Android sensor rotator cannot be switched off. Do not try
+  again.** It points an antenna using the phone's accelerometer, which
+  this app has no use for, and it is the only C++ in the tree we build,
+  so it looks like free savings. There is no `--without-androidsensor`;
+  upstream gates it on whether `android/sensor.h` exists
+  (`configure.ac:171`), and pre-seeding autoconf's cache with
+  `ac_cv_header_android_sensor_h=no` does correctly drop the directory
+  from `ROT_BACKEND_LIST`.
 
-  Note that `-lc++` still goes into `LDFLAGS` for every Android build,
-  unconditionally, whether or not any C++ is compiled
+  It then fails to build, because `src/rot_reg.c` guards the backend's
+  two halves on **different conditions**:
+
+  ```
+  line  87: #if HAVE_ANDROID_SENSOR                      (the declaration)
+  line 141: #if defined(ANDROID) || defined(__ANDROID__) (the table entry)
+  ```
+
+  `__ANDROID__` is defined by the compiler and cannot be unset, so the
+  table entry is unconditional on Android while the declaration is not.
+  They agree only when `HAVE_ANDROID_SENSOR` is true — which upstream is
+  entitled to assume, since a real NDK always has `android/sensor.h`.
+  Answering "no" leaves the file calling a function nobody declared.
+
+  So it builds, and setting `CXX` is what makes that work rather than a
+  precaution. (The cache mechanism itself is sound and is used for the
+  two malloc answers — verified against this configure with a proxy
+  header: `checking for linux/ppdev.h... (cached) no`, and
+  `/* #undef HAVE_LINUX_PPDEV_H */` in the generated `config.h`. The
+  problem is specific to this backend's guards.)
+
+  `-lc++` goes into `LDFLAGS` for every Android build regardless
   (`configure.ac:178`). The NDK sysroot ships `libc++.so` as an implicit
-  linker script so it resolves, but it does mean `libhamlib.so` carries
-  a `DT_NEEDED` on `libc++_shared.so` — which Qt for Android packages
+  linker script so it resolves, and `libhamlib.so` carries a
+  `DT_NEEDED` on `libc++_shared.so` — which Qt for Android packages
   anyway, because Qt itself needs it.
+
+- **A failed Hamlib build used to cement itself.** The "already built"
+  stamp was the installed `hamlib/rig.h`, and `SUBDIRS` puts `include`
+  second (`Makefile.am:25`) — so `make install` copies the headers long
+  before it reaches `src`, and any failure after that left a tree the
+  check accepted. The next configure skipped the rebuild and failed with
+  "Hamlib library not found", naming a path instead of the compile error
+  that actually stopped it. The stamp requires the library now. If you
+  are recovering from a build that failed before this landed, delete
+  `<build>/_deps/hamlib-install-*` once.
 
 **Testing it without a radio.** Hamlib model 1 is the dummy: it opens,
 keys and reports a frequency with nothing attached, so the whole path

--- a/native/android-app/RigPane.qml
+++ b/native/android-app/RigPane.qml
@@ -302,8 +302,9 @@ ColumnLayout {
         Label {
             text: "VOX means this app does not key the radio at all — the "
                   + "transmit audio does, and the leader tone on the Send screen "
-                  + "is what trips it. Anything else keys the radio directly, and "
-                  + "the leader is skipped."
+                  + "is what trips it. Anything else keys the radio directly. The "
+                  + "leader is sent either way; set it to zero on the Send screen "
+                  + "if you don't want it."
             font.pixelSize: 11
             color: "#666"
             Layout.fillWidth: true
@@ -324,15 +325,28 @@ ColumnLayout {
             }
             Label {
                 Layout.fillWidth: true
-                // The status text, and whether it was a failure, come
-                // from two properties rather than one: a failure message
-                // is whatever the backend's exception said and has no
-                // shape to recognise it by.
-                text: pane.rig.status
+                // **State first, the rig's own words second.** `running`
+                // means a session is configured, not that the radio is
+                // answering -- on hardware that read as "Connected" with
+                // the cable out. `connectionState` is the one an
+                // operator can act on; `status` below is the backend's
+                // message, which is what you want when the answer is
+                // "it will not open" rather than "it is unplugged".
+                text: pane.rig.connectionState
                 color: pane.rig.failed ? "#c62828" : "#666"
-                font.pixelSize: 12
+                font.pixelSize: 13
                 wrapMode: Text.Wrap
             }
+        }
+        Label {
+            text: pane.rig.status
+            visible: text !== "" && text !== pane.rig.connectionState
+            color: "#666"
+            font.pixelSize: 11
+            wrapMode: Text.Wrap
+            Layout.fillWidth: true
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
         }
         Label {
             text: pane.rig.frequency

--- a/native/android-app/RigPane.qml
+++ b/native/android-app/RigPane.qml
@@ -157,16 +157,24 @@ ColumnLayout {
                 Item { Layout.fillWidth: true }
             }
             Label {
-                text: pane.rig.devices.length === 0
-                      ? (pane.rig.connection === "bluetooth"
-                         ? "No paired radios. Pair the radio in Android's Bluetooth "
-                           + "settings first — this app deliberately does not scan, "
-                           + "so it never asks for location access."
-                         : "Nothing plugged in. Connect the radio or its serial "
-                           + "adapter, then Refresh.")
-                      : (pane.rig.devicePermitted
-                         ? ""
-                         : "Android needs permission before this device can be opened.")
+                // Three different empty lists, and they are not the same
+                // problem: Bluetooth access not granted, nothing paired,
+                // and nothing plugged in. Telling an operator to go and
+                // pair a radio they already paired is the kind of wrong
+                // advice that ends in a bug report.
+                text: pane.rig.connection === "bluetooth" && !pane.rig.bluetoothReady
+                      ? "Android needs Bluetooth access before paired radios can "
+                        + "be listed."
+                      : pane.rig.devices.length === 0
+                        ? (pane.rig.connection === "bluetooth"
+                           ? "No paired radios. Pair the radio in Android's Bluetooth "
+                             + "settings first — this app deliberately does not scan, "
+                             + "so it never asks for location access."
+                           : "Nothing plugged in. Connect the radio or its serial "
+                             + "adapter, then Refresh.")
+                        : (pane.rig.devicePermitted
+                           ? ""
+                           : "Android needs permission before this device can be opened.")
                 visible: text !== ""
                 font.pixelSize: 11
                 color: "#666"

--- a/native/android-app/RigPane.qml
+++ b/native/android-app/RigPane.qml
@@ -1,0 +1,388 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Rig control settings: CAT and PTT over USB, Bluetooth or a network.
+//
+// A section of the Settings tab rather than a tab of its own. The tab
+// bar already carries five and a sixth is a crowded row on a phone --
+// and this is a screen an operator visits once per radio, not once per
+// session. What *is* worth seeing every session, the dial frequency,
+// goes on the Listen screen where the waterfall is.
+//
+// **Why any of this exists**: `docs/android.md` recorded rig control as
+// structurally impossible here, because Hamlib's serial layer opens a
+// device path and Android gives an unprivileged app none. Hamlib takes
+// a socket for any backend, so the radio list on this screen is the
+// desktop's radio list. See `core/rig/transport.hpp`.
+ColumnLayout {
+    id: pane
+    spacing: 8
+
+    // Set by the parent, so this file does not reach out of itself for
+    // the object it drives.
+    required property var rig
+
+    // Re-enumerate whenever this becomes visible: USB devices come and
+    // go with the cable, and a picker showing a radio that was
+    // unplugged five minutes ago is worse than an empty one.
+    onVisibleChanged: if (visible) rig.refreshDevices()
+
+    Label {
+        text: "Rig control"
+        font.bold: true
+        Layout.margins: 12
+        Layout.bottomMargin: 0
+    }
+
+    Switch {
+        text: "Control the radio"
+        Layout.leftMargin: 4
+        checked: pane.rig.enabled
+        onToggled: pane.rig.enabled = checked
+    }
+
+    Label {
+        // Says what it is *for*, not what it is. An operator who is
+        // acoustically coupling a phone to a handheld has no radio to
+        // talk to and should be able to tell that from one sentence.
+        text: "Reads the dial frequency and can key the transmitter, over a "
+              + "USB serial adapter, a Bluetooth radio, or a station computer "
+              + "on the network. Leave it off if the phone is not wired to a "
+              + "radio — receiving and VOX transmitting need none of it."
+        font.pixelSize: 11
+        color: "#666"
+        Layout.fillWidth: true
+        Layout.leftMargin: 12
+        Layout.rightMargin: 12
+        wrapMode: Text.Wrap
+    }
+
+    // Everything below is meaningless with the switch off, and hiding it
+    // rather than disabling it keeps the Settings page short for the
+    // majority who never turn this on.
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: 8
+        visible: pane.rig.enabled
+
+        // ---- how it is connected -------------------------------------
+        Label {
+            text: "Connection"
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+        }
+        ComboBox {
+            id: connectionBox
+            Layout.fillWidth: true
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+            textRole: "text"
+            valueRole: "value"
+            model: [
+                { text: "USB serial", value: "usb" },
+                { text: "Bluetooth", value: "bluetooth" },
+                { text: "Network (rigctld or ser2net)", value: "network" }
+            ]
+            Component.onCompleted: currentIndex = indexOfValue(pane.rig.connection)
+            onActivated: {
+                pane.rig.connection = currentValue
+                pane.rig.refreshDevices()
+            }
+        }
+
+        // ---- which radio ---------------------------------------------
+        Label {
+            text: "Radio"
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+        }
+        Button {
+            Layout.fillWidth: true
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+            text: pane.rig.modelLabel
+            onClicked: modelDialog.open()
+        }
+
+        // ---- which device --------------------------------------------
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 4
+            visible: pane.rig.connection !== "network"
+
+            Label {
+                text: "Device"
+                Layout.leftMargin: 12
+                Layout.rightMargin: 12
+            }
+            ComboBox {
+                id: deviceCombo
+                Layout.fillWidth: true
+                Layout.leftMargin: 12
+                Layout.rightMargin: 12
+                model: pane.rig.devices
+                textRole: "label"
+                valueRole: "id"
+                enabled: !pane.rig.running
+                // Rebound whenever the list changes, because the index
+                // of a given device is not stable across a replug.
+                function sync() { currentIndex = indexOfValue(pane.rig.device) }
+                Component.onCompleted: sync()
+                Connections {
+                    target: pane.rig
+                    function onDevicesChanged() { deviceCombo.sync() }
+                }
+                onActivated: pane.rig.device = currentValue
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: 12
+                Layout.rightMargin: 12
+                Button {
+                    text: "Refresh"
+                    onClicked: pane.rig.refreshDevices()
+                }
+                Button {
+                    // **In front of Connect rather than behind it.**
+                    // Android will not open a USB device without
+                    // permission and forgets it on every detach, so the
+                    // alternative is a connection that fails with a
+                    // message the operator can do nothing about from the
+                    // screen they are looking at.
+                    text: "Grant access"
+                    visible: !pane.rig.devicePermitted
+                    onClicked: pane.rig.requestPermission()
+                }
+                Item { Layout.fillWidth: true }
+            }
+            Label {
+                text: pane.rig.devices.length === 0
+                      ? (pane.rig.connection === "bluetooth"
+                         ? "No paired radios. Pair the radio in Android's Bluetooth "
+                           + "settings first — this app deliberately does not scan, "
+                           + "so it never asks for location access."
+                         : "Nothing plugged in. Connect the radio or its serial "
+                           + "adapter, then Refresh.")
+                      : (pane.rig.devicePermitted
+                         ? ""
+                         : "Android needs permission before this device can be opened.")
+                visible: text !== ""
+                font.pixelSize: 11
+                color: "#666"
+                Layout.fillWidth: true
+                Layout.leftMargin: 12
+                Layout.rightMargin: 12
+                wrapMode: Text.Wrap
+            }
+        }
+
+        // ---- or which host -------------------------------------------
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 4
+            visible: pane.rig.connection === "network"
+
+            Label {
+                text: "Host"
+                Layout.leftMargin: 12
+                Layout.rightMargin: 12
+            }
+            TextField {
+                Layout.fillWidth: true
+                Layout.leftMargin: 12
+                Layout.rightMargin: 12
+                placeholderText: "192.168.1.10:4532"
+                text: pane.rig.host
+                inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
+                onEditingFinished: pane.rig.host = text
+            }
+            Label {
+                text: "With the radio set to \"Hamlib NET rigctl\" this is a "
+                      + "computer running rigctld — the usual way to share one "
+                      + "radio with WSJT-X. With a real radio chosen instead, it "
+                      + "is a serial-over-network server such as ser2net. The "
+                      + "port defaults to 4532."
+                font.pixelSize: 11
+                color: "#666"
+                Layout.fillWidth: true
+                Layout.leftMargin: 12
+                Layout.rightMargin: 12
+                wrapMode: Text.Wrap
+            }
+        }
+
+        // ---- speed ----------------------------------------------------
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 4
+            visible: pane.rig.connection === "usb"
+
+            Label {
+                text: "Speed"
+                Layout.leftMargin: 12
+                Layout.rightMargin: 12
+            }
+            ComboBox {
+                id: baudBox
+                Layout.fillWidth: true
+                Layout.leftMargin: 12
+                Layout.rightMargin: 12
+                model: pane.rig.bauds
+                enabled: !pane.rig.running
+                Component.onCompleted: {
+                    currentIndex = pane.rig.baud === 0
+                                   ? 0 : Math.max(0, model.indexOf(String(pane.rig.baud)))
+                }
+                onActivated: pane.rig.baud = currentIndex === 0
+                                             ? 0 : parseInt(currentValue)
+            }
+            Label {
+                // "Default" is not a synonym for one of the numbers, and
+                // saying so is the difference between an operator
+                // leaving it alone and guessing.
+                text: "Default uses whatever speed Hamlib would set for the radio "
+                      + "chosen above, which is right for almost every rig."
+                font.pixelSize: 11
+                color: "#666"
+                Layout.fillWidth: true
+                Layout.leftMargin: 12
+                Layout.rightMargin: 12
+                wrapMode: Text.Wrap
+            }
+        }
+
+        // ---- keying ---------------------------------------------------
+        Label {
+            text: "Transmit keying"
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+        }
+        ComboBox {
+            id: pttBox
+            Layout.fillWidth: true
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+            // The list itself narrows on Bluetooth: RFCOMM has no modem
+            // control lines, so DTR and RTS are not offered rather than
+            // offered and failing when somebody presses Send.
+            model: pane.rig.pttMethods
+            enabled: !pane.rig.running
+            function label(v) {
+                switch (v) {
+                case "vox": return "VOX (the audio keys the radio)"
+                case "cat": return "CAT command"
+                case "dtr": return "DTR line"
+                case "rts": return "RTS line"
+                }
+                return v
+            }
+            displayText: label(currentValue !== undefined ? currentValue : pane.rig.pttMethod)
+            delegate: ItemDelegate {
+                width: pttBox.width
+                text: pttBox.label(modelData)
+                highlighted: pttBox.highlightedIndex === index
+            }
+            function sync() { currentIndex = Math.max(0, model.indexOf(pane.rig.pttMethod)) }
+            Component.onCompleted: sync()
+            Connections {
+                target: pane.rig
+                function onChanged() { if (!pttBox.pressed) pttBox.sync() }
+            }
+            onActivated: pane.rig.pttMethod = currentValue
+        }
+        Label {
+            text: "VOX means this app does not key the radio at all — the "
+                  + "transmit audio does, and the leader tone on the Send screen "
+                  + "is what trips it. Anything else keys the radio directly, and "
+                  + "the leader is skipped."
+            font.pixelSize: 11
+            color: "#666"
+            Layout.fillWidth: true
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+            wrapMode: Text.Wrap
+        }
+
+        // ---- connect --------------------------------------------------
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+            Button {
+                text: pane.rig.running ? "Disconnect" : "Connect"
+                onClicked: pane.rig.running ? pane.rig.disconnectRig()
+                                            : pane.rig.connectRig()
+            }
+            Label {
+                Layout.fillWidth: true
+                // The status text, and whether it was a failure, come
+                // from two properties rather than one: a failure message
+                // is whatever the backend's exception said and has no
+                // shape to recognise it by.
+                text: pane.rig.status
+                color: pane.rig.failed ? "#c62828" : "#666"
+                font.pixelSize: 12
+                wrapMode: Text.Wrap
+            }
+        }
+        Label {
+            text: pane.rig.frequency
+            visible: text !== ""
+            font.pixelSize: 16
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+        }
+    }
+
+    // ---- the radio picker ---------------------------------------------
+    //
+    // A dialog with a search box, because Hamlib knows several hundred
+    // rigs. `findModels` caps what it returns, so this list is never the
+    // whole set at once.
+    Dialog {
+        id: modelDialog
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        width: Math.min(parent ? parent.width - 24 : 320, 480)
+        height: Math.min(parent ? parent.height - 80 : 400, 560)
+        modal: true
+        title: "Radio"
+        standardButtons: Dialog.Cancel
+
+        onOpened: {
+            search.text = ""
+            results.model = pane.rig.findModels("")
+            search.forceActiveFocus()
+        }
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 8
+
+            TextField {
+                id: search
+                Layout.fillWidth: true
+                placeholderText: "Search — maker or model"
+                inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
+                onTextChanged: results.model = pane.rig.findModels(text)
+            }
+            ListView {
+                id: results
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+                ScrollBar.vertical: ScrollBar {}
+                delegate: ItemDelegate {
+                    required property var modelData
+                    width: results.width
+                    text: modelData.label
+                    onClicked: {
+                        pane.rig.model = modelData.number
+                        modelDialog.close()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/native/android-app/TransmitPane.qml
+++ b/native/android-app/TransmitPane.qml
@@ -91,7 +91,7 @@ ColumnLayout {
         // session VOX is the only thing there is, and saying so every
         // time trains the eye to skip the line.
         text: pane.transmitter.keying
-        visible: pane.transmitter.keying.indexOf("Rig control") === 0
+        visible: pane.transmitter.rigKeyed
         font.pixelSize: 11
         color: "#666"
         Layout.fillWidth: true

--- a/native/android-app/TransmitPane.qml
+++ b/native/android-app/TransmitPane.qml
@@ -86,6 +86,21 @@ ColumnLayout {
     }
 
     Label {
+        // Which of the two keying stories this over will use. Only worth
+        // a line when there is a choice to have got wrong -- with no rig
+        // session VOX is the only thing there is, and saying so every
+        // time trains the eye to skip the line.
+        text: pane.transmitter.keying
+        visible: pane.transmitter.keying.indexOf("Rig control") === 0
+        font.pixelSize: 11
+        color: "#666"
+        Layout.fillWidth: true
+        Layout.leftMargin: 12
+        Layout.rightMargin: 12
+        wrapMode: Text.Wrap
+    }
+
+    Label {
         text: pane.transmitter.txStatus
         visible: text.length > 0
         Layout.fillWidth: true

--- a/native/android-app/android/AndroidManifest.xml
+++ b/native/android-app/android/AndroidManifest.xml
@@ -66,7 +66,9 @@
              the service's whole lifetime rather than re-declared at each
              transition.
              (No double hyphens in here: XML forbids them inside a
-             comment, and aapt reports it as a column number.) -->
+             comment, and aapt reports it as a column number.
+             tools/check_xml_comments.py is the gate; this note was not
+             enough on its own, which is why the gate exists.) -->
         <service
             android:name="org.cleverdomain.sstvae.ListenerService"
             android:exported="false"

--- a/native/android-app/android/AndroidManifest.xml
+++ b/native/android-app/android/AndroidManifest.xml
@@ -6,6 +6,16 @@
     android:versionName="-- %%INSERT_VERSION_NAME%% --">
     <!-- %%INSERT_PERMISSIONS -->
     <!-- %%INSERT_FEATURES -->
+
+    <!-- USB host, for CAT and PTT over a serial adapter.
+
+         required="false" is load-bearing: Play uses uses-feature to
+         decide which devices may install an app, and a required USB host
+         would hide this one from anything without an OTG port. Receiving
+         over acoustic coupling needs no USB at all, so most of what the
+         app does would be withheld from most phones to declare a feature
+         some of them use. -->
+    <uses-feature android:name="android.hardware.usb.host" android:required="false" />
     <supports-screens
         android:anyDensity="true"
         android:largeScreens="true"
@@ -75,6 +85,28 @@
             android:exported="false"
             android:excludeFromRecents="true"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <!-- Collects a persistent USB permission and disappears. See
+             UsbAttach.java: without it Android drops the grant on every
+             detach, so the operator re-authorises the radio at the start
+             of every session. Its own activity rather than a filter on
+             QtActivity, because device_filter.xml matches whole vendor
+             ranges and plugging in an Arduino must not open a radio app.
+             (No double hyphens in here: XML forbids them inside a
+             comment, and aapt reports it as a column number.) -->
+        <activity
+            android:name="org.cleverdomain.sstvae.UsbAttach"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/device_filter" />
+        </activity>
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/native/android-app/android/res/xml/device_filter.xml
+++ b/native/android-app/android/res/xml/device_filter.xml
@@ -14,9 +14,13 @@
      Class 2 is CDC-Communications, which covers the ACM adapters built
      into modern radios (an IC-705, a Digirig's serial half); the
      vendor entries are the four chip families every USB-to-serial
-     cable in a shack uses. It is deliberately not exhaustive -- an
+     cable in a shack uses. It is deliberately not exhaustive: an
      unlisted adapter still works, it just asks for permission each
-     time. -->
+     time.
+
+     (No double hyphens in this file: XML forbids them inside a comment,
+     and aapt reports it against a copy of the file in an intermediates
+     directory, which is a long way from here.) -->
 <resources>
     <!-- CDC-ACM, by class rather than by vendor. -->
     <usb-device class="2" />

--- a/native/android-app/android/res/xml/device_filter.xml
+++ b/native/android-app/android/res/xml/device_filter.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Which USB devices are worth offering this app for.
+
+     This exists for a reason that is not convenience. Android forgets a
+     USB permission the moment the device is detached, so without an
+     intent filter an operator re-grants it every single time they plug
+     the radio in. A device matched here and answered with "always open"
+     is granted automatically instead.
+
+     Values are DECIMAL. Android's parser reads these as base 10 and a
+     hex-looking 0x0403 is silently not a match, which is the kind of
+     failure that reads as "my adapter is unsupported".
+
+     Class 2 is CDC-Communications, which covers the ACM adapters built
+     into modern radios (an IC-705, a Digirig's serial half); the
+     vendor entries are the four chip families every USB-to-serial
+     cable in a shack uses. It is deliberately not exhaustive -- an
+     unlisted adapter still works, it just asks for permission each
+     time. -->
+<resources>
+    <!-- CDC-ACM, by class rather than by vendor. -->
+    <usb-device class="2" />
+
+    <!-- FTDI: 0x0403 -->
+    <usb-device vendor-id="1027" />
+    <!-- Silicon Labs (CP210x): 0x10c4 -->
+    <usb-device vendor-id="4292" />
+    <!-- Prolific (PL2303): 0x067b -->
+    <usb-device vendor-id="1659" />
+    <!-- QinHeng (CH340/CH341): 0x1a86 -->
+    <usb-device vendor-id="6790" />
+</resources>

--- a/native/android-app/android/src/org/cleverdomain/sstvae/UsbAttach.java
+++ b/native/android-app/android/src/org/cleverdomain/sstvae/UsbAttach.java
@@ -1,0 +1,30 @@
+package org.cleverdomain.sstvae;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+/**
+ * Receives {@code USB_DEVICE_ATTACHED} and does nothing with it.
+ *
+ * <p>The point is the side effect. Android drops a USB permission when the
+ * device is detached, so without an intent filter the operator re-grants it
+ * every time they plug the radio in — and a radio gets plugged in at the start
+ * of every session. An app that <i>can handle</i> the attach intent is granted
+ * permission automatically when the user answers "always open with this app",
+ * and that grant survives replugging.
+ *
+ * <p><b>Its own activity, not the main one, and that is the whole design.</b>
+ * The filter fires for anything in {@code res/xml/device_filter.xml} — which
+ * includes every CDC-ACM device and four whole vendor ranges, so an Arduino or
+ * a USB modem matches it too. Putting the filter on {@code QtActivity} would
+ * mean plugging any of those in yanks the operator into a radio app they were
+ * not using. This one starts, finishes, and is excluded from Recents, so the
+ * grant is collected and nothing is shown.
+ */
+public final class UsbAttach extends Activity {
+    @Override
+    protected void onCreate(Bundle state) {
+        super.onCreate(state);
+        finish();
+    }
+}

--- a/native/android-app/rigcontrol.cpp
+++ b/native/android-app/rigcontrol.cpp
@@ -23,6 +23,10 @@
 // so turning it off is not a second code path to keep working.
 
 using namespace sstvae;
+// Targeted, alongside the namespace directive, exactly as `listener.cpp`
+// and `transmitter.cpp` do it: `Session` is in `sstvae::androidapp`,
+// which `using namespace sstvae` does not reach into.
+using sstvae::androidapp::Session;
 
 namespace {
 

--- a/native/android-app/rigcontrol.cpp
+++ b/native/android-app/rigcontrol.cpp
@@ -1,0 +1,416 @@
+#include "rigcontrol.hpp"
+
+#include <QLatin1String>
+#include <QPointer>
+#include <QSettings>
+#include <QGuiApplication>
+#include <QVariantMap>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+
+#include "rig/android/androidrig.hpp"
+#include "rig/bridged.hpp"
+#include "rig/hamlib.hpp"
+#include "session.hpp"
+
+// `SSTVAE_ANDROID_RIG=OFF` is a supported configuration -- the one
+// escape hatch for a build environment whose NDK cannot cross-compile
+// Hamlib's autotools tarball. It costs CAT and keeps the app, which is
+// the right way round. Only the calls that need libhamlib are guarded:
+// the transport, the settings and the whole of this screen still build,
+// so turning it off is not a second code path to keep working.
+
+using namespace sstvae;
+
+namespace {
+
+// Spelled once each, per the discipline `transmitter.hpp` records: a
+// setting displayed and written back through two different spellings is
+// a setting that silently resets.
+constexpr auto kEnabledKey = "rig/enabled";
+constexpr auto kConnectionKey = "rig/connection";
+constexpr auto kModelKey = "rig/model";
+constexpr auto kDeviceKey = "rig/device";
+constexpr auto kHostKey = "rig/host";
+constexpr auto kBaudKey = "rig/baud";
+constexpr auto kPttKey = "rig/ptt";
+
+// How many rows a model search returns. Hamlib knows several hundred
+// rigs; a phone list view of all of them is a scroll, not a picker.
+constexpr int kMaxModelRows = 60;
+
+rig::PttMethod ptt_from(const QString& name) {
+    if (name == QLatin1String("cat")) return rig::PttMethod::Cat;
+    if (name == QLatin1String("dtr")) return rig::PttMethod::Dtr;
+    if (name == QLatin1String("rts")) return rig::PttMethod::Rts;
+    return rig::PttMethod::Vox;
+}
+
+QVariantMap model_row(const rig::RigModel& m) {
+    QVariantMap row;
+    row[QStringLiteral("number")] = m.model;
+    row[QStringLiteral("label")] = QString::fromStdString(m.label());
+    return row;
+}
+
+// Cached because `rig::list_models()` walks and initialises every
+// backend Hamlib has -- it is not cheap, and this is called on every
+// keystroke of the search box. The first call is on the UI thread when
+// the rig screen first opens, which is the same place the desktop pays
+// it.
+const std::vector<rig::RigModel>& all_models() {
+#ifdef SSTVAE_ANDROID_HAVE_RIG
+    static const std::vector<rig::RigModel> models = rig::list_models();
+#else
+    static const std::vector<rig::RigModel> models;
+#endif
+    return models;
+}
+
+bool have_rig_support() {
+#ifdef SSTVAE_ANDROID_HAVE_RIG
+    return true;
+#else
+    return false;
+#endif
+}
+
+}  // namespace
+
+RigControl::RigControl(QObject* parent) : QObject(parent) {
+    load();
+
+    // A guarded pointer, not a raw capture: the callback is queued, so
+    // an event can still be in flight when a rotation destroys this
+    // view. Clearing the callback in the destructor closes the window
+    // for new ones and this closes it for the one already posted.
+    QPointer<RigControl> self(this);
+    rig::android::set_permission_callback(
+        [self](const std::string& id, bool granted) {
+            // Arrives on Android's broadcast thread. Hopping to this
+            // object's thread is what makes touching `devices_` legal;
+            // a queued connection is the mechanism Qt provides for it.
+            QMetaObject::invokeMethod(
+                qApp,
+                [self, id = QString::fromStdString(id), granted] {
+                    if (self) self->publish_permission(id, granted);
+                },
+                Qt::QueuedConnection);
+        });
+
+    // Slower than the receive screen's, because there is nothing here
+    // that moves quickly: the rig itself is polled every 10 s, so a
+    // faster refresh would redraw the same frequency several times.
+    poll_.setInterval(1000);
+    connect(&poll_, &QTimer::timeout, this, &RigControl::changed);
+    poll_.start();
+
+    // A rig session survives this object, so a screen rotation must not
+    // reopen the radio -- but a *first* launch with rig control on
+    // should connect without the operator pressing anything.
+    if (!have_rig_support()) enabled_ = false;
+    if (enabled_ && !Session::instance().rig_running()) connectRig();
+}
+
+RigControl::~RigControl() {
+    // Deliberately does **not** stop the rig. The session outlives this
+    // view by design: a rotation during an over must not drop PTT, and
+    // this destructor runs on exactly that path.
+    rig::android::set_permission_callback({});
+}
+
+// --- settings ---------------------------------------------------------------
+
+void RigControl::load() {
+    QSettings s;
+    enabled_ = s.value(QLatin1String(kEnabledKey), false).toBool();
+    connection_ = s.value(QLatin1String(kConnectionKey), connection_).toString();
+    model_ = s.value(QLatin1String(kModelKey), model_).toInt();
+    device_ = s.value(QLatin1String(kDeviceKey), QString()).toString();
+    host_ = s.value(QLatin1String(kHostKey), QString()).toString();
+    baud_ = s.value(QLatin1String(kBaudKey), 0).toInt();
+    ptt_ = s.value(QLatin1String(kPttKey), ptt_).toString();
+}
+
+void RigControl::save() {
+    QSettings s;
+    s.setValue(QLatin1String(kEnabledKey), enabled_);
+    s.setValue(QLatin1String(kConnectionKey), connection_);
+    s.setValue(QLatin1String(kModelKey), model_);
+    s.setValue(QLatin1String(kDeviceKey), device_);
+    s.setValue(QLatin1String(kHostKey), host_);
+    s.setValue(QLatin1String(kBaudKey), baud_);
+    s.setValue(QLatin1String(kPttKey), ptt_);
+}
+
+void RigControl::setEnabled(bool on) {
+    if (on && !have_rig_support()) return;
+    if (on == enabled_) return;
+    enabled_ = on;
+    save();
+    if (!on) {
+        Session::instance().stop_rig();
+    } else {
+        connectRig();
+    }
+    emit changed();
+}
+
+void RigControl::setConnection(const QString& kind) {
+    if (kind == connection_) return;
+    connection_ = kind;
+    // The device belongs to the kind that was showing when it was
+    // chosen, so carrying it across would offer a Bluetooth address to
+    // the USB opener.
+    device_.clear();
+    save();
+    refreshDevices();
+    emit changed();
+}
+
+QStringList RigControl::connections() const {
+    return {QStringLiteral("usb"), QStringLiteral("bluetooth"),
+            QStringLiteral("network")};
+}
+
+void RigControl::setModel(int m) {
+    if (m == model_) return;
+    model_ = m;
+    save();
+    emit changed();
+}
+
+QString RigControl::modelLabel() const {
+    for (const rig::RigModel& m : all_models()) {
+        if (m.model == model_) return QString::fromStdString(m.label());
+    }
+    return QStringLiteral("model %1").arg(model_);
+}
+
+void RigControl::setDevice(const QString& id) {
+    if (id == device_) return;
+    device_ = id;
+    save();
+    emit changed();
+    emit devicesChanged();  // `devicePermitted` follows the selection
+}
+
+QString RigControl::deviceLabel() const {
+    for (const QVariant& row : devices_) {
+        const QVariantMap m = row.toMap();
+        if (m[QStringLiteral("id")].toString() == device_) {
+            return m[QStringLiteral("label")].toString();
+        }
+    }
+    return device_;
+}
+
+bool RigControl::devicePermitted() const {
+    if (connection_ == QLatin1String("network")) return true;
+    if (device_.isEmpty()) return false;
+    for (const QVariant& row : devices_) {
+        const QVariantMap m = row.toMap();
+        if (m[QStringLiteral("id")].toString() == device_) {
+            return m[QStringLiteral("permitted")].toBool();
+        }
+    }
+    return false;
+}
+
+void RigControl::setHost(const QString& h) {
+    if (h == host_) return;
+    host_ = h;
+    save();
+    emit changed();
+}
+
+void RigControl::setBaud(int b) {
+    if (b == baud_) return;
+    baud_ = b;
+    save();
+    emit changed();
+}
+
+QStringList RigControl::bauds() const {
+    // "Default" first, and it is not a synonym for one of the numbers:
+    // it means take whatever the chosen Hamlib backend would have set a
+    // serial port to, which `rig::serial_defaults` reads out of that
+    // backend's own caps. Right for almost every radio, and the reason
+    // a rate is a thing the operator can leave alone.
+    return {QStringLiteral("Default"), QStringLiteral("1200"),
+            QStringLiteral("2400"),    QStringLiteral("4800"),
+            QStringLiteral("9600"),    QStringLiteral("19200"),
+            QStringLiteral("38400"),   QStringLiteral("57600"),
+            QStringLiteral("115200")};
+}
+
+void RigControl::setPttMethod(const QString& m) {
+    if (m == ptt_) return;
+    ptt_ = m;
+    save();
+    emit changed();
+}
+
+QStringList RigControl::pttMethods() const {
+    QStringList out{QStringLiteral("vox"), QStringLiteral("cat")};
+    // **DTR and RTS are not offered over Bluetooth**, because RFCOMM has
+    // no modem control lines at all. Offering them and failing at the
+    // moment somebody presses transmit is the worst available order to
+    // discover it in.
+    if (connection_ != QLatin1String("bluetooth")) {
+        out << QStringLiteral("dtr") << QStringLiteral("rts");
+    }
+    return out;
+}
+
+// --- models -----------------------------------------------------------------
+
+QVariantList RigControl::findModels(const QString& query) const {
+    const QString needle = query.trimmed();
+    QVariantList out;
+
+    if (needle.isEmpty()) {
+        // Never a blank screen. The dummy is what makes the whole path
+        // exercisable with no radio attached, and NET rigctl is the
+        // "share the radio with the station PC" answer -- both are worth
+        // finding without knowing to search for them.
+        for (const rig::RigModel& m : all_models()) {
+            if (m.model == rig::MODEL_DUMMY || m.model == rig::MODEL_NET_RIGCTL) {
+                out.append(model_row(m));
+            }
+        }
+        for (const rig::RigModel& m : all_models()) {
+            if (static_cast<int>(out.size()) >= kMaxModelRows) break;
+            if (m.model == rig::MODEL_DUMMY || m.model == rig::MODEL_NET_RIGCTL) continue;
+            out.append(model_row(m));
+        }
+        return out;
+    }
+
+    for (const rig::RigModel& m : all_models()) {
+        if (static_cast<int>(out.size()) >= kMaxModelRows) break;
+        const QString label = QString::fromStdString(m.label());
+        if (label.contains(needle, Qt::CaseInsensitive)) out.append(model_row(m));
+    }
+    return out;
+}
+
+// --- devices ----------------------------------------------------------------
+
+void RigControl::refreshDevices() {
+    devices_.clear();
+    if (connection_ != QLatin1String("network")) {
+        std::vector<rig::android::SerialDevice> found;
+        try {
+            found = connection_ == QLatin1String("bluetooth")
+                        ? rig::android::bluetooth_devices()
+                        : rig::android::usb_devices();
+        } catch (const std::exception&) {
+            // An empty list, not an error banner: "no radio plugged in"
+            // and "the Bluetooth permission has not been granted" are
+            // both ordinary states of this screen, and the screen says
+            // so in its own words.
+            found.clear();
+        }
+        for (const rig::android::SerialDevice& d : found) {
+            QVariantMap row;
+            row[QStringLiteral("id")] = QString::fromStdString(d.id);
+            row[QStringLiteral("label")] = QString::fromStdString(d.label);
+            row[QStringLiteral("permitted")] = d.permitted;
+            devices_.append(row);
+        }
+    }
+    emit devicesChanged();
+    emit changed();
+}
+
+void RigControl::requestPermission() {
+    if (connection_ == QLatin1String("network")) return;
+    const std::string id = connection_ == QLatin1String("bluetooth") && device_.isEmpty()
+                               ? std::string("bt:")
+                               : device_.toStdString();
+    if (id.empty()) return;
+    try {
+        rig::android::request_permission(id);
+    } catch (const std::exception&) {
+        // The dialog could not be raised; the screen keeps showing the
+        // device as not permitted, which is the truth.
+    }
+}
+
+void RigControl::publish_permission(const QString& id, bool granted) {
+    Q_UNUSED(id);
+    Q_UNUSED(granted);
+    // Re-enumerate rather than patching the row: a USB grant can arrive
+    // for a device that has since been unplugged, and the answer to "is
+    // it usable now" is the enumeration, not the broadcast.
+    refreshDevices();
+}
+
+// --- the session ------------------------------------------------------------
+
+bool RigControl::connectRig() {
+    rig::HamlibConfig config;
+    config.model = model_;
+    config.baud = baud_;
+    config.ptt_method = ptt_from(ptt_);
+
+    std::shared_ptr<rig::SerialTransport> transport;
+    if (connection_ == QLatin1String("network")) {
+        config.device = host_.trimmed().toStdString();
+    } else {
+        config.device = device_.toStdString();
+        if (config.device.empty()) {
+            return false;
+        }
+        // The line settings the transport has to be given, with every
+        // "Default" filled from what this Hamlib backend would itself
+        // have used -- because over a socket Hamlib never touches the
+        // hardware and so cannot apply them. This is also where the
+        // control-line conflicts are caught (PTT by RTS with hardware
+        // handshaking, and so on): Hamlib's own checks for those sit
+        // inside its serial path and never run here.
+        rig::SerialDefaults defaults;
+#ifdef SSTVAE_ANDROID_HAVE_RIG
+        defaults = rig::serial_defaults(model_);
+#endif
+        rig::SerialParams params;
+        try {
+            params = rig::resolve_serial_params(config, defaults);
+        } catch (const std::exception&) {
+            // A control-line conflict. Left to `start_rig`, which runs
+            // the same resolution and publishes the message -- reporting
+            // it from two places would mean two wordings for one fault.
+            params = rig::SerialParams{};
+            params.device_id = config.device;
+        }
+        transport = rig::android::make_transport(params);
+    }
+
+    const bool ok = Session::instance().start_rig(config, std::move(transport));
+    emit changed();
+    return ok;
+}
+
+void RigControl::disconnectRig() {
+    Session::instance().stop_rig();
+    emit changed();
+}
+
+// --- live state -------------------------------------------------------------
+
+bool RigControl::running() const { return Session::instance().rig_running(); }
+bool RigControl::failed() const { return Session::instance().rig_failed(); }
+bool RigControl::canKey() const { return Session::instance().rig_can_key(); }
+
+QString RigControl::status() const {
+    return QString::fromStdString(Session::instance().rig_status());
+}
+
+QString RigControl::frequency() const {
+    const std::optional<double> hz = Session::instance().rig_frequency_hz();
+    if (!hz) return {};
+    return QStringLiteral("%1 MHz").arg(*hz / 1e6, 0, 'f', 6);
+}

--- a/native/android-app/rigcontrol.cpp
+++ b/native/android-app/rigcontrol.cpp
@@ -1,10 +1,13 @@
 #include "rigcontrol.hpp"
 
+#include <QJniEnvironment>
+#include <QJniObject>
 #include <QLatin1String>
 #include <QPointer>
 #include <QSettings>
 #include <QGuiApplication>
 #include <QVariantMap>
+#include <QtCore/qcoreapplication_platform.h>
 
 #include <algorithm>
 #include <memory>
@@ -29,6 +32,40 @@ using namespace sstvae;
 using sstvae::androidapp::Session;
 
 namespace {
+
+// Hand the rig layer the VM and an application Context.
+//
+// **This was missing, and both of the rig screen's first two bugs on
+// hardware were it.** Without the VM the layer cannot resolve
+// `SerialBridge` at all, so `usb_devices()` threw and the device list
+// came back silently empty; and `has_permission()` threw from inside a
+// QML property getter, which is not a place an exception can go -- it
+// took the process down, and did it again at every launch, because the
+// connection kind is persisted.
+//
+// Called from `RigControl`'s constructor rather than from `main`, for
+// the reason `core/audio/android/` records about `FindClass`: the class
+// reference has to be taken on a thread with the app's class loader on
+// its stack, and this object is constructed by QML on exactly that
+// thread. `listener.cpp`'s `init_audio_bridge` is the same four lines
+// for the same reason.
+bool init_rig_bridge(QString* error) {
+    rig::android::set_java_vm(
+        reinterpret_cast<rig::android::JavaVM_*>(QJniEnvironment::javaVM()));
+
+    QJniObject ctx = QNativeInterface::QAndroidApplication::context();
+    if (!ctx.isValid()) {
+        *error = QObject::tr("no Android context; rig control is unavailable");
+        return false;
+    }
+    QJniObject::callStaticMethod<void>("org/cleverdomain/sstvae/SerialBridge", "init",
+                                       "(Landroid/content/Context;)V", ctx.object());
+    if (QJniEnvironment().checkAndClearExceptions()) {
+        *error = QObject::tr("SerialBridge.init failed; rig control is unavailable");
+        return false;
+    }
+    return true;
+}
 
 // Spelled once each, per the discipline `transmitter.hpp` records: a
 // setting displayed and written back through two different spellings is
@@ -85,6 +122,16 @@ bool have_rig_support() {
 
 RigControl::RigControl(QObject* parent) : QObject(parent) {
     load();
+
+    // Before anything else here touches the rig layer -- including the
+    // `connectRig()` at the end of this constructor.
+    if (!init_rig_bridge(&error_)) {
+        // Not fatal: the screen still renders and says why. Everything
+        // below is written to cope with the layer being unavailable,
+        // which is also what makes this recoverable rather than a crash.
+        layer_ok_ = false;
+        enabled_ = false;
+    }
 
     // A guarded pointer, not a raw capture: the callback is queued, so
     // an event can still be in flight when a rotation destroys this
@@ -150,7 +197,12 @@ void RigControl::save() {
 }
 
 void RigControl::setEnabled(bool on) {
-    if (on && !have_rig_support()) return;
+    // Two different reasons to refuse, and the message already on
+    // `error_` distinguishes them: the build has no Hamlib, or the
+    // platform layer did not come up. Refusing silently would leave a
+    // switch that springs back with no explanation, so neither clears
+    // the status text.
+    if (on && (!have_rig_support() || !layer_ok_)) return;
     if (on == enabled_) return;
     enabled_ = on;
     save();
@@ -312,12 +364,18 @@ void RigControl::refreshDevices() {
             found = connection_ == QLatin1String("bluetooth")
                         ? rig::android::bluetooth_devices()
                         : rig::android::usb_devices();
-        } catch (const std::exception&) {
-            // An empty list, not an error banner: "no radio plugged in"
-            // and "the Bluetooth permission has not been granted" are
-            // both ordinary states of this screen, and the screen says
-            // so in its own words.
+        } catch (const std::exception& e) {
+            // An enumeration that *threw* is not the same as one that
+            // came back empty, and conflating them is what made the
+            // first hardware failure invisible: with the JNI layer
+            // uninitialised the list was empty and the screen said "no
+            // radio plugged in", which was a confident lie.
+            //
+            // "Nothing connected" and "Bluetooth not granted" are
+            // ordinary states and still produce an empty list with no
+            // error; this is only for the ones that raised.
             found.clear();
+            error_ = QString::fromStdString(e.what());
         }
         for (const rig::android::SerialDevice& d : found) {
             QVariantMap row;
@@ -427,7 +485,16 @@ bool RigControl::failed() const {
 }
 
 bool RigControl::bluetoothReady() const {
-    return rig::android::has_permission("bt:");
+    // **Nothing that reaches JNI may throw from here.** This is read by
+    // a QML binding, and an exception crossing that boundary terminates
+    // the process -- which is exactly what it did when the layer was
+    // uninitialised, at every launch, because the connection kind is
+    // persisted and the binding is evaluated on load.
+    try {
+        return rig::android::has_permission("bt:");
+    } catch (const std::exception&) {
+        return false;
+    }
 }
 
 QString RigControl::frequency() const {

--- a/native/android-app/rigcontrol.cpp
+++ b/native/android-app/rigcontrol.cpp
@@ -161,6 +161,7 @@ void RigControl::setEnabled(bool on) {
 void RigControl::setConnection(const QString& kind) {
     if (kind == connection_) return;
     connection_ = kind;
+    error_.clear();
     // The device belongs to the kind that was showing when it was
     // chosen, so carrying it across would offer a Bluetooth address to
     // the USB opener.
@@ -363,6 +364,8 @@ bool RigControl::connectRig() {
     } else {
         config.device = device_.toStdString();
         if (config.device.empty()) {
+            error_ = tr("Choose a device first.");
+            emit changed();
             return false;
         }
         // The line settings the transport has to be given, with every
@@ -379,16 +382,22 @@ bool RigControl::connectRig() {
         rig::SerialParams params;
         try {
             params = rig::resolve_serial_params(config, defaults);
-        } catch (const std::exception&) {
-            // A control-line conflict. Left to `start_rig`, which runs
-            // the same resolution and publishes the message -- reporting
-            // it from two places would mean two wordings for one fault.
-            params = rig::SerialParams{};
-            params.device_id = config.device;
+        } catch (const std::exception& e) {
+            // A control-line conflict -- PTT by RTS with hardware
+            // handshaking, and the two like it. **Reported here, because
+            // nothing downstream will**: `make_bridged_backend` does not
+            // resolve line settings (the transport is built with them
+            // before it is handed over), so an earlier draft that left
+            // this to `start_rig` swallowed the message and connected
+            // with a silently wrong configuration.
+            error_ = QString::fromStdString(e.what());
+            emit changed();
+            return false;
         }
         transport = rig::android::make_transport(params);
     }
 
+    error_.clear();
     const bool ok = Session::instance().start_rig(config, std::move(transport));
     emit changed();
     return ok;
@@ -402,11 +411,19 @@ void RigControl::disconnectRig() {
 // --- live state -------------------------------------------------------------
 
 bool RigControl::running() const { return Session::instance().rig_running(); }
-bool RigControl::failed() const { return Session::instance().rig_failed(); }
 bool RigControl::canKey() const { return Session::instance().rig_can_key(); }
 
 QString RigControl::status() const {
+    if (!error_.isEmpty()) return error_;
     return QString::fromStdString(Session::instance().rig_status());
+}
+
+bool RigControl::failed() const {
+    return !error_.isEmpty() || Session::instance().rig_failed();
+}
+
+bool RigControl::bluetoothReady() const {
+    return rig::android::has_permission("bt:");
 }
 
 QString RigControl::frequency() const {

--- a/native/android-app/rigcontrol.cpp
+++ b/native/android-app/rigcontrol.cpp
@@ -155,7 +155,10 @@ RigControl::RigControl(QObject* parent) : QObject(parent) {
     // that moves quickly: the rig itself is polled every 10 s, so a
     // faster refresh would redraw the same frequency several times.
     poll_.setInterval(1000);
-    connect(&poll_, &QTimer::timeout, this, &RigControl::changed);
+    connect(&poll_, &QTimer::timeout, this, [this] {
+        maybe_reconnect();
+        emit changed();
+    });
     poll_.start();
 
     // A rig session survives this object, so a screen rotation must not
@@ -470,9 +473,75 @@ void RigControl::disconnectRig() {
     emit changed();
 }
 
+// --- staying connected ------------------------------------------------------
+
+void RigControl::maybe_reconnect() {
+    if (!enabled_ || !layer_ok_) return;
+
+    Session& session = Session::instance();
+    if (!session.rig_running()) return;
+
+    // **A published frequency is the only proof the radio is
+    // answering.** `failed` alone cannot tell "still opening the port"
+    // from "the cable is out", and `running` says neither -- it means a
+    // session is configured, which stayed true with the plug on the
+    // bench. This is the one signal that comes from the radio itself.
+    if (session.rig_frequency_hz().has_value()) {
+        reconnect_wait_ = 0;
+        reconnect_step_ = 0;
+        device_present_ = true;
+        return;
+    }
+    if (!session.rig_failed()) return;  // still connecting; leave it alone
+
+    // **Never while transmitting.** Reconnecting re-starts the
+    // controller, and although `ptt_function()` is bound to the
+    // controller rather than the backend and survives that, an over is
+    // committed airtime with the radio held on -- swapping the link
+    // underneath it buys nothing and risks the one operation that must
+    // not fail.
+    if (session.transmitting()) return;
+
+    if (connection_ != QLatin1String("network")) {
+        // `has_permission` is false for a device that is not there, so
+        // this is one cheap call that answers both "is it back" and
+        // "may we open it". A device that is simply absent does not
+        // spend the backoff: the next tick after it is plugged in
+        // reconnects.
+        device_present_ = rig::android::has_permission(device_.toStdString());
+        if (!device_present_) return;
+    } else {
+        device_present_ = true;
+    }
+
+    if (reconnect_wait_ > 0) {
+        --reconnect_wait_;
+        return;
+    }
+
+    // 2, 4, 8, 16, 32 s. Spent only on attempts that reached the radio
+    // and failed, which is the case where trying harder is the wrong
+    // answer -- a host that is not there, or a rig that will not open.
+    reconnect_step_ = std::min(reconnect_step_ + 1, 5);
+    reconnect_wait_ = 1 << reconnect_step_;
+    connectRig();
+}
+
 // --- live state -------------------------------------------------------------
 
 bool RigControl::running() const { return Session::instance().rig_running(); }
+
+QString RigControl::connectionState() const {
+    if (!layer_ok_) return tr("Unavailable");
+    if (!enabled_) return {};
+
+    Session& session = Session::instance();
+    if (!session.rig_running()) return tr("Not connected");
+    if (session.rig_frequency_hz().has_value()) return tr("Connected");
+    if (!session.rig_failed()) return tr("Connecting…");
+    if (!device_present_) return tr("Device disconnected — plug it back in");
+    return tr("Not responding — reconnecting");
+}
 bool RigControl::canKey() const { return Session::instance().rig_can_key(); }
 
 QString RigControl::status() const {

--- a/native/android-app/rigcontrol.hpp
+++ b/native/android-app/rigcontrol.hpp
@@ -182,6 +182,12 @@ private:
     int baud_ = 0;  // 0 = whatever the chosen backend would have used
     QString ptt_ = QStringLiteral("cat");
 
+    // False when `init_rig_bridge` could not hand the layer a VM and a
+    // Context. Distinct from the compile-time `SSTVAE_ANDROID_HAVE_RIG`:
+    // that says the build has Hamlib, this says the platform side came
+    // up. Either way the switch will not turn on, and `status` says why.
+    bool layer_ok_ = true;
+
     QVariantList devices_;
     // Set by a failed `connectRig` and shown in place of the session's
     // status, which for a configuration that never reached `start_rig`

--- a/native/android-app/rigcontrol.hpp
+++ b/native/android-app/rigcontrol.hpp
@@ -1,0 +1,183 @@
+// CAT and PTT, as QML sees it.
+//
+// A view, owning nothing, like `Listener` and `Transmitter`: the
+// `RigController` lives in `Session` because keying has to outlive a
+// rotation, and everything here is derived on demand or written
+// straight through to `QSettings`.
+//
+// **What is behind it is the whole reason this file exists.**
+// `docs/android.md` recorded rig control as structurally impossible on
+// Android, because Hamlib's serial layer opens a device path and an
+// unprivileged app is given none. Hamlib takes a socket for any backend
+// instead (`core/rig/transport.hpp`), so the radio list here is the
+// desktop's radio list, unmodified and unpatched. The three connection
+// kinds below are what a phone can actually offer:
+//
+//   * **USB** -- a serial adapter or a radio's own USB port, through the
+//     USB host API and `usb-serial-for-android`. CAT, plus DTR or RTS
+//     keying.
+//   * **Bluetooth** -- an RFCOMM link to a radio with a serial profile.
+//     CAT keying only: RFCOMM has no modem control lines to assert, and
+//     the transport says so rather than failing silently.
+//   * **Network** -- a host and port handed to Hamlib directly, with no
+//     bridge in the path. That covers a station PC running `rigctld`
+//     (model 2) and a serial-over-TCP server pointed at with a native
+//     backend, which are the same thing in Hamlib and are the same
+//     thing here.
+//
+// The settings live in `QSettings` for the reason `Transmitter`
+// records: the desktop's `config.json` schema is a rig section, folder
+// paths and a window layout, and its hand-editability buys nothing on a
+// phone. The discipline that does carry over is that every setting
+// displayed is written back through the same key it was read from, with
+// the key spelled once as a constant.
+
+#ifndef SSTVAE_ANDROID_RIGCONTROL_HPP
+#define SSTVAE_ANDROID_RIGCONTROL_HPP
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QTimer>
+#include <QVariantList>
+#include <QtQml/qqmlregistration.h>
+
+class RigControl : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+
+    // Whether the operator wants rig control at all. Off is the
+    // shipping default and not a degraded mode: the app was built to
+    // work with no CAT, and a phone acoustically coupled to a handheld
+    // has no radio to talk to.
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY changed)
+
+    // "usb" | "bluetooth" | "network". **This, not the shape of the
+    // device string, is what decides whether a bridge is built** --
+    // see `rig::make_bridged_backend`, where an earlier draft sniffed
+    // the string and got it wrong for every USB device.
+    Q_PROPERTY(QString connection READ connection WRITE setConnection NOTIFY changed)
+    Q_PROPERTY(QStringList connections READ connections CONSTANT)
+
+    // The Hamlib model number, and its label for display. Two
+    // properties rather than an index into a list: the list is
+    // hundreds of rows and is filtered by a search box, so an index
+    // would mean something different after every keystroke.
+    Q_PROPERTY(int model READ model WRITE setModel NOTIFY changed)
+    Q_PROPERTY(QString modelLabel READ modelLabel NOTIFY changed)
+
+    // {id, label, permitted} per row, for the current connection kind.
+    // Empty for "network".
+    Q_PROPERTY(QVariantList devices READ devices NOTIFY devicesChanged)
+    Q_PROPERTY(QString device READ device WRITE setDevice NOTIFY changed)
+    Q_PROPERTY(QString deviceLabel READ deviceLabel NOTIFY changed)
+    // Whether the app may open the selected device right now. False
+    // puts a "Grant access" button in front of the connect button
+    // rather than letting the connection fail with a permission error.
+    Q_PROPERTY(bool devicePermitted READ devicePermitted NOTIFY devicesChanged)
+
+    // host[:port] for the network kind. Hamlib defaults the port to
+    // 4532, which is rigctld's, so a bare host is the common case.
+    Q_PROPERTY(QString host READ host WRITE setHost NOTIFY changed)
+
+    Q_PROPERTY(int baud READ baud WRITE setBaud NOTIFY changed)
+    Q_PROPERTY(QStringList bauds READ bauds CONSTANT)
+
+    // "vox" | "cat" | "dtr" | "rts". `vox` means *do not key at all*,
+    // because the operator's audio is doing it -- not "key by VOX".
+    Q_PROPERTY(QString pttMethod READ pttMethod WRITE setPttMethod NOTIFY changed)
+    Q_PROPERTY(QStringList pttMethods READ pttMethods NOTIFY changed)
+
+    // --- live state --------------------------------------------------
+    Q_PROPERTY(bool running READ running NOTIFY changed)
+    Q_PROPERTY(bool failed READ failed NOTIFY changed)
+    Q_PROPERTY(QString status READ status NOTIFY changed)
+    // The dial frequency as text, empty when unknown. Text rather than a
+    // number because "unknown" is a state the UI has to render and a
+    // sentinel double is how that becomes 0.000 000 MHz on screen.
+    Q_PROPERTY(QString frequency READ frequency NOTIFY changed)
+    // Whether an over will be keyed by the rig. Read by the transmit
+    // screen, which says so rather than leaving the operator to work out
+    // whether the VOX leader is still doing the job.
+    Q_PROPERTY(bool canKey READ canKey NOTIFY changed)
+
+public:
+    explicit RigControl(QObject* parent = nullptr);
+    ~RigControl() override;
+
+    bool enabled() const { return enabled_; }
+    void setEnabled(bool on);
+
+    QString connection() const { return connection_; }
+    void setConnection(const QString& kind);
+    QStringList connections() const;
+
+    int model() const { return model_; }
+    void setModel(int m);
+    QString modelLabel() const;
+
+    QVariantList devices() const { return devices_; }
+    QString device() const { return device_; }
+    void setDevice(const QString& id);
+    QString deviceLabel() const;
+    bool devicePermitted() const;
+
+    QString host() const { return host_; }
+    void setHost(const QString& h);
+
+    int baud() const { return baud_; }
+    void setBaud(int b);
+    QStringList bauds() const;
+
+    QString pttMethod() const { return ptt_; }
+    void setPttMethod(const QString& m);
+    QStringList pttMethods() const;
+
+    bool running() const;
+    bool failed() const;
+    QString status() const;
+    QString frequency() const;
+    bool canKey() const;
+
+    // Rows matching `query`, capped -- Hamlib knows several hundred
+    // rigs and a phone list view of all of them is not a picker. An
+    // empty query returns the most useful few rather than nothing, so
+    // the screen is never blank.
+    Q_INVOKABLE QVariantList findModels(const QString& query) const;
+
+    // Re-enumerate. Called when the screen appears and after a
+    // permission answer; USB devices come and go with the cable.
+    Q_INVOKABLE void refreshDevices();
+
+    // Raise the system permission dialog for the selected device.
+    // Returns immediately -- nothing here waits on a human.
+    Q_INVOKABLE void requestPermission();
+
+    // Open the radio with the current settings, or close it. `connect`
+    // returns immediately: reaching the rig can take its full timeout
+    // and the answer arrives through `status`.
+    Q_INVOKABLE bool connectRig();
+    Q_INVOKABLE void disconnectRig();
+
+signals:
+    void changed();
+    void devicesChanged();
+
+private:
+    void save();
+    void load();
+    void publish_permission(const QString& id, bool granted);
+
+    bool enabled_ = false;
+    QString connection_ = QStringLiteral("usb");
+    int model_ = 1;  // Hamlib's dummy: connects with no radio attached
+    QString device_;
+    QString host_;
+    int baud_ = 0;  // 0 = whatever the chosen backend would have used
+    QString ptt_ = QStringLiteral("cat");
+
+    QVariantList devices_;
+    QTimer poll_;
+};
+
+#endif

--- a/native/android-app/rigcontrol.hpp
+++ b/native/android-app/rigcontrol.hpp
@@ -100,6 +100,11 @@ class RigControl : public QObject {
     // screen, which says so rather than leaving the operator to work out
     // whether the VOX leader is still doing the job.
     Q_PROPERTY(bool canKey READ canKey NOTIFY changed)
+    // Whether Bluetooth can be listed at all. Distinct from "no paired
+    // radios", which is what an empty list looks like either way -- and
+    // telling an operator to go and pair a radio they already paired is
+    // the kind of wrong advice that ends in a bug report.
+    Q_PROPERTY(bool bluetoothReady READ bluetoothReady NOTIFY devicesChanged)
 
 public:
     explicit RigControl(QObject* parent = nullptr);
@@ -138,6 +143,7 @@ public:
     QString status() const;
     QString frequency() const;
     bool canKey() const;
+    bool bluetoothReady() const;
 
     // Rows matching `query`, capped -- Hamlib knows several hundred
     // rigs and a phone list view of all of them is not a picker. An
@@ -177,6 +183,10 @@ private:
     QString ptt_ = QStringLiteral("cat");
 
     QVariantList devices_;
+    // Set by a failed `connectRig` and shown in place of the session's
+    // status, which for a configuration that never reached `start_rig`
+    // would be the *previous* session's text or nothing at all.
+    QString error_;
     QTimer poll_;
 };
 

--- a/native/android-app/rigcontrol.hpp
+++ b/native/android-app/rigcontrol.hpp
@@ -90,6 +90,15 @@ class RigControl : public QObject {
 
     // --- live state --------------------------------------------------
     Q_PROPERTY(bool running READ running NOTIFY changed)
+    // One line an operator can act on, which `running` cannot be.
+    //
+    // **`running` means a session is configured, not that the radio is
+    // answering** -- the desktop's distinction, kept for the desktop's
+    // reason. On hardware that read as "Connected" with the cable
+    // pulled out, which is the most misleading thing this screen could
+    // say. This separates them: "Connecting", "Connected", "Device
+    // disconnected", "Not responding".
+    Q_PROPERTY(QString connectionState READ connectionState NOTIFY changed)
     Q_PROPERTY(bool failed READ failed NOTIFY changed)
     Q_PROPERTY(QString status READ status NOTIFY changed)
     // The dial frequency as text, empty when unknown. Text rather than a
@@ -139,6 +148,7 @@ public:
     QStringList pttMethods() const;
 
     bool running() const;
+    QString connectionState() const;
     bool failed() const;
     QString status() const;
     QString frequency() const;
@@ -174,6 +184,10 @@ private:
     void load();
     void publish_permission(const QString& id, bool granted);
 
+    // Called once per poll tick. Rebuilds the rig session when the radio
+    // has stopped answering and the device is reachable again.
+    void maybe_reconnect();
+
     bool enabled_ = false;
     QString connection_ = QStringLiteral("usb");
     int model_ = 1;  // Hamlib's dummy: connects with no radio attached
@@ -187,6 +201,20 @@ private:
     // that says the build has Hamlib, this says the platform side came
     // up. Either way the switch will not turn on, and `status` says why.
     bool layer_ok_ = true;
+
+    // Reconnection state, in whole poll ticks (the timer is 1 Hz) so
+    // there is no clock to reason about.
+    //
+    // `reconnect_wait_` is only spent on attempts that actually ran: a
+    // device that is simply absent costs nothing and is retried on the
+    // very next tick, which is what makes replugging feel immediate
+    // rather than "somewhere in the next 30 seconds".
+    int reconnect_wait_ = 0;
+    int reconnect_step_ = 0;
+    // Cached by `maybe_reconnect` so `connectionState` can distinguish
+    // "unplugged" from "not answering" without a JNI call of its own on
+    // every property read.
+    bool device_present_ = true;
 
     QVariantList devices_;
     // Set by a failed `connectRig` and shown in place of the session's

--- a/native/android-app/session.cpp
+++ b/native/android-app/session.cpp
@@ -164,6 +164,11 @@ Session::~Session() {
     cancel_transmit();
     join_tx();
     stop();
+    // Before the threads below, and deliberately: `stop_rig` detaches
+    // rather than joining, so a wedged rig cannot hold up teardown --
+    // but a *keyed* rig must be released, and the departing worker's
+    // destructor is what does it.
+    stop_rig();
     if (model_thread_.joinable()) model_thread_.join();
     if (encoder_thread_.joinable()) encoder_thread_.join();
 }
@@ -506,6 +511,113 @@ bool Session::start_transmit(TxRequest request) {
     return true;
 }
 
+// --- rig control ------------------------------------------------------------
+
+bool Session::start_rig(const rig::HamlibConfig& config,
+                        std::shared_ptr<rig::SerialTransport> transport) {
+#ifndef SSTVAE_ANDROID_HAVE_RIG
+    (void)config;
+    (void)transport;
+    std::lock_guard<std::mutex> lk(rig_mu_);
+    rig_status_ = "this build has no rig control";
+    rig_failed_ = true;
+    return false;
+#else
+    std::unique_ptr<rig::RigBackend> backend;
+    try {
+        // Everything that can be rejected on the spot is rejected here,
+        // on the caller's thread, so a settings screen gets an answer
+        // rather than a status line arriving later: an impossible
+        // control-line combination, a device with nothing to open it, a
+        // typed host that Hamlib will not dial.
+        backend = rig::make_bridged_backend(
+            config, std::move(transport),
+            [](const rig::HamlibConfig& c) { return rig::make_hamlib_backend(c); });
+    } catch (const std::exception& e) {
+        std::lock_guard<std::mutex> lk(rig_mu_);
+        rig_status_ = e.what();
+        rig_failed_ = true;
+        rig_can_key_ = false;
+        return false;
+    }
+
+    auto controller = std::make_unique<rig::RigController>(
+        [this](std::optional<double> hz) {
+            std::lock_guard<std::mutex> lk(rig_mu_);
+            rig_frequency_ = hz;
+        },
+        [this](const std::string& text, bool error) {
+            std::lock_guard<std::mutex> lk(rig_mu_);
+            rig_status_ = text;
+            rig_failed_ = error;
+        });
+
+    rig::RigConfig rig_config;
+    // Slower than the desktop's 5 s. A frequency readout is a comfort
+    // on a phone rather than a working instrument -- there is no rig
+    // panel competing for it -- and every poll is a CAT round trip plus
+    // a wakeup on a device whose battery is the whole reason
+    // `decode_loop_low_cpu` exists.
+    rig_config.poll_interval_s = 10.0;
+    controller->start(std::move(backend), rig_config);
+
+    std::unique_ptr<rig::RigController> old;
+    {
+        std::lock_guard<std::mutex> lk(rig_mu_);
+        old = std::move(rig_);
+        rig_ = std::move(controller);
+        rig_frequency_.reset();
+        rig_status_ = "connecting";
+        rig_failed_ = false;
+        rig_can_key_ = config.ptt_method != rig::PttMethod::Vox;
+    }
+    // Outside the lock, and after the new one is in place: `stop()`
+    // detaches rather than joining, so this returns immediately, but the
+    // destructor still runs a teardown that must not be holding a lock
+    // the UI is about to take.
+    if (old) old->stop();
+    return true;
+#endif
+}
+
+void Session::stop_rig() {
+    std::unique_ptr<rig::RigController> old;
+    {
+        std::lock_guard<std::mutex> lk(rig_mu_);
+        old = std::move(rig_);
+        rig_frequency_.reset();
+        rig_status_.clear();
+        rig_failed_ = false;
+        rig_can_key_ = false;
+    }
+    if (old) old->stop();
+}
+
+bool Session::rig_running() const {
+    std::lock_guard<std::mutex> lk(rig_mu_);
+    return rig_ != nullptr && rig_->running();
+}
+
+std::optional<double> Session::rig_frequency_hz() const {
+    std::lock_guard<std::mutex> lk(rig_mu_);
+    return rig_frequency_;
+}
+
+std::string Session::rig_status() const {
+    std::lock_guard<std::mutex> lk(rig_mu_);
+    return rig_status_;
+}
+
+bool Session::rig_failed() const {
+    std::lock_guard<std::mutex> lk(rig_mu_);
+    return rig_failed_;
+}
+
+bool Session::rig_can_key() const {
+    std::lock_guard<std::mutex> lk(rig_mu_);
+    return rig_ != nullptr && rig_can_key_;
+}
+
 void Session::run_transmit(const TxRequest& request) {
     // **Capture stops before anything else happens**, including the
     // encode -- not because the encode would disturb it, but because a
@@ -536,15 +648,34 @@ void Session::run_transmit(const TxRequest& request) {
     cfg.cw_id = request.cw_id;
     if (!request.cw_message.empty()) cfg.cw_message = request.cw_message;
     cfg.vox_lead_s = request.vox_lead_s;
-    // **No PTT, and that is the whole keying story on this platform.**
-    // Android gives an unprivileged app no serial node, so rig control
-    // is structurally absent (docs/android.md) and the transmitter is
-    // keyed by its own audio. The state machine is kept exactly as it
-    // is anyway: `PttWatchdog` with a null `Ptt` stands itself down and
-    // does nothing, so there is no special case here, and CAT over
-    // NET rigctl later is a `Ptt` to pass rather than a restructure.
+
+    // **Keying, which this platform does have now.** `docs/android.md`
+    // said it could not: Hamlib opens a device path and Android gives an
+    // app none. It takes a socket for any backend instead (see
+    // `core/rig/transport.hpp`), so what reaches `TxEngine` here is an
+    // ordinary `Ptt` -- exactly the shape that file predicted CAT would
+    // arrive in, and the prediction held: nothing above this line
+    // changed to accept it.
+    //
+    // Null when the operator has no rig session, or has it set to VOX.
+    // That is still a supported configuration and not a degraded one:
+    // `PttWatchdog` with a null `Ptt` stands itself down, so there is no
+    // special case below either way.
+    tx::Ptt ptt;
+    if (request.use_ptt) {
+        std::lock_guard<std::mutex> lk(rig_mu_);
+        if (rig_ && rig_can_key_) ptt = rig_->ptt_function();
+    }
+    if (ptt) {
+        // The VOX leader exists to trip an audio-detecting transmitter
+        // that is not being told anything. With PTT it is a swept tone
+        // sent into an already-keyed radio for no reason, and it delays
+        // the picture by its own length.
+        cfg.vox_lead_s = 0.0;
+    }
+
     auto engine = std::make_unique<tx::TxEngine>(
-        nullptr,
+        std::move(ptt),
         [](const std::string& device, std::span<const double> wave, int samplerate,
            const std::function<void(double)>& on_progress,
            const std::function<bool()>& should_stop,

--- a/native/android-app/session.cpp
+++ b/native/android-app/session.cpp
@@ -541,16 +541,42 @@ bool Session::start_rig(const rig::HamlibConfig& config,
         return false;
     }
 
-    auto controller = std::make_unique<rig::RigController>(
-        [this](std::optional<double> hz) {
-            std::lock_guard<std::mutex> lk(rig_mu_);
-            rig_frequency_ = hz;
-        },
-        [this](const std::string& text, bool error) {
-            std::lock_guard<std::mutex> lk(rig_mu_);
-            rig_status_ = text;
-            rig_failed_ = error;
-        });
+    // **The controller is created once and never destroyed.** Two
+    // reasons, and the second is a bug this replaced.
+    //
+    // `ptt_function()` returns a lambda capturing the *controller*, and
+    // `TxEngine` holds that for the length of an over. Destroying the
+    // controller while a transmission is in flight -- which is what
+    // turning rig control off mid-over used to do -- left the engine
+    // calling into freed memory to bring PTT back down, at the one
+    // moment it matters most.
+    //
+    // And `start()` supersedes a session in place, so re-starting the
+    // same controller with a freshly built backend is exactly what a
+    // reconnect needs: the `Ptt` already handed out stays valid across
+    // it. `Session` is immortal for its own reasons; this rides along
+    // with them.
+    rig::RigController* controller = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(rig_mu_);
+        if (!rig_) {
+            rig_ = std::make_unique<rig::RigController>(
+                [this](std::optional<double> hz) {
+                    std::lock_guard<std::mutex> lock(rig_mu_);
+                    rig_frequency_ = hz;
+                },
+                [this](const std::string& text, bool error) {
+                    std::lock_guard<std::mutex> lock(rig_mu_);
+                    rig_status_ = text;
+                    rig_failed_ = error;
+                });
+        }
+        controller = rig_.get();
+        rig_frequency_.reset();
+        rig_status_ = "connecting";
+        rig_failed_ = false;
+        rig_can_key_ = config.ptt_method != rig::PttMethod::Vox;
+    }
 
     rig::RigConfig rig_config;
     // Slower than the desktop's 5 s. A frequency readout is a comfort
@@ -559,38 +585,31 @@ bool Session::start_rig(const rig::HamlibConfig& config,
     // a wakeup on a device whose battery is the whole reason
     // `decode_loop_low_cpu` exists.
     rig_config.poll_interval_s = 10.0;
-    controller->start(std::move(backend), rig_config);
 
-    std::unique_ptr<rig::RigController> old;
-    {
-        std::lock_guard<std::mutex> lk(rig_mu_);
-        old = std::move(rig_);
-        rig_ = std::move(controller);
-        rig_frequency_.reset();
-        rig_status_ = "connecting";
-        rig_failed_ = false;
-        rig_can_key_ = config.ptt_method != rig::PttMethod::Vox;
-    }
-    // Outside the lock, and after the new one is in place: `stop()`
-    // detaches rather than joining, so this returns immediately, but the
-    // destructor still runs a teardown that must not be holding a lock
-    // the UI is about to take.
-    if (old) old->stop();
+    // **Outside the lock, and that is not incidental.** `start()`
+    // publishes "connecting" through the status callback, which takes
+    // `rig_mu_`; calling it with the lock held would deadlock on the
+    // first line of every connection attempt.
+    controller->start(std::move(backend), rig_config);
     return true;
 #endif
 }
 
 void Session::stop_rig() {
-    std::unique_ptr<rig::RigController> old;
+    rig::RigController* controller = nullptr;
     {
         std::lock_guard<std::mutex> lk(rig_mu_);
-        old = std::move(rig_);
+        controller = rig_.get();
         rig_frequency_.reset();
         rig_status_.clear();
         rig_failed_ = false;
         rig_can_key_ = false;
     }
-    if (old) old->stop();
+    // Stopped, never destroyed -- see `start_rig`. `stop()` detaches
+    // rather than joining, so this returns immediately even against a
+    // rig that has stopped answering, which is the whole point of the
+    // controller's design.
+    if (controller) controller->stop();
 }
 
 bool Session::rig_running() const {
@@ -666,13 +685,15 @@ void Session::run_transmit(const TxRequest& request) {
         std::lock_guard<std::mutex> lk(rig_mu_);
         if (rig_ && rig_can_key_) ptt = rig_->ptt_function();
     }
-    if (ptt) {
-        // The VOX leader exists to trip an audio-detecting transmitter
-        // that is not being told anything. With PTT it is a swept tone
-        // sent into an already-keyed radio for no reason, and it delays
-        // the picture by its own length.
-        cfg.vox_lead_s = 0.0;
-    }
+    // **The leader is not suppressed when the rig is keyed directly**
+    // (Andrew, on hardware). An earlier version zeroed it here, on the
+    // theory that a swept tone into an already-keyed radio only delays
+    // the picture. That is the app second-guessing a setting the
+    // operator made: the leader is also a settling period for an
+    // interface that wants audio flowing before the radio is properly
+    // in transmit, and `ptt_lead_s` is a different quantity doing a
+    // different job. If it is not wanted with CAT keying, the operator
+    // sets it to zero.
 
     auto engine = std::make_unique<tx::TxEngine>(
         std::move(ptt),

--- a/native/android-app/session.hpp
+++ b/native/android-app/session.hpp
@@ -36,6 +36,10 @@
 #include "codec/codec.hpp"
 #include "images/types.hpp"
 #include "modem/modem.hpp"
+#include "rig/bridged.hpp"
+#include "rig/controller.hpp"
+#include "rig/hamlib.hpp"
+#include "rig/transport.hpp"
 #include "rx/engine.hpp"
 #include "rx/ringbuffer.hpp"
 #include "tx/engine.hpp"
@@ -170,6 +174,56 @@ public:
     // holes in its own audio.
     std::vector<double> audio_tail(std::size_t n) const;
 
+    // --- rig control -------------------------------------------------
+    //
+    // **Owned here rather than by the UI, for the transmit reason and
+    // not the receive one.** A frequency readout is a view's business
+    // and could live with the view; keying is not. An over is 32-95 s
+    // of committed airtime with the radio held on, and the thing that
+    // has to bring PTT back down at the end of it cannot be something
+    // the operator can destroy by rotating the screen.
+    //
+    // `RigController` itself is unchanged from the desktop's -- one
+    // worker, PTT as priority work, `stop()` that detaches rather than
+    // joining. What is new is only what sits under it: on Android the
+    // backend reaches the radio through a `SerialTransport` and a
+    // loopback socket instead of a device path. See
+    // `core/rig/transport.hpp`.
+
+    // Open the radio, or reconfigure an already-open one. `transport`
+    // null means `config.device` is a host and Hamlib dials it itself;
+    // non-null means USB or Bluetooth. Returns false and sets
+    // `rig_error()` if the configuration cannot work at all -- a failure
+    // to *reach* the radio is reported asynchronously through
+    // `rig_status()`, because it can take the rig's full timeout and
+    // nothing may wait on that.
+    bool start_rig(const rig::HamlibConfig& config,
+                   std::shared_ptr<rig::SerialTransport> transport);
+    void stop_rig();
+
+    // Whether a session is configured -- **not** whether the radio is
+    // answering, which is what `rig_status()` reports. The desktop's
+    // distinction, kept for the desktop's reason: a worker whose open()
+    // failed has already exited while this still says true, and only the
+    // status text can tell "connecting" from "no such device".
+    bool rig_running() const;
+
+    // The last frequency the worker published. Cached, never a request,
+    // so reading it cannot block.
+    std::optional<double> rig_frequency_hz() const;
+
+    // The most recent status line, and whether it was a failure. Both,
+    // because the text alone cannot carry it: a failure message is
+    // whatever the backend's exception said and has no reliable shape.
+    std::string rig_status() const;
+    bool rig_failed() const;
+
+    // Whether keying the radio is possible right now: a rig session is
+    // open and its PTT method is something other than "let the audio do
+    // it". The transmit screen reads this to decide whether an over is
+    // keyed by CAT or by VOX.
+    bool rig_can_key() const;
+
     // --- transmit ----------------------------------------------------
     //
     // **Owned here for the same reason receiving is**, and it is not the
@@ -192,6 +246,11 @@ public:
     // configuration, because the transmitting thread must keep sending
     // what the operator committed to at the moment they pressed Send.
     struct TxRequest {
+        // Key the radio through the rig session rather than letting the
+        // audio do it. Read once at staging, like everything else here:
+        // an operator who turns rig control off mid-over must not leave
+        // the transmitter keyed with nothing arranged to release it.
+        bool use_ptt = false;
         images::Picture picture;  // already framed to IMG_W x IMG_H
         std::string mode = "B";
         std::string callsign;
@@ -250,6 +309,19 @@ private:
     // on a session that is starting or stopping.
     mutable std::mutex gallery_mu_;
     std::string gallery_error_;
+
+    // Its own lock, like the gallery's and for the same reason: the rig
+    // worker publishes a frequency every poll and the UI reads it
+    // several times a second, and neither has any business waiting on a
+    // capture start or a model load. `rig_` is a pointer rather than a
+    // value because `RigController` is not movable and a session is
+    // torn down and rebuilt on every reconfigure.
+    mutable std::mutex rig_mu_;
+    std::unique_ptr<rig::RigController> rig_;
+    std::optional<double> rig_frequency_;
+    std::string rig_status_;
+    bool rig_failed_ = false;
+    bool rig_can_key_ = false;
 
     // Guards the members below against a view thread reading while the
     // UI thread starts or stops. It is never held across a decode: the

--- a/native/android-app/transmitter.cpp
+++ b/native/android-app/transmitter.cpp
@@ -345,12 +345,7 @@ QString Transmitter::airtime() const {
     const config::ModeSpec* m = find_mode(mode_);
     if (m == nullptr) return {};
     double seconds = m->duration_s;
-    // Not counted when the rig will be keyed directly: `run_transmit`
-    // zeroes the leader in that case, because a swept tone into an
-    // already-keyed radio only delays the picture.
-    if (vox_lead_s_ > 0.0 && !Session::instance().rig_can_key()) {
-        seconds += vox_lead_s_ + dsp::VOX_LEAD_GAP_S;
-    }
+    if (vox_lead_s_ > 0.0) seconds += vox_lead_s_ + dsp::VOX_LEAD_GAP_S;
     // The CW ID's length depends on the message, so it is deliberately
     // not counted here rather than guessed at: a figure that is
     // sometimes wrong is worse than one that is consistently the
@@ -358,14 +353,18 @@ QString Transmitter::airtime() const {
     return QStringLiteral("%1 s").arg(seconds, 0, 'f', 0);
 }
 
+bool Transmitter::rigKeyed() const { return Session::instance().rig_can_key(); }
+
 QString Transmitter::keying() const {
+    // The leader is reported the same way either way: it is the
+    // operator's setting and it is sent whatever keys the radio.
+    const QString leader = vox_lead_s_ > 0.0
+                               ? tr("a %1 s leader tone").arg(vox_lead_s_, 0, 'g', 2)
+                               : tr("no leader tone");
     if (Session::instance().rig_can_key()) {
-        return tr("Rig control keys the radio; the VOX leader is skipped.");
+        return tr("Rig control keys the radio, with %1.").arg(leader);
     }
-    if (vox_lead_s_ > 0.0) {
-        return tr("VOX, with a %1 s leader tone.").arg(vox_lead_s_, 0, 'g', 2);
-    }
-    return tr("VOX, with no leader tone.");
+    return tr("VOX, with %1.").arg(leader);
 }
 
 QString Transmitter::lastError() const {

--- a/native/android-app/transmitter.cpp
+++ b/native/android-app/transmitter.cpp
@@ -345,12 +345,27 @@ QString Transmitter::airtime() const {
     const config::ModeSpec* m = find_mode(mode_);
     if (m == nullptr) return {};
     double seconds = m->duration_s;
-    if (vox_lead_s_ > 0.0) seconds += vox_lead_s_ + dsp::VOX_LEAD_GAP_S;
+    // Not counted when the rig will be keyed directly: `run_transmit`
+    // zeroes the leader in that case, because a swept tone into an
+    // already-keyed radio only delays the picture.
+    if (vox_lead_s_ > 0.0 && !Session::instance().rig_can_key()) {
+        seconds += vox_lead_s_ + dsp::VOX_LEAD_GAP_S;
+    }
     // The CW ID's length depends on the message, so it is deliberately
     // not counted here rather than guessed at: a figure that is
     // sometimes wrong is worse than one that is consistently the
     // picture's own airtime.
     return QStringLiteral("%1 s").arg(seconds, 0, 'f', 0);
+}
+
+QString Transmitter::keying() const {
+    if (Session::instance().rig_can_key()) {
+        return tr("Rig control keys the radio; the VOX leader is skipped.");
+    }
+    if (vox_lead_s_ > 0.0) {
+        return tr("VOX, with a %1 s leader tone.").arg(vox_lead_s_, 0, 'g', 2);
+    }
+    return tr("VOX, with no leader tone.");
 }
 
 QString Transmitter::lastError() const {
@@ -375,6 +390,12 @@ void Transmitter::send() {
     req.cw_id = cw_id_;
     req.cw_message = cw_message_.toStdString();
     req.vox_lead_s = vox_lead_s_;
+    // **Read here, at the tap, like everything else in this request.**
+    // An operator who switches rig control off mid-over must not leave a
+    // transmitter keyed with nothing arranged to release it; the engine
+    // holds whichever `Ptt` it was handed for the whole transmission,
+    // and its watchdog is sized against that.
+    req.use_ptt = Session::instance().rig_can_key();
     req.output_device = device_ == kSystemDefault ? std::string{} : device_.toStdString();
     Session::instance().stage_transmit(std::move(req));
 

--- a/native/android-app/transmitter.hpp
+++ b/native/android-app/transmitter.hpp
@@ -82,6 +82,10 @@ class Transmitter : public QObject {
     // that was doing the job yesterday is silently not in the waveform
     // today.
     Q_PROPERTY(QString keying READ keying NOTIFY changed)
+    // Whether the rig will key the radio, as a fact rather than as a
+    // substring of `keying` -- that text is translatable, so testing its
+    // prefix works until somebody ships a translation.
+    Q_PROPERTY(bool rigKeyed READ rigKeyed NOTIFY changed)
     Q_PROPERTY(QString lastError READ lastError NOTIFY changed)
     // Empty unless the CW ID settings would key a partial
     // identification; see `tx::cw_id_problem`. Non-empty blocks Send,
@@ -132,6 +136,7 @@ public:
     double txProgress() const;
     QString airtime() const;
     QString keying() const;
+    bool rigKeyed() const;
     QString lastError() const;
     QString cwIdProblem() const;
     bool needsFirstTransmitPrompt() const { return !acknowledged_; }

--- a/native/android-app/transmitter.hpp
+++ b/native/android-app/transmitter.hpp
@@ -75,6 +75,13 @@ class Transmitter : public QObject {
     // How long this mode's transmission will take, as text, so the
     // operator can decide whether to start one now.
     Q_PROPERTY(QString airtime READ airtime NOTIFY changed)
+    // How the radio will be put into transmit for this over. A sentence
+    // rather than a flag, because the two cases behave differently in a
+    // way the operator can otherwise only find out on the air: with rig
+    // control keying the radio the VOX leader is skipped, so a leader
+    // that was doing the job yesterday is silently not in the waveform
+    // today.
+    Q_PROPERTY(QString keying READ keying NOTIFY changed)
     Q_PROPERTY(QString lastError READ lastError NOTIFY changed)
     // Empty unless the CW ID settings would key a partial
     // identification; see `tx::cw_id_problem`. Non-empty blocks Send,
@@ -124,6 +131,7 @@ public:
     QString txStatus() const;
     double txProgress() const;
     QString airtime() const;
+    QString keying() const;
     QString lastError() const;
     QString cwIdProblem() const;
     bool needsFirstTransmitPrompt() const { return !acknowledged_; }

--- a/native/cmake/hamlib.cmake
+++ b/native/cmake/hamlib.cmake
@@ -32,6 +32,8 @@ set(SSTVAE_HAMLIB_SYSTEM OFF CACHE BOOL
     "Use the system libhamlib via pkg-config instead of the pinned build")
 set(SSTVAE_HAMLIB_DIR "" CACHE PATH
     "Prebuilt Hamlib tree (containing include/ and lib/); skips the download")
+set(SSTVAE_ANDROID_API "" CACHE STRING
+    "Android API level for the Hamlib cross-build; empty = detect")
 
 # --- the system option ------------------------------------------------------
 if(SSTVAE_HAMLIB_SYSTEM)
@@ -213,9 +215,44 @@ else()
       endif()
       set(_ndk_bin "${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/${_ndk_host}/bin")
 
-      set(_hl_api "${CMAKE_SYSTEM_VERSION}")
-      if(NOT _hl_api)
-        set(_hl_api 29)  # the app's minSdk
+      # **The API level is not reliably in `CMAKE_SYSTEM_VERSION`**, and
+      # believing it was is what made this block's first real run fail.
+      # CMake defaults that variable to `1` when cross-compiling and
+      # nothing sets it, which the NDK toolchain path does not always
+      # do -- so the compiler wrapper came out as
+      # `x86_64-linux-android1-clang`. Worse, the fallback written to
+      # catch exactly that was `if(NOT _hl_api)`, and `1` is *true* in
+      # CMake, so it never ran. A guard whose condition cannot fire is
+      # not a guard.
+      #
+      # Ask everything that might know, in order of how directly it
+      # means "API level", and take the first plausible answer.
+      # `SSTVAE_ANDROID_API` is first so a build with an NDK layout
+      # nobody here anticipated can be unblocked with one -D.
+      set(_hl_api "")
+      set(_hl_api_from "")
+      foreach(_src SSTVAE_ANDROID_API CMAKE_ANDROID_API ANDROID_NATIVE_API_LEVEL
+                   ANDROID_PLATFORM_LEVEL CMAKE_SYSTEM_VERSION)
+        if(DEFINED ${_src} AND "${${_src}}" MATCHES "^[0-9]+$"
+           AND "${${_src}}" GREATER_EQUAL 16)
+          set(_hl_api "${${_src}}")
+          set(_hl_api_from "${_src}")
+          break()
+        endif()
+      endforeach()
+      # The NDK's own spelling, "android-29".
+      if(_hl_api STREQUAL "" AND DEFINED ANDROID_PLATFORM
+         AND "${ANDROID_PLATFORM}" MATCHES "([0-9]+)")
+        set(_hl_api "${CMAKE_MATCH_1}")
+        set(_hl_api_from "ANDROID_PLATFORM")
+      endif()
+      if(_hl_api STREQUAL "")
+        # The floor of every NDK that still exists, and safe against the
+        # app's minSdk of 29: a library built for a *lower* level loads
+        # on a higher one, never the reverse. Guessing high is the
+        # failure that would only show up on somebody else's phone.
+        set(_hl_api 21)
+        set(_hl_api_from "fallback")
       endif()
 
       if(CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
@@ -235,13 +272,46 @@ else()
           "Hamlib for Android: unknown ABI '${CMAKE_ANDROID_ARCH_ABI}'")
       endif()
 
+      # The NDK ships one wrapper per API level, and which levels exist
+      # depends on the NDK release -- r28 dropped everything below 21.
+      # So a level that is right for the *app* can still have no wrapper
+      # here. Rather than refuse, take the lowest one at or above it:
+      # that is the same library, built against an older libc, and it
+      # runs everywhere the requested one would have.
       set(_hl_cc "${_ndk_bin}/${_hl_cc_triple}${_hl_api}-clang")
       if(NOT EXISTS "${_hl_cc}")
-        message(FATAL_ERROR
-          "No NDK compiler at ${_hl_cc}.\n"
-          "The API level comes from CMAKE_SYSTEM_VERSION (${_hl_api}); the "
-          "NDK ships a wrapper per level, so an unsupported one is missing "
-          "rather than wrong.")
+        file(GLOB _hl_wrappers "${_ndk_bin}/${_hl_cc_triple}[0-9]*-clang")
+        set(_hl_best "")
+        set(_hl_have "")
+        foreach(_w IN LISTS _hl_wrappers)
+          if("${_w}" MATCHES "${_hl_cc_triple}([0-9]+)-clang$")
+            set(_hl_level "${CMAKE_MATCH_1}")
+            list(APPEND _hl_have "${_hl_level}")
+            if(_hl_level GREATER_EQUAL _hl_api
+               AND (_hl_best STREQUAL "" OR _hl_level LESS _hl_best))
+              set(_hl_best "${_hl_level}")
+            endif()
+          endif()
+        endforeach()
+        if(_hl_best STREQUAL "")
+          list(SORT _hl_have COMPARE NATURAL)
+          # Joined, because an unjoined CMake list renders as
+          # `21;22;23` -- which reads like shell syntax in the one
+          # message somebody is reading precisely because they are stuck.
+          string(REPLACE ";" ", " _hl_have "${_hl_have}")
+          message(FATAL_ERROR
+            "No NDK compiler for ${_hl_cc_triple} at API ${_hl_api} or above "
+            "in ${_ndk_bin}.\n"
+            "The level was taken from ${_hl_api_from}. Levels this NDK has: "
+            "${_hl_have}.\n"
+            "Set -DSSTVAE_ANDROID_API=<level> to choose one, or "
+            "-DSSTVAE_ANDROID_RIG=OFF to build without CAT.")
+        endif()
+        message(STATUS
+          "Hamlib: no API ${_hl_api} wrapper for ${_hl_cc_triple}; "
+          "using ${_hl_best}")
+        set(_hl_api "${_hl_best}")
+        set(_hl_cc "${_ndk_bin}/${_hl_cc_triple}${_hl_api}-clang")
       endif()
 
       list(APPEND _hl_configure_args
@@ -255,7 +325,7 @@ else()
            "ac_cv_func_realloc_0_nonnull=yes")
       message(STATUS
         "Hamlib: cross-building for Android ${CMAKE_ANDROID_ARCH_ABI} "
-        "(API ${_hl_api})")
+        "(API ${_hl_api}, from ${_hl_api_from})")
     endif()
 
     # Cross-compiling to the other macOS architecture.

--- a/native/cmake/hamlib.cmake
+++ b/native/cmake/hamlib.cmake
@@ -105,10 +105,19 @@ else()
   # directory, so that whatever caches FETCHCONTENT_BASE_DIR caches the
   # *built* Hamlib too. CI throws its build tree away every run; without
   # this, every job on every platform would rebuild Hamlib from source.
+  #
+  # On Android the install tree is per ABI: two ABIs are two builds of
+  # two different libraries, and sharing a prefix would have the second
+  # find the first's headers, skip its own build, and link an arm64
+  # library into an armeabi-v7a APK.
+  set(_hl_suffix "")
+  if(ANDROID)
+    set(_hl_suffix "-${CMAKE_ANDROID_ARCH_ABI}")
+  endif()
   if(FETCHCONTENT_BASE_DIR)
-    set(_hl_root "${FETCHCONTENT_BASE_DIR}/hamlib-install-${_hl_v}")
+    set(_hl_root "${FETCHCONTENT_BASE_DIR}/hamlib-install-${_hl_v}${_hl_suffix}")
   else()
-    set(_hl_root "${CMAKE_CURRENT_BINARY_DIR}/hamlib-install")
+    set(_hl_root "${CMAKE_CURRENT_BINARY_DIR}/hamlib-install${_hl_suffix}")
   endif()
 
   # Built once and stamped. ExternalProject would rebuild on every
@@ -154,6 +163,100 @@ else()
         "--without-cxx-binding"
         "--without-libusb"
         "--disable-silent-rules")
+
+    # Cross-compiling for Android.
+    #
+    # **Unverified as of 2026-08-22**: this session had no NDK and
+    # dl.google.com is unreachable from it, so the recipe below is
+    # written from the NDK's documented layout and has never been run.
+    # Treat a first failure as expected work rather than as a bug, and
+    # see docs/android.md ("Rig control over a socket") for what it is
+    # for. Everything downstream of it -- the bridge, the transport, the
+    # PTT routing -- is covered by tests that run without it.
+    #
+    # Three things here are Android-specific and none of them are
+    # optional:
+    #
+    #   * **`--host` and the compiler triple are not the same string on
+    #     32-bit ARM.** autotools wants `arm-linux-androideabi`, which is
+    #     what its config.sub knows; the NDK's clang wrapper is
+    #     `armv7a-linux-androideabi<api>-clang`. Using either name for
+    #     both fails -- one at configure, one at the first compile.
+    #   * **`-avoid-version`, or the library cannot be packaged.** libtool
+    #     would produce `libhamlib.so.4.0.7` with `libhamlib.so` a
+    #     symlink to it, and Android's packager takes only files named
+    #     exactly `lib*.so` from `libs/<abi>/` -- a versioned SONAME is
+    #     silently not installed, and the app then dies at `dlopen`
+    #     before reaching main. That is checked for below rather than
+    #     trusted, because libtool ignoring a flag it does not like
+    #     would otherwise surface as that same invisible failure.
+    #   * **The malloc probes have to be answered.** configure cannot run
+    #     what it just built, so `AC_FUNC_MALLOC` guesses "no" and
+    #     substitutes its own `rpl_malloc`, which does not exist here.
+    #
+    # Deliberately still `--enable-shared`: Hamlib is LGPL-2.1+ and the
+    # reasoning at the top of this file does not change because the
+    # target is a phone. An APK with a static Hamlib inside would carry
+    # the relinking obligation.
+    if(ANDROID)
+      if(NOT CMAKE_ANDROID_NDK)
+        message(FATAL_ERROR
+          "Hamlib for Android needs CMAKE_ANDROID_NDK. Configure through "
+          "Qt's android toolchain file, or set -DSSTVAE_BUILD_RIG=OFF.")
+      endif()
+      if(CMAKE_HOST_APPLE)
+        set(_ndk_host "darwin-x86_64")
+      elseif(CMAKE_HOST_WIN32)
+        set(_ndk_host "windows-x86_64")
+      else()
+        set(_ndk_host "linux-x86_64")
+      endif()
+      set(_ndk_bin "${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/${_ndk_host}/bin")
+
+      set(_hl_api "${CMAKE_SYSTEM_VERSION}")
+      if(NOT _hl_api)
+        set(_hl_api 29)  # the app's minSdk
+      endif()
+
+      if(CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
+        set(_hl_cc_triple "aarch64-linux-android")
+        set(_hl_triple "aarch64-linux-android")
+      elseif(CMAKE_ANDROID_ARCH_ABI STREQUAL "armeabi-v7a")
+        set(_hl_cc_triple "armv7a-linux-androideabi")
+        set(_hl_triple "arm-linux-androideabi")
+      elseif(CMAKE_ANDROID_ARCH_ABI STREQUAL "x86_64")
+        set(_hl_cc_triple "x86_64-linux-android")
+        set(_hl_triple "x86_64-linux-android")
+      elseif(CMAKE_ANDROID_ARCH_ABI STREQUAL "x86")
+        set(_hl_cc_triple "i686-linux-android")
+        set(_hl_triple "i686-linux-android")
+      else()
+        message(FATAL_ERROR
+          "Hamlib for Android: unknown ABI '${CMAKE_ANDROID_ARCH_ABI}'")
+      endif()
+
+      set(_hl_cc "${_ndk_bin}/${_hl_cc_triple}${_hl_api}-clang")
+      if(NOT EXISTS "${_hl_cc}")
+        message(FATAL_ERROR
+          "No NDK compiler at ${_hl_cc}.\n"
+          "The API level comes from CMAKE_SYSTEM_VERSION (${_hl_api}); the "
+          "NDK ships a wrapper per level, so an unsupported one is missing "
+          "rather than wrong.")
+      endif()
+
+      list(APPEND _hl_configure_args
+           "--host=${_hl_triple}"
+           "CC=${_hl_cc}"
+           "AR=${_ndk_bin}/llvm-ar"
+           "RANLIB=${_ndk_bin}/llvm-ranlib"
+           "STRIP=${_ndk_bin}/llvm-strip"
+           "LDFLAGS=-avoid-version"
+           "ac_cv_func_malloc_0_nonnull=yes"
+           "ac_cv_func_realloc_0_nonnull=yes")
+      message(STATUS
+        "Hamlib: cross-building for Android ${CMAKE_ANDROID_ARCH_ABI} "
+        "(API ${_hl_api})")
+    endif()
 
     # Cross-compiling to the other macOS architecture.
     #
@@ -227,6 +330,31 @@ else()
     endif()
   else()
     message(STATUS "Hamlib: reusing the build in ${_hl_root}")
+  endif()
+
+  # The `-avoid-version` check, asserted rather than assumed.
+  #
+  # A versioned SONAME here is not a cosmetic problem: Android's
+  # packager takes only files named exactly `lib*.so`, so
+  # `libhamlib.so.4` is dropped from the APK without comment and the app
+  # dies at `dlopen` before `main` -- the same shape of pre-main,
+  # no-output failure as the Windows import-library trap this file
+  # already records, and just as hard to tell from a deadlock.
+  if(ANDROID)
+    file(GLOB _hl_versioned "${_hl_root}/lib/libhamlib.so.[0-9]*")
+    if(_hl_versioned)
+      message(FATAL_ERROR
+        "Hamlib built with a versioned SONAME (${_hl_versioned}).\n"
+        "libtool did not honour -avoid-version, so this library cannot go "
+        "into an APK: Android installs only files named lib*.so and would "
+        "drop it silently, leaving a dlopen failure before main. Delete "
+        "${_hl_root} and fix the LDFLAGS before going further.")
+    endif()
+    if(IS_SYMLINK "${_hl_root}/lib/libhamlib.so")
+      message(FATAL_ERROR
+        "${_hl_root}/lib/libhamlib.so is a symlink; an APK needs the real "
+        "file under that name.")
+    endif()
   endif()
 endif()
 

--- a/native/cmake/hamlib.cmake
+++ b/native/cmake/hamlib.cmake
@@ -125,7 +125,25 @@ else()
   # Built once and stamped. ExternalProject would rebuild on every
   # configure of a fresh build directory even when the install tree is
   # already there, which is the common case with a warm CI cache.
-  if(NOT EXISTS "${_hl_root}/include/hamlib/rig.h")
+  #
+  # **The stamp is the library, not just the header.** `SUBDIRS` puts
+  # `include` second (Makefile.am:25), so `make install` copies
+  # `hamlib/rig.h` into the prefix long before it reaches `src` -- which
+  # means a build that fails anywhere after that leaves a tree this
+  # check would accept. The next configure then skips the rebuild
+  # entirely and fails much later with "Hamlib library not found",
+  # naming a path rather than the compile error that actually stopped
+  # it. Requiring both is what makes a failed build retry instead of
+  # cementing itself.
+  set(_hl_built FALSE)
+  if(EXISTS "${_hl_root}/include/hamlib/rig.h")
+    file(GLOB _hl_installed "${_hl_root}/lib/libhamlib*")
+    if(_hl_installed)
+      set(_hl_built TRUE)
+    endif()
+  endif()
+
+  if(NOT _hl_built)
     # Unpacking a tarball gives every file the same mtime, so make
     # cannot tell that `configure` is already newer than `configure.ac`
     # and tries to re-run aclocal -- which fails on any machine without
@@ -201,7 +219,8 @@ else()
     #     what it just built, so `AC_FUNC_MALLOC` guesses "no" and
     #     substitutes its own `rpl_malloc`, which does not exist here.
     #   * **`CC` alone is not enough**, and the Android sensor *rotator*
-    #     is what proves it -- see the configure arguments below.
+    #     is what proves it -- it is C++, it cannot be switched off, and
+    #     with no `CXX` the host g++ gets it. See the arguments below.
     #
     # Deliberately still `--enable-shared`: Hamlib is LGPL-2.1+ and the
     # reasoning at the top of this file does not change because the
@@ -321,18 +340,15 @@ else()
         set(_hl_cc "${_ndk_bin}/${_hl_cc_triple}${_hl_api}-clang")
       endif()
 
-      # **`CXX` as well as `CC`, even though nothing C++ should build.**
-      # Setting only `CC` is what produced the third failure here:
-      # configure found the cross compiler for C and then silently fell
-      # back to the *host* `g++` for C++, which got as far as
-      # `rotators/androidsensor` before dying on `-stdlib=libc++` -- a
-      # flag configure adds for every Android host, and one the host
-      # g++ has never heard of. With `ac_cv_header_android_sensor_h`
-      # below there is now no C++ left in the tree to compile, so this
-      # line does nothing today; it is here because a host compiler
-      # quietly standing in for a cross one is the failure mode, and it
-      # would come back the moment upstream adds a C++ file or somebody
-      # passes --with-indi.
+      # **`CXX` as well as `CC`, and it is load-bearing.** Setting only
+      # `CC` produced a failure late in the build: configure found the
+      # cross compiler for C and then silently fell back to the *host*
+      # `g++` for C++. Most of Hamlib is C, so it got all the way to
+      # `rotators/androidsensor` -- the one C++ directory, and one that
+      # cannot be switched off, see below -- before dying on
+      # `-stdlib=libc++`, a flag configure adds for every Android host
+      # and one the host g++ has never heard of. A host compiler quietly
+      # standing in for a cross one is the shape of this bug.
       set(_hl_cxx "${_ndk_bin}/${_hl_cc_triple}${_hl_api}-clang++")
 
       list(APPEND _hl_configure_args
@@ -343,21 +359,34 @@ else()
            "RANLIB=${_ndk_bin}/llvm-ranlib"
            "STRIP=${_ndk_bin}/llvm-strip"
            "ac_cv_func_malloc_0_nonnull=yes"
-           "ac_cv_func_realloc_0_nonnull=yes"
-           # **Skip the Android sensor rotator.** It is the only C++ in
-           # the tree we build, it is a *rotator* backend for pointing an
-           # antenna by the phone's own accelerometer, and this app does
-           # rig control -- so it is pure build time and a libc++
-           # dependency for something that can never be used here.
-           #
-           # There is no --without-androidsensor: upstream gates it on
-           # whether `android/sensor.h` exists (configure.ac:171), so the
-           # lever is autoconf's own cache, pre-seeded the same way the
-           # two malloc answers above are. `rot_reg.c:87` guards the
-           # registration with `#if HAVE_ANDROID_SENSOR`, so the backend
-           # drops out of the library cleanly rather than leaving a
-           # dangling reference.
-           "ac_cv_header_android_sensor_h=no")
+           "ac_cv_func_realloc_0_nonnull=yes")
+
+      # **The Android sensor rotator cannot be switched off, and it was
+      # tried.** It is a rotator backend that points an antenna by the
+      # phone's accelerometer -- no use whatever to this app, and the
+      # only C++ in the tree we build -- so `-DSSTVAE_ANDROID_API`'s
+      # neighbour here was briefly
+      # `ac_cv_header_android_sensor_h=no`, pre-seeding autoconf's cache
+      # to fail the check upstream gates it on (`configure.ac:171`).
+      #
+      # That does drop the directory from `ROT_BACKEND_LIST`. It also
+      # breaks the build, because `src/rot_reg.c` guards the backend's
+      # two halves on **different conditions**:
+      #
+      #   line  87: `#if HAVE_ANDROID_SENSOR`                 (declaration)
+      #   line 141: `#if defined(ANDROID) || defined(__ANDROID__)` (table entry)
+      #
+      # `__ANDROID__` is defined by the compiler and cannot be unset, so
+      # the table entry is unconditional on Android while the
+      # declaration is not. The two agree only when `HAVE_ANDROID_SENSOR`
+      # is true -- which upstream is entitled to assume, since a real NDK
+      # always has `android/sensor.h`. Answering "no" makes the file
+      # reference a function nobody declared.
+      #
+      # So it builds, and `CXX` above is what makes that work rather
+      # than a precaution. Do not reach for the cache override again
+      # without also solving line 141, which cannot be solved from
+      # outside the source.
       message(STATUS
         "Hamlib: cross-building for Android ${CMAKE_ANDROID_ARCH_ABI} "
         "(API ${_hl_api}, from ${_hl_api_from})")

--- a/native/cmake/hamlib.cmake
+++ b/native/cmake/hamlib.cmake
@@ -184,14 +184,19 @@ else()
     #     what its config.sub knows; the NDK's clang wrapper is
     #     `armv7a-linux-androideabi<api>-clang`. Using either name for
     #     both fails -- one at configure, one at the first compile.
-    #   * **`-avoid-version`, or the library cannot be packaged.** libtool
-    #     would produce `libhamlib.so.4.0.7` with `libhamlib.so` a
-    #     symlink to it, and Android's packager takes only files named
-    #     exactly `lib*.so` from `libs/<abi>/` -- a versioned SONAME is
-    #     silently not installed, and the app then dies at `dlopen`
-    #     before reaching main. That is checked for below rather than
-    #     trusted, because libtool ignoring a flag it does not like
-    #     would otherwise surface as that same invisible failure.
+    #   * **The library must come out unversioned, and the flag for that
+    #     is libtool's, not the linker's.** Otherwise libtool produces
+    #     `libhamlib.so.4.0.7` with `libhamlib.so` a symlink to it, and
+    #     Android's packager takes only files named exactly `lib*.so`
+    #     from `libs/<abi>/` -- a versioned SONAME is silently not
+    #     installed and the app dies at `dlopen` before reaching main.
+    #     `-avoid-version` is what suppresses it, and putting it in
+    #     `LDFLAGS` here is what the first attempt did: configure's very
+    #     first link test runs the compiler *directly*, clang rejects an
+    #     argument it has never heard of, and the whole thing stops at
+    #     "C compiler cannot create executables". It is applied at make
+    #     time instead, to the one automake variable that carries
+    #     `-version-info` -- see the build step below.
     #   * **The malloc probes have to be answered.** configure cannot run
     #     what it just built, so `AC_FUNC_MALLOC` guesses "no" and
     #     substitutes its own `rpl_malloc`, which does not exist here.
@@ -320,7 +325,6 @@ else()
            "AR=${_ndk_bin}/llvm-ar"
            "RANLIB=${_ndk_bin}/llvm-ranlib"
            "STRIP=${_ndk_bin}/llvm-strip"
-           "LDFLAGS=-avoid-version"
            "ac_cv_func_malloc_0_nonnull=yes"
            "ac_cv_func_realloc_0_nonnull=yes")
       message(STATUS
@@ -388,8 +392,32 @@ else()
     endif()
 
     message(STATUS "Hamlib: building with ${_hl_jobs} jobs")
+
+    # **`-avoid-version` belongs here, not in configure's LDFLAGS.** It
+    # is a libtool flag; configure's link test invokes the compiler
+    # directly, so putting it there stops the build at "C compiler
+    # cannot create executables" with the real reason two layers down in
+    # config.log.
+    #
+    # Overriding `libhamlib_la_LDFLAGS` rather than passing plain
+    # `LDFLAGS=-avoid-version` at make time, for two reasons that are
+    # not about libtool's precedence -- it copes with `-version-info`
+    # and `-avoid-version` together, and strips the version. First, a
+    # command-line `LDFLAGS` *replaces* the tree's, silently discarding
+    # anything configure computed. Second, it would reach every link in
+    # the tree, including the fifteen tool executables, where the flag
+    # means nothing. This names the one variable upstream puts
+    # `-version-info` in (`src/Makefile.am:24`) and substitutes for
+    # exactly that; `-no-undefined` is carried over from the same line
+    # because dropping it is not part of what is wanted here.
+    set(_hl_make_args "-j${_hl_jobs}")
+    if(ANDROID)
+      list(APPEND _hl_make_args
+           "libhamlib_la_LDFLAGS=-no-undefined -avoid-version")
+    endif()
+
     execute_process(
-      COMMAND make -j${_hl_jobs} install
+      COMMAND make ${_hl_make_args} install
       WORKING_DIRECTORY "${hamlib_src_BINARY_DIR}"
       RESULT_VARIABLE _hl_rc
       OUTPUT_FILE "${hamlib_src_BINARY_DIR}/build.log"

--- a/native/cmake/hamlib.cmake
+++ b/native/cmake/hamlib.cmake
@@ -200,6 +200,8 @@ else()
     #   * **The malloc probes have to be answered.** configure cannot run
     #     what it just built, so `AC_FUNC_MALLOC` guesses "no" and
     #     substitutes its own `rpl_malloc`, which does not exist here.
+    #   * **`CC` alone is not enough**, and the Android sensor *rotator*
+    #     is what proves it -- see the configure arguments below.
     #
     # Deliberately still `--enable-shared`: Hamlib is LGPL-2.1+ and the
     # reasoning at the top of this file does not change because the
@@ -319,14 +321,43 @@ else()
         set(_hl_cc "${_ndk_bin}/${_hl_cc_triple}${_hl_api}-clang")
       endif()
 
+      # **`CXX` as well as `CC`, even though nothing C++ should build.**
+      # Setting only `CC` is what produced the third failure here:
+      # configure found the cross compiler for C and then silently fell
+      # back to the *host* `g++` for C++, which got as far as
+      # `rotators/androidsensor` before dying on `-stdlib=libc++` -- a
+      # flag configure adds for every Android host, and one the host
+      # g++ has never heard of. With `ac_cv_header_android_sensor_h`
+      # below there is now no C++ left in the tree to compile, so this
+      # line does nothing today; it is here because a host compiler
+      # quietly standing in for a cross one is the failure mode, and it
+      # would come back the moment upstream adds a C++ file or somebody
+      # passes --with-indi.
+      set(_hl_cxx "${_ndk_bin}/${_hl_cc_triple}${_hl_api}-clang++")
+
       list(APPEND _hl_configure_args
            "--host=${_hl_triple}"
            "CC=${_hl_cc}"
+           "CXX=${_hl_cxx}"
            "AR=${_ndk_bin}/llvm-ar"
            "RANLIB=${_ndk_bin}/llvm-ranlib"
            "STRIP=${_ndk_bin}/llvm-strip"
            "ac_cv_func_malloc_0_nonnull=yes"
-           "ac_cv_func_realloc_0_nonnull=yes")
+           "ac_cv_func_realloc_0_nonnull=yes"
+           # **Skip the Android sensor rotator.** It is the only C++ in
+           # the tree we build, it is a *rotator* backend for pointing an
+           # antenna by the phone's own accelerometer, and this app does
+           # rig control -- so it is pure build time and a libc++
+           # dependency for something that can never be used here.
+           #
+           # There is no --without-androidsensor: upstream gates it on
+           # whether `android/sensor.h` exists (configure.ac:171), so the
+           # lever is autoconf's own cache, pre-seeded the same way the
+           # two malloc answers above are. `rot_reg.c:87` guards the
+           # registration with `#if HAVE_ANDROID_SENSOR`, so the backend
+           # drops out of the library cleanly rather than leaving a
+           # dangling reference.
+           "ac_cv_header_android_sensor_h=no")
       message(STATUS
         "Hamlib: cross-building for Android ${CMAKE_ANDROID_ARCH_ABI} "
         "(API ${_hl_api}, from ${_hl_api_from})")

--- a/native/core/rig/android/androidrig.cpp
+++ b/native/core/rig/android/androidrig.cpp
@@ -324,21 +324,36 @@ std::vector<SerialDevice> usb_devices() { return device_list("usbDevices"); }
 std::vector<SerialDevice> bluetooth_devices() { return device_list("bluetoothDevices"); }
 
 bool has_permission(const std::string& id) {
-    Env env;
-    jclass cls = env.bridge();
-    jmethodID m = env->GetStaticMethodID(cls, "hasPermission", "(Ljava/lang/String;)Z");
-    if (m == nullptr) {
-        env->ExceptionClear();
+    // **A query answers; an action reports.** This is read from a QML
+    // property binding, where a thrown exception terminates the
+    // process -- so "the layer is not initialised" and "the JNI call
+    // failed" both become false, which is the truthful answer to "may
+    // the app open this device right now" in either case. The
+    // enumerators below are the other half of the rule: they are called
+    // from an explicit refresh that catches and shows the message, so
+    // there they throw rather than return an empty list that reads as
+    // "nothing is plugged in".
+    if (!ready()) return false;
+    try {
+        Env env;
+        jclass cls = env.bridge();
+        jmethodID m = env->GetStaticMethodID(cls, "hasPermission",
+                                             "(Ljava/lang/String;)Z");
+        if (m == nullptr) {
+            env->ExceptionClear();
+            return false;
+        }
+        jstring s = env->NewStringUTF(id.c_str());
+        const jboolean ok = env->CallStaticBooleanMethod(cls, m, s);
+        env->DeleteLocalRef(s);
+        if (env->ExceptionCheck() != JNI_FALSE) {
+            env->ExceptionClear();
+            return false;
+        }
+        return ok != JNI_FALSE;
+    } catch (const std::exception&) {
         return false;
     }
-    jstring s = env->NewStringUTF(id.c_str());
-    const jboolean ok = env->CallStaticBooleanMethod(cls, m, s);
-    env->DeleteLocalRef(s);
-    if (env->ExceptionCheck() != JNI_FALSE) {
-        env->ExceptionClear();
-        return false;
-    }
-    return ok != JNI_FALSE;
 }
 
 void request_permission(const std::string& id) {

--- a/native/core/rig/android/androidrig.cpp
+++ b/native/core/rig/android/androidrig.cpp
@@ -1,0 +1,392 @@
+#include "rig/android/androidrig.hpp"
+
+#include <jni.h>
+
+#include <atomic>
+#include <mutex>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace sstvae::rig::android {
+namespace {
+
+constexpr const char* kBridge = "org/cleverdomain/sstvae/SerialBridge";
+
+JavaVM* g_vm = nullptr;
+jclass g_bridge = nullptr;
+
+std::mutex g_callback_mu;
+PermissionResult g_permission_callback;
+
+// Attach once per thread, detach when the thread ends.
+//
+// `core/audio/android/` attaches per *call*, which is right there:
+// control calls are rare and the data path runs the other way, with
+// Java calling an already-attached thread. Here the data path is ours
+// -- `LoopbackBridge`'s two pump threads call in continuously -- so a
+// per-call `AttachCurrentThread`/`DetachCurrentThread` pair would run
+// on every read timeout for the life of a session. A thread_local with
+// a destructor is what makes "attached for as long as this thread
+// exists" expressible.
+class ThreadEnv {
+public:
+    ThreadEnv() = default;
+    ~ThreadEnv() {
+        if (attached_ && g_vm != nullptr) g_vm->DetachCurrentThread();
+    }
+    ThreadEnv(const ThreadEnv&) = delete;
+    ThreadEnv& operator=(const ThreadEnv&) = delete;
+
+    JNIEnv* get() {
+        if (env_ != nullptr) return env_;
+        if (g_vm == nullptr) throw RigError("android rig: set_java_vm() was never called");
+        const jint rc = g_vm->GetEnv(reinterpret_cast<void**>(&env_), JNI_VERSION_1_6);
+        if (rc == JNI_EDETACHED) {
+            // As a daemon, so a pump thread that outlives an orderly
+            // shutdown cannot hold the VM open at exit -- the same
+            // reasoning as `RigController::stop()` detaching rather
+            // than joining.
+            if (g_vm->AttachCurrentThreadAsDaemon(&env_, nullptr) != JNI_OK) {
+                throw RigError("android rig: AttachCurrentThread failed");
+            }
+            attached_ = true;
+        } else if (rc != JNI_OK) {
+            throw RigError("android rig: GetEnv failed");
+        }
+        return env_;
+    }
+
+private:
+    JNIEnv* env_ = nullptr;
+    bool attached_ = false;
+};
+
+thread_local ThreadEnv t_env;
+
+struct Env {
+    JNIEnv* e;
+    Env() : e(t_env.get()) {}
+    JNIEnv* operator->() const { return e; }
+
+    jclass bridge() const {
+        // The cached global reference first: on a thread this library
+        // created it is the only thing that resolves, because
+        // `FindClass` there falls back to the system class loader.
+        if (g_bridge != nullptr) return g_bridge;
+        jclass c = e->FindClass(kBridge);
+        if (c == nullptr) {
+            e->ExceptionClear();
+            throw RigError(std::string("android rig: ") + kBridge + " not found");
+        }
+        return c;
+    }
+
+    // A Java exception left pending poisons the *next* unrelated JNI
+    // call, which is a long way from where it was raised. Every call
+    // below converts it here instead, keeping the Java message: it is
+    // the one that says "permission denied" or "device disconnected".
+    void rethrow(const char* what) const {
+        if (e->ExceptionCheck() == JNI_FALSE) return;
+        jthrowable ex = e->ExceptionOccurred();
+        e->ExceptionClear();
+        std::string detail;
+        if (ex != nullptr) {
+            jclass cls = e->GetObjectClass(ex);
+            jmethodID m = e->GetMethodID(cls, "getMessage", "()Ljava/lang/String;");
+            if (m != nullptr) {
+                auto s = static_cast<jstring>(e->CallObjectMethod(ex, m));
+                if (e->ExceptionCheck() != JNI_FALSE) e->ExceptionClear();
+                if (s != nullptr) {
+                    const char* c = e->GetStringUTFChars(s, nullptr);
+                    if (c != nullptr) {
+                        detail = c;
+                        e->ReleaseStringUTFChars(s, c);
+                    }
+                    e->DeleteLocalRef(s);
+                }
+            }
+            e->DeleteLocalRef(cls);
+            e->DeleteLocalRef(ex);
+        }
+        throw RigError(detail.empty() ? std::string(what) : detail);
+    }
+};
+
+std::string to_std(JNIEnv* env, jstring s) {
+    if (s == nullptr) return {};
+    const char* c = env->GetStringUTFChars(s, nullptr);
+    std::string out(c == nullptr ? "" : c);
+    if (c != nullptr) env->ReleaseStringUTFChars(s, c);
+    return out;
+}
+
+// Java returns each device as "id\tlabel\t0|1" -- one array rather than
+// three, so a device cannot be described by rows from two different
+// enumerations. Labels have tabs stripped on the Java side.
+std::vector<SerialDevice> device_list(const char* method) {
+    Env env;
+    jclass cls = env.bridge();
+    jmethodID m = env->GetStaticMethodID(cls, method, "()[Ljava/lang/String;");
+    if (m == nullptr) {
+        env->ExceptionClear();
+        throw RigError(std::string("android rig: no ") + method);
+    }
+    auto arr = static_cast<jobjectArray>(env->CallStaticObjectMethod(cls, m));
+    env.rethrow(method);
+
+    std::vector<SerialDevice> out;
+    if (arr == nullptr) return out;
+    const jsize n = env->GetArrayLength(arr);
+    out.reserve(static_cast<std::size_t>(n));
+    for (jsize i = 0; i < n; ++i) {
+        auto s = static_cast<jstring>(env->GetObjectArrayElement(arr, i));
+        const std::string row = to_std(env.e, s);
+        env->DeleteLocalRef(s);
+
+        const std::size_t a = row.find('\t');
+        if (a == std::string::npos) continue;
+        const std::size_t b = row.find('\t', a + 1);
+        SerialDevice d;
+        d.id = row.substr(0, a);
+        d.label = b == std::string::npos ? row.substr(a + 1) : row.substr(a + 1, b - a - 1);
+        d.permitted = b != std::string::npos && b + 1 < row.size() && row[b + 1] == '1';
+        out.push_back(std::move(d));
+    }
+    return out;
+}
+
+// --- the transport ----------------------------------------------------------
+
+class AndroidTransport : public SerialTransport {
+public:
+    explicit AndroidTransport(SerialParams params) : params_(std::move(params)) {}
+    ~AndroidTransport() override { close(); }
+
+    void open() override {
+        if (token_ >= 0) return;
+        Env env;
+        jclass cls = env.bridge();
+        jmethodID m = env->GetStaticMethodID(cls, "open", "(Ljava/lang/String;IIIII)I");
+        if (m == nullptr) {
+            env->ExceptionClear();
+            throw RigError("android rig: no SerialBridge.open");
+        }
+        jstring id = env->NewStringUTF(params_.device_id.c_str());
+        const jint token =
+            env->CallStaticIntMethod(cls, m, id, params_.baud, params_.data_bits,
+                                     params_.stop_bits, params_.parity, params_.flow);
+        env->DeleteLocalRef(id);
+        env.rethrow("could not open the serial device");
+        if (token < 0) throw RigError("could not open " + params_.device_id);
+        token_ = token;
+
+        // A buffer per transport, allocated once. `NewByteArray` on
+        // every read would be an allocation and a GC root twice a
+        // second for the life of a session.
+        jbyteArray local = env->NewByteArray(kBufferBytes);
+        if (local == nullptr) {
+            env->ExceptionClear();
+            close();
+            throw RigError("android rig: could not allocate a transfer buffer");
+        }
+        buffer_ = static_cast<jbyteArray>(env->NewGlobalRef(local));
+        env->DeleteLocalRef(local);
+    }
+
+    void close() noexcept override {
+        const int token = token_.exchange(-1);
+        try {
+            Env env;
+            if (token >= 0) {
+                jclass cls = env.bridge();
+                jmethodID m = env->GetStaticMethodID(cls, "close", "(I)V");
+                if (m != nullptr) env->CallStaticVoidMethod(cls, m, token);
+                env->ExceptionClear();
+            }
+            if (buffer_ != nullptr) {
+                env->DeleteGlobalRef(buffer_);
+                buffer_ = nullptr;
+            }
+        } catch (const std::exception&) {
+            // Nobody left to tell, as `SerialTransport::close` says.
+        }
+    }
+
+    std::size_t read(std::uint8_t* dst, std::size_t n, int timeout_ms) override {
+        const int token = token_.load();
+        if (token < 0) return 0;
+        Env env;
+        jclass cls = env.bridge();
+        jmethodID m = env->GetStaticMethodID(cls, "read", "(I[BII)I");
+        if (m == nullptr) {
+            env->ExceptionClear();
+            throw RigError("android rig: no SerialBridge.read");
+        }
+        const std::size_t cap = static_cast<std::size_t>(kBufferBytes);
+        const jint want = static_cast<jint>(n < cap ? n : cap);
+        const jint got = env->CallStaticIntMethod(cls, m, token, buffer_, want, timeout_ms);
+        env.rethrow("the serial device stopped answering");
+        // Negative means the link is gone; zero means an idle radio,
+        // which is not an error and must not be reported as one.
+        if (got < 0) throw RigError("the serial device went away");
+        if (got == 0) return 0;
+        env->GetByteArrayRegion(buffer_, 0, got, reinterpret_cast<jbyte*>(dst));
+        return static_cast<std::size_t>(got);
+    }
+
+    void write(const std::uint8_t* src, std::size_t n) override {
+        const int token = token_.load();
+        if (token < 0) throw RigError("the serial device is not open");
+        Env env;
+        jclass cls = env.bridge();
+        jmethodID m = env->GetStaticMethodID(cls, "write", "(I[BI)V");
+        if (m == nullptr) {
+            env->ExceptionClear();
+            throw RigError("android rig: no SerialBridge.write");
+        }
+        // A fresh array rather than the read buffer: reads and writes
+        // run on two different threads by `SerialTransport`'s contract,
+        // and sharing one would be a data race whose shape is a
+        // corrupted CAT command. CAT commands are a handful of bytes
+        // and this runs a few times a poll, so the allocation is not
+        // worth a second cached buffer and the lifetime rules to go
+        // with it.
+        std::size_t sent = 0;
+        while (sent < n) {
+            const std::size_t cap = static_cast<std::size_t>(kBufferBytes);
+            const std::size_t left = n - sent;
+            const jint chunk = static_cast<jint>(left < cap ? left : cap);
+            jbyteArray out = env->NewByteArray(chunk);
+            if (out == nullptr) {
+                env->ExceptionClear();
+                throw RigError("android rig: out of memory writing to the rig");
+            }
+            env->SetByteArrayRegion(out, 0, chunk,
+                                    reinterpret_cast<const jbyte*>(src + sent));
+            env->CallStaticVoidMethod(cls, m, token, out, chunk);
+            env->DeleteLocalRef(out);
+            env.rethrow("could not write to the serial device");
+            sent += static_cast<std::size_t>(chunk);
+        }
+    }
+
+    void set_dtr(bool on) override { set_line("setDtr", on); }
+    void set_rts(bool on) override { set_line("setRts", on); }
+
+    std::string description() const override { return params_.device_id; }
+
+private:
+    static constexpr jsize kBufferBytes = 512;
+
+    void set_line(const char* method, bool on) {
+        const int token = token_.load();
+        if (token < 0) throw RigError("the serial device is not open");
+        Env env;
+        jclass cls = env.bridge();
+        jmethodID m = env->GetStaticMethodID(cls, method, "(IZ)V");
+        if (m == nullptr) {
+            env->ExceptionClear();
+            throw RigError(std::string("android rig: no SerialBridge.") + method);
+        }
+        env->CallStaticVoidMethod(cls, m, token, static_cast<jboolean>(on));
+        env.rethrow("could not set a control line");
+    }
+
+    SerialParams params_;
+    std::atomic<int> token_{-1};
+    jbyteArray buffer_ = nullptr;
+};
+
+}  // namespace
+
+void set_java_vm(JavaVM_* vm) {
+    g_vm = reinterpret_cast<JavaVM*>(vm);
+    if (g_vm == nullptr || g_bridge != nullptr) return;
+    try {
+        Env env;
+        jclass local = env->FindClass(kBridge);
+        if (local != nullptr) {
+            g_bridge = static_cast<jclass>(env->NewGlobalRef(local));
+            env->DeleteLocalRef(local);
+        } else {
+            env->ExceptionClear();
+        }
+    } catch (const std::exception&) {
+        // Leave it null; `bridge()` falls back to FindClass, which is
+        // no worse than before this cache existed.
+    }
+}
+
+bool ready() { return g_vm != nullptr; }
+
+std::vector<SerialDevice> usb_devices() { return device_list("usbDevices"); }
+std::vector<SerialDevice> bluetooth_devices() { return device_list("bluetoothDevices"); }
+
+bool has_permission(const std::string& id) {
+    Env env;
+    jclass cls = env.bridge();
+    jmethodID m = env->GetStaticMethodID(cls, "hasPermission", "(Ljava/lang/String;)Z");
+    if (m == nullptr) {
+        env->ExceptionClear();
+        return false;
+    }
+    jstring s = env->NewStringUTF(id.c_str());
+    const jboolean ok = env->CallStaticBooleanMethod(cls, m, s);
+    env->DeleteLocalRef(s);
+    if (env->ExceptionCheck() != JNI_FALSE) {
+        env->ExceptionClear();
+        return false;
+    }
+    return ok != JNI_FALSE;
+}
+
+void request_permission(const std::string& id) {
+    Env env;
+    jclass cls = env.bridge();
+    jmethodID m = env->GetStaticMethodID(cls, "requestPermission", "(Ljava/lang/String;)V");
+    if (m == nullptr) {
+        env->ExceptionClear();
+        throw RigError("android rig: no SerialBridge.requestPermission");
+    }
+    jstring s = env->NewStringUTF(id.c_str());
+    env->CallStaticVoidMethod(cls, m, s);
+    env->DeleteLocalRef(s);
+    env.rethrow("could not ask for USB permission");
+}
+
+void set_permission_callback(PermissionResult callback) {
+    std::lock_guard<std::mutex> lock(g_callback_mu);
+    g_permission_callback = std::move(callback);
+}
+
+std::shared_ptr<SerialTransport> make_transport(const SerialParams& params) {
+    return std::make_shared<AndroidTransport>(params);
+}
+
+}  // namespace sstvae::rig::android
+
+extern "C" {
+
+JNIEXPORT void JNICALL Java_org_cleverdomain_sstvae_SerialBridge_nativePermissionResult(
+    JNIEnv* env, jclass, jstring jid, jboolean granted) {
+    std::string id;
+    if (jid != nullptr) {
+        const char* c = env->GetStringUTFChars(jid, nullptr);
+        if (c != nullptr) {
+            id = c;
+            env->ReleaseStringUTFChars(jid, c);
+        }
+    }
+    sstvae::rig::android::PermissionResult callback;
+    {
+        std::lock_guard<std::mutex> lock(sstvae::rig::android::g_callback_mu);
+        callback = sstvae::rig::android::g_permission_callback;
+    }
+    // Copied out and invoked outside the lock: the callback goes on to
+    // touch the UI, and holding a lock across that is how a settings
+    // screen ends up waiting on a broadcast receiver.
+    if (callback) callback(id, granted != JNI_FALSE);
+}
+
+}  // extern "C"

--- a/native/core/rig/android/androidrig.hpp
+++ b/native/core/rig/android/androidrig.hpp
@@ -1,0 +1,102 @@
+// USB and Bluetooth serial on Android, as a `rig::SerialTransport`.
+//
+// The Java half of this is `java/org/cleverdomain/sstvae/SerialBridge.java`;
+// this is the JNI shim in front of it. It is a **separate library**
+// (`SSTVAE_BUILD_ANDROIDRIG`), for the same reason `core/audio/qt/` and
+// `core/audio/android/` are: everything with logic in it -- the bridge,
+// the composition, the PTT routing, the line-setting resolution --
+// lives in `sstvae_core` and is tested against fakes on a desktop, and
+// what is left here is only the code that talks to the platform.
+//
+// **Why Java at all.** Android hands an unprivileged app no
+// `/dev/ttyUSB0`; USB serial goes through the USB host API, and the
+// standard library for the chip-level protocols is
+// `usb-serial-for-android` (MIT, FTDI/CP210x/CH34x/PL2303/CDC-ACM).
+// Bluetooth is an RFCOMM socket on the Serial Port Profile UUID, which
+// is also Java-only. There is no C API under either of them to reach
+// for instead.
+//
+// **Bonded Bluetooth devices only, deliberately.** Listing paired
+// devices needs `BLUETOOTH_CONNECT` and nothing else; *discovering*
+// them needs `BLUETOOTH_SCAN` and, before API 31, location permission,
+// which is a large ask for a screen whose whole job is to show the
+// radio the operator already paired in Settings. Pairing is the
+// system's job and it does it better.
+//
+// **The direction rule is the opposite of the audio layer's**, and that
+// is not an inconsistency. Audio is a stream with a thread pushing it,
+// so Java calls into C++ and never waits. A rig link is request and
+// response driven by `LoopbackBridge`'s pump threads, so C++ calls into
+// Java -- which means those threads must be attached, and attaching and
+// detaching per call would be two JNI transitions per idle wakeup.
+// `androidrig.cpp` attaches each calling thread once and detaches when
+// it exits.
+
+#ifndef SSTVAE_RIG_ANDROID_ANDROIDRIG_HPP
+#define SSTVAE_RIG_ANDROID_ANDROIDRIG_HPP
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rig/transport.hpp"
+
+namespace sstvae::rig::android {
+
+// Must be called once from the UI thread before anything else here,
+// exactly like `audio::android::set_java_vm` and for the same reason:
+// `FindClass` from a thread we created cannot see an application class,
+// so the class reference has to be taken on a thread that has the app's
+// loader on its stack.
+struct JavaVM_;
+void set_java_vm(JavaVM_* vm);
+bool ready();
+
+// One row of a device picker.
+struct SerialDevice {
+    // What goes in the config file. `usb:10c4:ea60` (vendor and product,
+    // lower-case hex, with `#N` appended for the second and later ports
+    // of a multi-port adapter) or `bt:00:11:22:33:44:55`.
+    //
+    // **Deliberately not the USB device node or the enumeration
+    // index**, either of which changes when the cable is replugged --
+    // and a rig setting that stops working after unplugging the radio is
+    // not a setting. The accepted cost is the same one the audio layer
+    // takes on device names: two identical adapters are indistinguishable
+    // and the first one wins.
+    std::string id;
+    std::string label;
+
+    // USB: whether the app already holds permission for it. Bluetooth:
+    // always true, since only bonded devices are listed. A device that
+    // is present but not permitted is worth showing -- it is the one the
+    // operator is about to grant.
+    bool permitted = false;
+};
+
+std::vector<SerialDevice> usb_devices();
+std::vector<SerialDevice> bluetooth_devices();
+
+// Whether the app may open `id` right now. Cheap, and safe to poll.
+bool has_permission(const std::string& id);
+
+// Ask the user. **Returns immediately**: this raises a system dialog,
+// so it must be called from the UI thread and the answer arrives later
+// through the callback below. Nothing here blocks on a human.
+void request_permission(const std::string& id);
+
+// Called from whichever thread Android delivers the broadcast on --
+// which is the main thread in practice, but do not rely on it.
+using PermissionResult = std::function<void(const std::string& id, bool granted)>;
+void set_permission_callback(PermissionResult callback);
+
+// The transport itself. Construction is cheap and does not touch the
+// device; `open()` does, and throws `RigError` if it cannot -- which is
+// what puts every blocking operation on the rig worker thread, where
+// `RigController` requires it.
+std::shared_ptr<SerialTransport> make_transport(const SerialParams& params);
+
+}  // namespace sstvae::rig::android
+
+#endif

--- a/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
+++ b/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
@@ -1,0 +1,640 @@
+package org.cleverdomain.sstvae;
+
+import android.Manifest;
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothManager;
+import android.bluetooth.BluetoothSocket;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbManager;
+import android.os.Build;
+import android.util.Log;
+
+import com.hoho.android.usbserial.driver.UsbSerialDriver;
+import com.hoho.android.usbserial.driver.UsbSerialPort;
+import com.hoho.android.usbserial.driver.UsbSerialProber;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The Java half of {@code core/rig/android/}: a serial link to a radio, over
+ * USB or Bluetooth.
+ *
+ * <p><b>Direction rule, and it is the opposite of {@link AudioBridge}'s.</b>
+ * Audio is a stream, so Java owns a thread and pushes into C++. A rig link is
+ * request and response, driven by {@code LoopbackBridge}'s pump threads, so
+ * C++ calls in here. The one exception is the USB permission result, which
+ * arrives on a broadcast receiver and goes out through {@code
+ * nativePermissionResult}.
+ *
+ * <p><b>Device identifiers are vendor and product, never the device node.</b>
+ * {@code UsbDevice.getDeviceName()} is {@code /dev/bus/usb/001/007} and changes
+ * on every replug, so a setting keyed on it stops working the first time the
+ * operator unplugs the radio. {@code usb:10c4:ea60} survives, with {@code #N}
+ * for the second and later ports of a multi-port adapter. Two identical
+ * adapters are indistinguishable and the first wins — the same accepted
+ * ambiguity the audio layer takes on device names.
+ *
+ * <p>Call {@link #init} once with an application context before anything else.
+ */
+public final class SerialBridge {
+
+    private static final String TAG = "sstvae";
+
+    /**
+     * Our own permission-result action.
+     *
+     * <p>Package-qualified rather than something generic because it is
+     * broadcast to ourselves and nothing else has any business seeing it.
+     */
+    private static final String ACTION_GRANT_USB = "org.cleverdomain.sstvae.USB_PERMISSION";
+
+    /** The Serial Port Profile. The one UUID every RFCOMM radio answers on. */
+    private static final UUID SPP = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB");
+
+    private static final int REQUEST_BLUETOOTH_CONNECT = 1002;
+
+    /** How long a CAT command may take to reach the radio before it is a fault. */
+    private static final int WRITE_TIMEOUT_MS = 2000;
+
+    private static Context context;
+    private static BroadcastReceiver receiver;
+    private static final AtomicInteger nextToken = new AtomicInteger(1);
+    private static final Map<Integer, Link> links = new ConcurrentHashMap<>();
+
+    private SerialBridge() {}
+
+    public static void init(Context appContext) {
+        context = appContext.getApplicationContext();
+        registerReceiver();
+    }
+
+    // --- permission -------------------------------------------------------
+
+    private static void registerReceiver() {
+        if (receiver != null) return;
+        receiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context c, Intent intent) {
+                if (!ACTION_GRANT_USB.equals(intent.getAction())) return;
+                final boolean granted =
+                        intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false);
+                final UsbDevice device = usbExtra(intent);
+                nativePermissionResult(device == null ? "" : usbId(device, 0), granted);
+            }
+        };
+        final IntentFilter filter = new IntentFilter(ACTION_GRANT_USB);
+        if (Build.VERSION.SDK_INT >= 33) {
+            // Required from API 33 up, and the app targets 36. The
+            // broadcast is ours to ourselves, so NOT_EXPORTED is both the
+            // safe answer and the correct one.
+            context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(receiver, filter);
+        }
+    }
+
+    /**
+     * {@code EXTRA_DEVICE}, without the API 33 deprecation warning.
+     *
+     * <p>The untyped {@code getParcelableExtra} still works on 33+ and is what
+     * every example uses, but the app targets 36 and a deprecated call in a
+     * file nobody looks at is how a removal gets discovered by a build break.
+     */
+    @SuppressWarnings("deprecation")
+    private static UsbDevice usbExtra(Intent intent) {
+        if (Build.VERSION.SDK_INT >= 33) {
+            return intent.getParcelableExtra(UsbManager.EXTRA_DEVICE, UsbDevice.class);
+        }
+        return intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+    }
+
+    static boolean hasPermission(String id) {
+        if (id == null) return false;
+        if (id.startsWith("bt:")) return bluetoothPermitted();
+        final UsbManager manager = usbManager();
+        if (manager == null) return false;
+        final UsbDevice device = findUsbDevice(id);
+        return device != null && manager.hasPermission(device);
+    }
+
+    static void requestPermission(String id) {
+        if (id == null) return;
+        if (id.startsWith("bt:")) {
+            requestBluetoothPermission();
+            return;
+        }
+        final UsbManager manager = usbManager();
+        final UsbDevice device = findUsbDevice(id);
+        if (manager == null || device == null) {
+            nativePermissionResult(id, false);
+            return;
+        }
+        // **Three things here are Android 14 requirements, not style.**
+        // A mutable PendingIntent may not carry an implicit intent, so
+        // the intent names our own package; the USB framework has to be
+        // able to fill in EXTRA_DEVICE, so it cannot be immutable
+        // either. Getting this wrong throws at the moment the operator
+        // taps the device, which is a long way from where it is written.
+        final Intent intent = new Intent(ACTION_GRANT_USB).setPackage(context.getPackageName());
+        final int flags = Build.VERSION.SDK_INT >= 31
+                ? PendingIntent.FLAG_MUTABLE
+                : 0;
+        manager.requestPermission(device, PendingIntent.getBroadcast(context, 0, intent, flags));
+    }
+
+    private static boolean bluetoothPermitted() {
+        // BLUETOOTH_CONNECT became a runtime permission at API 31. Below
+        // that the manifest permission is enough and there is nothing to
+        // ask for.
+        if (Build.VERSION.SDK_INT < 31) return true;
+        return context != null
+                && context.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT)
+                        == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private static void requestBluetoothPermission() {
+        if (bluetoothPermitted()) {
+            nativePermissionResult("bt:", true);
+            return;
+        }
+        // Needs an Activity, and `context` is deliberately the
+        // *application* context, so it has to be fetched. The result
+        // comes back through onRequestPermissionsResult, which Qt owns;
+        // rather than reach into that, the settings screen re-reads
+        // `hasPermission` when it regains focus.
+        final Activity activity = currentActivity();
+        if (activity == null) {
+            nativePermissionResult("bt:", false);
+            return;
+        }
+        activity.requestPermissions(
+                new String[] {Manifest.permission.BLUETOOTH_CONNECT},
+                REQUEST_BLUETOOTH_CONNECT);
+    }
+
+    /**
+     * Qt's activity, which is not the application context this class was
+     * given. Reflection because Qt's bindings are not a compile-time
+     * dependency of this layer, and adding one would tie the rig transport to
+     * a toolkit it has nothing to do with.
+     */
+    private static Activity currentActivity() {
+        try {
+            final Class<?> qt = Class.forName("org.qtproject.qt.android.QtNative");
+            final Object activity = qt.getMethod("activity").invoke(null);
+            return activity instanceof Activity ? (Activity) activity : null;
+        } catch (Exception e) {
+            Log.w(TAG, "no Qt activity for a permission request: " + e);
+            return null;
+        }
+    }
+
+    // --- enumeration ------------------------------------------------------
+    //
+    // One string per device rather than parallel arrays: "id\tlabel\t0|1".
+    // Three arrays could be returned out of step with each other and a device
+    // would then be described by another device's row.
+
+    static String[] usbDevices() {
+        final UsbManager manager = usbManager();
+        final List<String> out = new ArrayList<>();
+        if (manager == null) return new String[0];
+        for (UsbSerialDriver driver : UsbSerialProber.getDefaultProber()
+                .findAllDrivers(manager)) {
+            final UsbDevice device = driver.getDevice();
+            final boolean permitted = manager.hasPermission(device);
+            final int ports = driver.getPorts().size();
+            for (int i = 0; i < ports; i++) {
+                final StringBuilder label = new StringBuilder(describe(device));
+                if (ports > 1) label.append(" port ").append(i + 1);
+                out.add(usbId(device, i) + "\t" + clean(label.toString()) + "\t"
+                        + (permitted ? "1" : "0"));
+            }
+        }
+        return out.toArray(new String[0]);
+    }
+
+    static String[] bluetoothDevices() {
+        if (!bluetoothPermitted()) return new String[0];
+        final BluetoothAdapter adapter = bluetoothAdapter();
+        if (adapter == null) return new String[0];
+        final List<String> out = new ArrayList<>();
+        try {
+            // **Bonded devices only.** Discovery needs BLUETOOTH_SCAN and,
+            // before API 31, location permission — a large ask for a list
+            // whose whole content is the radio the operator already paired
+            // in system Settings.
+            final Collection<BluetoothDevice> bonded = adapter.getBondedDevices();
+            if (bonded == null) return new String[0];
+            for (BluetoothDevice device : bonded) {
+                final String name = device.getName();
+                final String label = (name == null || name.isEmpty())
+                        ? device.getAddress()
+                        : name + " (" + device.getAddress() + ")";
+                out.add("bt:" + device.getAddress() + "\t" + clean(label) + "\t1");
+            }
+        } catch (SecurityException e) {
+            // The permission was revoked between the check and the call.
+            return new String[0];
+        }
+        return out.toArray(new String[0]);
+    }
+
+    private static String describe(UsbDevice device) {
+        String product = null;
+        String manufacturer = null;
+        try {
+            product = device.getProductName();
+            manufacturer = device.getManufacturerName();
+        } catch (SecurityException e) {
+            // Some names need permission we do not have yet; the ids
+            // below are always readable and are what identifies it.
+        }
+        if (product != null && !product.trim().isEmpty()) {
+            if (manufacturer != null && !manufacturer.trim().isEmpty()) {
+                return manufacturer.trim() + " " + product.trim();
+            }
+            return product.trim();
+        }
+        return String.format(Locale.US, "USB %04x:%04x",
+                device.getVendorId(), device.getProductId());
+    }
+
+    /** Tabs are the field separator, so they cannot appear inside a field. */
+    private static String clean(String s) {
+        return s.replace('\t', ' ').replace('\n', ' ');
+    }
+
+    private static String usbId(UsbDevice device, int port) {
+        final String base = String.format(Locale.US, "usb:%04x:%04x",
+                device.getVendorId(), device.getProductId());
+        return port == 0 ? base : base + "#" + port;
+    }
+
+    private static int usbPortIndex(String id) {
+        final int hash = id.indexOf('#');
+        if (hash < 0) return 0;
+        try {
+            return Integer.parseInt(id.substring(hash + 1));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private static UsbDevice findUsbDevice(String id) {
+        final UsbManager manager = usbManager();
+        if (manager == null || id == null || !id.startsWith("usb:")) return null;
+        final int hash = id.indexOf('#');
+        final String base = hash < 0 ? id : id.substring(0, hash);
+        for (UsbDevice device : manager.getDeviceList().values()) {
+            if (usbId(device, 0).equals(base)) return device;
+        }
+        return null;
+    }
+
+    private static UsbManager usbManager() {
+        if (context == null) return null;
+        return (UsbManager) context.getSystemService(Context.USB_SERVICE);
+    }
+
+    private static BluetoothAdapter bluetoothAdapter() {
+        if (context == null) return null;
+        final BluetoothManager manager =
+                (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+        return manager == null ? null : manager.getAdapter();
+    }
+
+    // --- links ------------------------------------------------------------
+
+    /** What both transports have in common, which is all C++ ever sees. */
+    private interface Link {
+        /** Bytes read, 0 on timeout, -1 if the link is gone. */
+        int read(byte[] dest, int length, int timeoutMs) throws IOException;
+
+        void write(byte[] src, int length) throws IOException;
+
+        void setDtr(boolean on) throws IOException;
+
+        void setRts(boolean on) throws IOException;
+
+        void close();
+    }
+
+    static int open(String id, int baud, int dataBits, int stopBits, int parity, int flow)
+            throws IOException {
+        if (context == null) throw new IOException("SerialBridge.init was never called");
+        final Link link = id != null && id.startsWith("bt:")
+                ? openBluetooth(id)
+                : openUsb(id, baud, dataBits, stopBits, parity, flow);
+        final int token = nextToken.getAndIncrement();
+        links.put(token, link);
+        return token;
+    }
+
+    static void close(int token) {
+        final Link link = links.remove(token);
+        if (link != null) link.close();
+    }
+
+    static int read(int token, byte[] dest, int length, int timeoutMs) throws IOException {
+        final Link link = links.get(token);
+        if (link == null) return -1;
+        return link.read(dest, length, timeoutMs);
+    }
+
+    static void write(int token, byte[] src, int length) throws IOException {
+        final Link link = links.get(token);
+        if (link == null) throw new IOException("the serial link is closed");
+        link.write(src, length);
+    }
+
+    static void setDtr(int token, boolean on) throws IOException {
+        final Link link = links.get(token);
+        if (link == null) throw new IOException("the serial link is closed");
+        link.setDtr(on);
+    }
+
+    static void setRts(int token, boolean on) throws IOException {
+        final Link link = links.get(token);
+        if (link == null) throw new IOException("the serial link is closed");
+        link.setRts(on);
+    }
+
+    // --- USB --------------------------------------------------------------
+
+    private static Link openUsb(String id, int baud, int dataBits, int stopBits, int parity,
+                                int flow) throws IOException {
+        final UsbManager manager = usbManager();
+        if (manager == null) throw new IOException("no USB service");
+        final UsbDevice device = findUsbDevice(id);
+        if (device == null) throw new IOException("no such USB device: " + id);
+        if (!manager.hasPermission(device)) {
+            // Deliberately not a permission request: this runs on the rig
+            // worker thread, and a system dialog needs the UI thread and
+            // an answer from a human. The settings screen asks; this only
+            // reports.
+            throw new IOException("no permission for " + id + " — grant it in Settings");
+        }
+        final UsbSerialDriver driver = UsbSerialProber.getDefaultProber().probeDevice(device);
+        if (driver == null) throw new IOException("no serial driver for " + id);
+        final int index = usbPortIndex(id);
+        if (index >= driver.getPorts().size()) {
+            throw new IOException("no port " + index + " on " + id);
+        }
+        final UsbSerialPort port = driver.getPorts().get(index);
+        final UsbDeviceConnection connection = manager.openDevice(device);
+        if (connection == null) {
+            // The common cause on a composite audio+serial interface: the
+            // platform's own driver has the device. Say so, because the
+            // operator's next move is a different cable, not a different
+            // setting.
+            throw new IOException("could not open " + id
+                    + " — another driver may hold it");
+        }
+        port.open(connection);
+        try {
+            port.setParameters(baud, dataBits, stopBits, toParity(parity));
+            applyFlowControl(port, flow);
+        } catch (IOException | UnsupportedOperationException e) {
+            port.close();
+            throw new IOException("could not configure " + id + ": " + e.getMessage());
+        }
+        return new UsbLink(port);
+    }
+
+    private static int toParity(int parity) {
+        switch (parity) {
+            case 1: return UsbSerialPort.PARITY_ODD;
+            case 2: return UsbSerialPort.PARITY_EVEN;
+            default: return UsbSerialPort.PARITY_NONE;
+        }
+    }
+
+    private static void applyFlowControl(UsbSerialPort port, int flow) {
+        final UsbSerialPort.FlowControl want;
+        switch (flow) {
+            case 1: want = UsbSerialPort.FlowControl.RTS_CTS; break;
+            case 2: want = UsbSerialPort.FlowControl.XON_XOFF; break;
+            default: want = UsbSerialPort.FlowControl.NONE; break;
+        }
+        try {
+            // **Not fatal if the chip cannot do it.** Only some drivers
+            // implement hardware handshaking, and the alternative to
+            // carrying on is refusing to talk to a radio that would have
+            // worked — CAT is a few bytes at a time and almost never
+            // needs flow control at all.
+            if (want == UsbSerialPort.FlowControl.NONE
+                    || port.getSupportedFlowControl().contains(want)) {
+                port.setFlowControl(want);
+            } else {
+                Log.w(TAG, "flow control " + want + " unsupported; leaving it off");
+            }
+        } catch (IOException | UnsupportedOperationException e) {
+            Log.w(TAG, "could not set flow control: " + e);
+        }
+    }
+
+    private static final class UsbLink implements Link {
+        private final UsbSerialPort port;
+        private volatile boolean closed;
+
+        UsbLink(UsbSerialPort port) {
+            this.port = port;
+        }
+
+        @Override
+        public int read(byte[] dest, int length, int timeoutMs) throws IOException {
+            if (closed) return -1;
+            try {
+                // The library honours the timeout itself (a bulk transfer
+                // with a deadline), so no reader thread is needed here —
+                // unlike Bluetooth below, whose streams have none.
+                return port.read(dest, length, timeoutMs);
+            } catch (IOException e) {
+                if (closed) return -1;
+                throw e;
+            } catch (IllegalStateException e) {
+                // What the library raises when the device is unplugged
+                // mid-read. Not an IOException, and an uncaught one here
+                // would come out of JNI as a crash rather than a rig
+                // error.
+                return -1;
+            }
+        }
+
+        @Override
+        public void write(byte[] src, int length) throws IOException {
+            if (closed) throw new IOException("the serial link is closed");
+            port.write(src, length, WRITE_TIMEOUT_MS);
+        }
+
+        @Override
+        public void setDtr(boolean on) throws IOException {
+            port.setDTR(on);
+        }
+
+        @Override
+        public void setRts(boolean on) throws IOException {
+            port.setRTS(on);
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+            try {
+                port.close();
+            } catch (IOException | RuntimeException e) {
+                Log.w(TAG, "closing the USB port: " + e);
+            }
+        }
+    }
+
+    // --- Bluetooth --------------------------------------------------------
+
+    private static Link openBluetooth(String id) throws IOException {
+        if (!bluetoothPermitted()) {
+            throw new IOException("no Bluetooth permission — grant it in Settings");
+        }
+        final BluetoothAdapter adapter = bluetoothAdapter();
+        if (adapter == null) throw new IOException("no Bluetooth adapter");
+        final String address = id.substring(3);
+        final BluetoothDevice device;
+        try {
+            device = adapter.getRemoteDevice(address);
+        } catch (IllegalArgumentException e) {
+            throw new IOException("not a Bluetooth address: " + address);
+        }
+        try {
+            // Discovery is expensive and slows a connection down badly if
+            // it happens to be running; cancelling is what every RFCOMM
+            // example does and it costs nothing when it is not.
+            adapter.cancelDiscovery();
+            final BluetoothSocket socket = device.createRfcommSocketToServiceRecord(SPP);
+            socket.connect();
+            return new BluetoothLink(socket);
+        } catch (SecurityException e) {
+            throw new IOException("no Bluetooth permission — grant it in Settings");
+        }
+    }
+
+    /**
+     * RFCOMM, with a reader thread because {@code InputStream} has no timeout.
+     *
+     * <p>{@code BluetoothSocket}'s input stream blocks indefinitely and offers
+     * nothing to bound it, so the timeout has to come from somewhere else: a
+     * thread doing the blocking read and a queue with a poll deadline. That is
+     * the same shape as the audio layer's capture thread, and for the same
+     * reason — the blocking read belongs on a thread that is allowed to block.
+     */
+    private static final class BluetoothLink implements Link {
+        private final BluetoothSocket socket;
+        private final OutputStream out;
+        private final LinkedBlockingQueue<byte[]> queue = new LinkedBlockingQueue<>();
+        private final Thread reader;
+        private volatile boolean closed;
+        private byte[] leftover;
+        private int leftoverAt;
+
+        BluetoothLink(BluetoothSocket socket) throws IOException {
+            this.socket = socket;
+            this.out = socket.getOutputStream();
+            final InputStream in = socket.getInputStream();
+            reader = new Thread(() -> {
+                final byte[] buf = new byte[512];
+                while (!closed) {
+                    try {
+                        final int n = in.read(buf);
+                        if (n < 0) break;
+                        if (n == 0) continue;
+                        final byte[] chunk = new byte[n];
+                        System.arraycopy(buf, 0, chunk, 0, n);
+                        queue.add(chunk);
+                    } catch (IOException e) {
+                        break;
+                    }
+                }
+                closed = true;
+                // Wake a reader waiting on the queue rather than making it
+                // sit out its timeout to discover the link is gone.
+                queue.add(new byte[0]);
+            }, "sstvae-bt-rig");
+            reader.setDaemon(true);
+            reader.start();
+        }
+
+        @Override
+        public int read(byte[] dest, int length, int timeoutMs) throws IOException {
+            if (leftover == null) {
+                if (closed && queue.isEmpty()) return -1;
+                final byte[] chunk;
+                try {
+                    chunk = queue.poll(timeoutMs, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return 0;
+                }
+                if (chunk == null) return 0;            // an idle radio
+                if (chunk.length == 0) return -1;       // the reader gave up
+                leftover = chunk;
+                leftoverAt = 0;
+            }
+            final int n = Math.min(length, leftover.length - leftoverAt);
+            System.arraycopy(leftover, leftoverAt, dest, 0, n);
+            leftoverAt += n;
+            if (leftoverAt >= leftover.length) leftover = null;
+            return n;
+        }
+
+        @Override
+        public void write(byte[] src, int length) throws IOException {
+            if (closed) throw new IOException("the Bluetooth link is closed");
+            out.write(src, 0, length);
+            out.flush();
+        }
+
+        @Override
+        public void setDtr(boolean on) throws IOException {
+            throw new IOException("Bluetooth has no DTR line — use CAT or VOX for PTT");
+        }
+
+        @Override
+        public void setRts(boolean on) throws IOException {
+            throw new IOException("Bluetooth has no RTS line — use CAT or VOX for PTT");
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+            try {
+                // Closing is what unblocks the reader thread's read(): it
+                // has no timeout of its own, so nothing else would.
+                socket.close();
+            } catch (IOException | RuntimeException e) {
+                Log.w(TAG, "closing the Bluetooth socket: " + e);
+            }
+        }
+    }
+
+    private static native void nativePermissionResult(String id, boolean granted);
+}

--- a/native/core/rig/bridge.cpp
+++ b/native/core/rig/bridge.cpp
@@ -1,0 +1,365 @@
+#include "rig/bridge.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <mutex>
+#include <utility>
+
+#ifdef _WIN32
+// Confined to this file on purpose. <winsock2.h> pulls in <windows.h>,
+// whose `min`/`max` macros turn every later `std::max` into a syntax
+// error -- the trap CLAUDE.md records from `check.hpp`. Nothing here is
+// exposed through bridge.hpp.
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
+#  include <winsock2.h>
+#  include <ws2tcpip.h>
+#else
+#  include <arpa/inet.h>
+#  include <netinet/in.h>
+#  include <netinet/tcp.h>
+#  include <poll.h>
+#  include <sys/socket.h>
+#  include <unistd.h>
+#endif
+
+namespace sstvae::rig {
+namespace {
+
+#ifdef _WIN32
+using socket_t = SOCKET;
+using poll_fd = WSAPOLLFD;
+
+int poll_sockets(poll_fd* fds, unsigned n, int timeout_ms) {
+    return ::WSAPoll(fds, n, timeout_ms);
+}
+void close_socket(socket_t s) { ::closesocket(s); }
+int socket_errno() { return ::WSAGetLastError(); }
+constexpr int kShutBoth = SD_BOTH;
+
+// Winsock has to be started before any of it works, and nothing else in
+// this process does it -- Qt's networking is not linked here and the
+// Android build never reaches this branch.
+void init_sockets() {
+    static std::once_flag once;
+    std::call_once(once, [] {
+        WSADATA data;
+        ::WSAStartup(MAKEWORD(2, 2), &data);
+    });
+}
+#else
+using socket_t = int;
+using poll_fd = struct pollfd;
+
+int poll_sockets(poll_fd* fds, unsigned n, int timeout_ms) {
+    return ::poll(fds, n, timeout_ms);
+}
+void close_socket(socket_t s) { ::close(s); }
+int socket_errno() { return errno; }
+constexpr int kShutBoth = SHUT_RDWR;
+void init_sockets() {}
+#endif
+
+constexpr std::intptr_t kNoFd = -1;
+
+socket_t as_socket(std::intptr_t v) { return static_cast<socket_t>(v); }
+std::intptr_t as_handle(socket_t s) { return static_cast<std::intptr_t>(s); }
+
+std::string socket_error_text(const char* what) {
+    return std::string(what) + " failed (errno " + std::to_string(socket_errno()) + ")";
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+
+bool is_network_device(const std::string& device) {
+    // Hamlib's `parse_hoststr` (src/misc.c), rule for rule. The
+    // exclusions are the whole of it: a path, a Windows COM port, or an
+    // escaped UNC-style COM port is a serial device, and **everything
+    // else is a network address** -- including a bare hostname with no
+    // colon and no port, which is the part that surprises people. That
+    // is genuinely how Hamlib reads it (the final branch accepts a
+    // one-conversion `%255[^:]` match), and matching it is the point:
+    // disagreeing here means the app opens a bridge Hamlib will not
+    // connect to, or dials a hostname while a radio sits idle.
+    if (device.empty()) return false;
+    if (device.find('/') != std::string::npos) return false;
+    if (device.find("\\.\\") != std::string::npos) return false;
+    if (device.size() >= 3) {
+        std::string head = device.substr(0, 3);
+        std::transform(head.begin(), head.end(), head.begin(),
+                       [](unsigned char c) { return static_cast<char>(::tolower(c)); });
+        if (head == "com") return false;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+
+LoopbackBridge::LoopbackBridge(std::shared_ptr<SerialTransport> transport)
+    : transport_(std::move(transport)) {
+    if (!transport_) throw RigError("bridge: no transport");
+}
+
+LoopbackBridge::~LoopbackBridge() { stop(); }
+
+void LoopbackBridge::start() {
+    init_sockets();
+
+    // The transport first: if the cable is gone there is no point
+    // holding a port open, and this is the failure an operator most
+    // needs named.
+    transport_->open();
+
+    socket_t listener = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (listener == static_cast<socket_t>(kNoFd)) {
+        transport_->close();
+        throw RigError(socket_error_text("bridge: socket"));
+    }
+
+    // **127.0.0.1, never INADDR_ANY.** The far end of this is an
+    // unauthenticated path to a transmitter; anything that can reach
+    // the port can key the radio. Port 0 asks the kernel for an
+    // ephemeral one, so there is nothing fixed to scan for either.
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+
+    auto give_up = [&](const char* what) {
+        close_socket(listener);
+        transport_->close();
+        throw RigError(socket_error_text(what));
+    };
+
+    if (::bind(listener, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        give_up("bridge: bind");
+    }
+    if (::listen(listener, 1) != 0) give_up("bridge: listen");
+
+    sockaddr_in bound{};
+#ifdef _WIN32
+    int len = static_cast<int>(sizeof(bound));
+#else
+    socklen_t len = sizeof(bound);
+#endif
+    if (::getsockname(listener, reinterpret_cast<sockaddr*>(&bound), &len) != 0) {
+        give_up("bridge: getsockname");
+    }
+
+    const int port = ntohs(bound.sin_port);
+    listen_fd_.store(as_handle(listener));
+    port_.store(port);
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        endpoint_ = "127.0.0.1:" + std::to_string(port);
+    }
+
+    stopping_.store(false);
+    in_ = std::thread([this] { pump_in(); });
+    out_ = std::thread([this] { pump_out(); });
+}
+
+std::string LoopbackBridge::endpoint() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return endpoint_;
+}
+
+int LoopbackBridge::port() const { return port_.load(); }
+
+bool LoopbackBridge::connected() const { return connected_.load(); }
+
+std::string LoopbackBridge::last_error() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return error_;
+}
+
+void LoopbackBridge::set_error(const std::string& what) {
+    std::lock_guard<std::mutex> lock(mu_);
+    // First one wins: the first failure is the cause and everything
+    // after it is the consequence, which is the wrong thing to show an
+    // operator.
+    if (error_.empty()) error_ = what;
+}
+
+void LoopbackBridge::stop() noexcept {
+    // **No early return on "already stopping".** A pump thread sets
+    // `stopping_` itself when the far end hangs up, so by the time the
+    // owner calls stop() the flag is routinely already true -- and an
+    // early return there would skip closing the listener and the
+    // transport, leaking a descriptor and a USB claim for every session
+    // that ended by itself rather than by request. Everything below is
+    // written to be idempotent instead; `stop_mu_` is only here because
+    // joining one thread from two callers at once is undefined.
+    std::lock_guard<std::mutex> once(stop_mu_);
+    {
+        // Under `mu_`, not merely atomic: `pump_out` waits on `cv_` with
+        // this predicate, so setting it outside the lock loses the
+        // wakeup when the store lands between its test and its wait.
+        std::lock_guard<std::mutex> lock(mu_);
+        stopping_.store(true);
+    }
+    cv_.notify_all();
+
+    // Wake pump_in out of recv/accept. `shutdown` rather than a bare
+    // close, because closing a descriptor another thread is blocked on
+    // is not portable: the fd number can be reused before the blocked
+    // call notices, and then the wakeup lands on a stranger.
+    const std::intptr_t client = client_fd_.load();
+    if (client != kNoFd) ::shutdown(as_socket(client), kShutBoth);
+
+    // Wake pump_out out of a blocked read. This is the contract; the
+    // read timeout is only the backstop for a transport that ignores it.
+    if (transport_) transport_->close();
+
+    if (in_.joinable()) in_.join();
+    if (out_.joinable()) out_.join();
+
+    // Only once nobody can be inside them.
+    const std::intptr_t listener = listen_fd_.exchange(kNoFd);
+    if (listener != kNoFd) close_socket(as_socket(listener));
+    const std::intptr_t c = client_fd_.exchange(kNoFd);
+    if (c != kNoFd) close_socket(as_socket(c));
+    connected_.store(false);
+}
+
+void LoopbackBridge::pump_in() {
+    const socket_t listener = as_socket(listen_fd_.load());
+
+    // Accept with a deadline rather than a blocking accept, so that a
+    // caller who builds a bridge and then fails before opening the rig
+    // does not leave this thread parked for the life of the process.
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::duration<double>(BRIDGE_ACCEPT_TIMEOUT_S);
+    socket_t client = static_cast<socket_t>(kNoFd);
+    while (!stopping_.load()) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+            set_error("bridge: nothing connected");
+            break;
+        }
+        poll_fd pfd{};
+        pfd.fd = listener;
+        pfd.events = POLLIN;
+        const int rc = poll_sockets(&pfd, 1, 100);
+        if (rc < 0) {
+            if (socket_errno() == EINTR) continue;
+            set_error(socket_error_text("bridge: poll"));
+            break;
+        }
+        if (rc == 0) continue;
+        client = ::accept(listener, nullptr, nullptr);
+        if (client == static_cast<socket_t>(kNoFd)) {
+            if (stopping_.load()) break;
+            set_error(socket_error_text("bridge: accept"));
+            break;
+        }
+        break;
+    }
+
+    if (client == static_cast<socket_t>(kNoFd)) {
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            stopping_.store(true);
+        }
+        cv_.notify_all();
+        return;
+    }
+
+    // **Nagle off.** CAT is a stream of very short writes that each
+    // expect a reply, which is precisely the traffic Nagle delays: it
+    // would hold a 4-byte command back waiting for more to send, and
+    // the symptom is a radio that reads as slow or intermittent rather
+    // than as a socket option.
+    int one = 1;
+    ::setsockopt(client, IPPROTO_TCP, TCP_NODELAY,
+                 reinterpret_cast<const char*>(&one), sizeof(one));
+
+    client_fd_.store(as_handle(client));
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        connected_.store(true);
+    }
+    cv_.notify_all();
+
+    std::array<std::uint8_t, 512> buf{};
+    while (!stopping_.load()) {
+        const auto n = ::recv(client, reinterpret_cast<char*>(buf.data()),
+                              static_cast<int>(buf.size()), 0);
+        if (n == 0) break;  // Hamlib closed the rig; the session is over.
+        if (n < 0) {
+            if (socket_errno() == EINTR) continue;
+            if (!stopping_.load()) set_error(socket_error_text("bridge: recv"));
+            break;
+        }
+        try {
+            transport_->write(buf.data(), static_cast<std::size_t>(n));
+        } catch (const std::exception& e) {
+            set_error(std::string("bridge: write to rig: ") + e.what());
+            break;
+        }
+    }
+
+    // One direction ending ends the session: a half-open bridge would
+    // let a poll succeed against a link that can no longer answer.
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        connected_.store(false);
+        stopping_.store(true);
+    }
+    cv_.notify_all();
+}
+
+void LoopbackBridge::pump_out() {
+    {
+        std::unique_lock<std::mutex> lock(mu_);
+        cv_.wait(lock, [this] { return connected_.load() || stopping_.load(); });
+    }
+
+    std::array<std::uint8_t, 512> buf{};
+    while (!stopping_.load()) {
+        std::size_t n = 0;
+        try {
+            n = transport_->read(buf.data(), buf.size(), BRIDGE_READ_TIMEOUT_MS);
+        } catch (const std::exception& e) {
+            if (!stopping_.load()) set_error(std::string("bridge: read from rig: ") + e.what());
+            break;
+        }
+        if (n == 0) continue;  // An idle radio, not a failure.
+
+        const std::intptr_t handle = client_fd_.load();
+        if (handle == kNoFd) break;
+        const socket_t client = as_socket(handle);
+
+        std::size_t sent = 0;
+        while (sent < n) {
+            const auto wrote = ::send(client,
+                                      reinterpret_cast<const char*>(buf.data() + sent),
+                                      static_cast<int>(n - sent), 0);
+            if (wrote <= 0) {
+                if (wrote < 0 && socket_errno() == EINTR) continue;
+                if (!stopping_.load()) set_error(socket_error_text("bridge: send"));
+                sent = n;  // give up on this block
+                stopping_.store(true);
+                break;
+            }
+            sent += static_cast<std::size_t>(wrote);
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        stopping_.store(true);
+    }
+    cv_.notify_all();
+}
+
+}  // namespace sstvae::rig

--- a/native/core/rig/bridge.hpp
+++ b/native/core/rig/bridge.hpp
@@ -1,0 +1,157 @@
+// A serial transport, presented to Hamlib as a socket it can connect to.
+//
+// `transport.hpp` explains why this works: Hamlib turns any backend
+// into a network client when its pathname parses as `host:port`, so the
+// whole of `native/cmake/hamlib.cmake`'s pinned radio list is reachable
+// over a socket. This is the socket. It binds a listener on loopback,
+// waits for exactly one connection, and pumps bytes between it and the
+// transport for as long as the session lasts.
+//
+// **Loopback only, and that is a security property rather than a
+// default.** The far end of this socket is an unauthenticated path to
+// somebody's transmitter: anything that can connect can key it. So the
+// bind address is `127.0.0.1` explicitly, never `INADDR_ANY`, and the
+// port is ephemeral rather than well-known so it is not a thing to
+// scan for. On Android the app sandbox is a second layer, but this file
+// also builds and runs on the desktop, where it is the only one.
+//
+// **One connection, then done.** Hamlib's `network_open` connects once
+// per `rig_open`, so a disconnect means the session is over -- and
+// re-accepting would mean the pump-out thread having to hand its
+// descriptor over mid-flight, which is a race in exchange for a case
+// that does not arise. A `RigController` reconfigure builds a new
+// backend and therefore a new bridge.
+//
+// **A thread per direction, not one thread polling both.** The
+// alternative -- `poll()` the socket briefly, then read the transport
+// briefly, forever -- costs tens of wakeups a second doing nothing on a
+// device where a listening session is measured in hours of battery.
+// Two threads that each block cost none. What it buys is paid for by
+// `SerialTransport`'s threading contract, which both Android transports
+// satisfy for free.
+
+#ifndef SSTVAE_RIG_BRIDGE_HPP
+#define SSTVAE_RIG_BRIDGE_HPP
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "rig/transport.hpp"
+
+namespace sstvae::rig {
+
+// How long a blocked transport read waits before looking at the stop
+// flag again.
+//
+// The primary way a read is woken is `SerialTransport::close()`, which
+// the contract requires -- this is the backstop for a transport that
+// does not honour it, so that a shutdown is bounded rather than
+// indefinite. Same shape as `tx::PttWatchdog`: the scope guard is the
+// mechanism, the independent timer is for when the mechanism does not
+// run. Long enough that an idle link wakes twice a second and no more.
+inline constexpr int BRIDGE_READ_TIMEOUT_MS = 500;
+
+// How long to wait for Hamlib to connect after `start()`.
+//
+// It connects within a millisecond or two in practice: `rig_open` is
+// called immediately after, on the same thread that just read
+// `endpoint()`. This bound exists so that a caller who builds a bridge
+// and then fails before opening the rig does not leave a thread parked
+// forever.
+inline constexpr double BRIDGE_ACCEPT_TIMEOUT_S = 30.0;
+
+class LoopbackBridge {
+public:
+    explicit LoopbackBridge(std::shared_ptr<SerialTransport> transport);
+
+    // Stops and joins. Safe with the pump running.
+    ~LoopbackBridge();
+
+    LoopbackBridge(const LoopbackBridge&) = delete;
+    LoopbackBridge& operator=(const LoopbackBridge&) = delete;
+
+    // Bind, listen, and start pumping. The transport is opened here,
+    // on the calling thread, so a device that cannot be acquired fails
+    // before anything else is built -- and it fails on the rig worker,
+    // which is the only thread allowed to block on hardware.
+    //
+    // Throws RigError. Binding and listening happen *before* this
+    // returns, so `endpoint()` is valid the moment it does.
+    void start();
+
+    // "127.0.0.1:54321" -- what to hand Hamlib as the rig pathname.
+    // Empty before `start()`.
+    std::string endpoint() const;
+    int port() const;
+
+    // Idempotent, and safe to call from a thread other than the one
+    // that started it.
+    void stop() noexcept;
+
+    // Whether the pump is still carrying traffic. False before a client
+    // connects and after either side goes away -- so a caller polling
+    // this can tell a rig that hung up from one that is merely quiet.
+    bool connected() const;
+
+    // Why the pump stopped, empty if it has not. Reported rather than
+    // thrown: it happens on a pump thread, where there is no call to
+    // fail.
+    std::string last_error() const;
+
+private:
+    void pump_in();   // socket -> transport
+    void pump_out();  // transport -> socket
+    void set_error(const std::string& what);
+
+    std::shared_ptr<SerialTransport> transport_;
+
+    // `intptr_t` rather than a platform socket type so this header
+    // stays free of <winsock2.h>, which drags in <windows.h> and its
+    // `min` and `max` macros -- CLAUDE.md's rule about never letting
+    // that into a widely-included header. Windows' `SOCKET` is a
+    // `UINT_PTR`, so this is the one integer type that round-trips it
+    // on both platforms; -1 is the sentinel, which is also what
+    // `INVALID_SOCKET` casts to. The .cpp does the conversion in one
+    // place.
+    std::atomic<std::intptr_t> listen_fd_{-1};
+    std::atomic<std::intptr_t> client_fd_{-1};
+    std::atomic<int> port_{0};
+
+    std::atomic<bool> stopping_{false};
+    std::atomic<bool> connected_{false};
+
+    mutable std::mutex mu_;
+    // Serialises stop() against itself. Only that: joining one thread
+    // from two callers at once is undefined, and the destructor and a
+    // caller's explicit stop() are two callers.
+    mutable std::mutex stop_mu_;
+    std::condition_variable cv_;
+    std::string error_;
+    std::string endpoint_;
+
+    std::thread in_;
+    std::thread out_;
+};
+
+// Whether Hamlib will read `device` as a network address rather than a
+// serial port -- **the same question `parse_hoststr()` in Hamlib's
+// `src/misc.c` answers**, and deliberately the same answer.
+//
+// It matters because the two decisions have to agree. If the app
+// concludes "this is a device, open a transport and bridge it" while
+// Hamlib concludes "this is a hostname", the operator gets a connection
+// attempt to a machine that does not exist while a perfectly good radio
+// sits idle -- and the reverse leaves a bridge nobody connects to. The
+// rules are Hamlib's, not ours: anything containing `/` is a path,
+// anything starting `com` is a Windows port, an escaped `\\.\COM3` is
+// one too, and what is left needs a colon with a number after it.
+bool is_network_device(const std::string& device);
+
+}  // namespace sstvae::rig
+
+#endif

--- a/native/core/rig/bridged.cpp
+++ b/native/core/rig/bridged.cpp
@@ -1,0 +1,156 @@
+#include "rig/bridged.hpp"
+
+#include <utility>
+
+namespace sstvae::rig {
+namespace {
+
+class BridgedBackend : public RigBackend {
+public:
+    BridgedBackend(HamlibConfig config, std::shared_ptr<SerialTransport> transport,
+                   BackendFactory make_inner)
+        : config_(std::move(config)),
+          transport_(std::move(transport)),
+          make_inner_(std::move(make_inner)) {}
+
+    ~BridgedBackend() override { close(); }
+
+    void open() override {
+        HamlibConfig inner_config = config_;
+
+        bridge_ = std::make_unique<LoopbackBridge>(transport_);
+        bridge_->start();  // opens the transport too; throws RigError
+        inner_config.device = bridge_->endpoint();
+
+        // **Hamlib must not be asked to key a control line here.**
+        // `ser_set_dtr` is a `TIOCMSET` ioctl and the descriptor it
+        // holds is a socket, so the call fails and the radio never
+        // keys. `Vox` is the value that means "do not key at all"
+        // (hamlib.cpp maps it to ptt_type "None"), which is exactly
+        // right: something else -- us, below -- is doing it.
+        const bool line_ptt = ptt_uses_control_line(config_.ptt_method);
+        if (line_ptt) inner_config.ptt_method = PttMethod::Vox;
+
+        // The serial-line tokens go the same way. `serial_speed`,
+        // `data_bits`, `dtr_state` and the rest are applied by Hamlib's
+        // `serial_open`, which a network port never reaches -- so
+        // setting them would be silently doing nothing. The transport
+        // owns the line settings, and applied them in its own `open()`.
+        try {
+            park_control_lines(line_ptt);
+            inner_ = make_inner_(inner_config);
+            if (!inner_) throw RigError("no rig backend was built");
+            inner_->open();
+        } catch (...) {
+            inner_.reset();
+            bridge_.reset();  // stops the pump and closes the transport
+            throw;
+        }
+    }
+
+    void close() noexcept override {
+        if (inner_) {
+            inner_->close();
+            inner_.reset();
+        }
+        // After the inner backend, never before: Hamlib's `rig_close`
+        // may write a last command (some backends restore the mode they
+        // changed), and pulling the bridge out from under it would turn
+        // an orderly close into a broken pipe on the way out.
+        bridge_.reset();
+    }
+
+    void set_ptt(bool on) override {
+        if (ptt_uses_control_line(config_.ptt_method)) {
+            if (!transport_) throw RigError("no transport to key");
+            if (config_.ptt_method == PttMethod::Dtr) {
+                transport_->set_dtr(on);
+            } else {
+                transport_->set_rts(on);
+            }
+            return;
+        }
+        require_inner();
+        inner_->set_ptt(on);
+    }
+
+    double frequency_hz() override {
+        require_inner();
+        return inner_->frequency_hz();
+    }
+
+    std::string description() const override {
+        std::string text = inner_ ? inner_->description() : std::string("rig");
+        if (transport_) {
+            const std::string via = transport_->description();
+            if (!via.empty()) text += " via " + via;
+        }
+        return text;
+    }
+
+private:
+    void require_inner() const {
+        if (!inner_) throw RigError("the rig is not open");
+    }
+
+    // Interfaces that steal their power from a control line need it
+    // held for the whole session, which is what `LineState` is for on
+    // the desktop. Over a socket Hamlib cannot do it, so it happens
+    // here.
+    void park_control_lines(bool line_ptt) {
+        if (!transport_) return;
+        const bool dtr_is_ptt = line_ptt && config_.ptt_method == PttMethod::Dtr;
+        const bool rts_is_ptt = line_ptt && config_.ptt_method == PttMethod::Rts;
+
+        // A parked state on the line that keys the radio would be a
+        // transmitter held on from the moment the session opens. The
+        // PTT line is parked unkeyed instead, whatever the setting
+        // says.
+        if (dtr_is_ptt) {
+            transport_->set_dtr(false);
+        } else if (config_.dtr == LineState::High) {
+            transport_->set_dtr(true);
+        } else if (config_.dtr == LineState::Low) {
+            transport_->set_dtr(false);
+        }
+
+        if (rts_is_ptt) {
+            transport_->set_rts(false);
+        } else if (config_.rts == LineState::High) {
+            transport_->set_rts(true);
+        } else if (config_.rts == LineState::Low) {
+            transport_->set_rts(false);
+        }
+    }
+
+    HamlibConfig config_;
+    std::shared_ptr<SerialTransport> transport_;
+    BackendFactory make_inner_;
+    std::unique_ptr<LoopbackBridge> bridge_;
+    std::unique_ptr<RigBackend> inner_;
+};
+
+}  // namespace
+
+std::unique_ptr<RigBackend> make_bridged_backend(
+    HamlibConfig config, std::shared_ptr<SerialTransport> transport,
+    BackendFactory make_inner) {
+    if (!make_inner) throw RigError("make_bridged_backend: no backend factory");
+
+    // No transport: the operator chose a network rig. Hamlib opens the
+    // socket itself, for model 2 and for a native backend alike, and
+    // there is nothing to add -- wrapping it would only put two of our
+    // threads in the path of a socket Hamlib is perfectly able to open.
+    if (!transport) {
+        if (!is_network_device(config.device)) {
+            throw RigError("'" + config.device +
+                           "' is not an address Hamlib will dial, and no device "
+                           "was opened for it");
+        }
+        return make_inner(config);
+    }
+    return std::make_unique<BridgedBackend>(std::move(config), std::move(transport),
+                                            std::move(make_inner));
+}
+
+}  // namespace sstvae::rig

--- a/native/core/rig/bridged.cpp
+++ b/native/core/rig/bridged.cpp
@@ -132,6 +132,61 @@ private:
 
 }  // namespace
 
+SerialParams resolve_serial_params(const HamlibConfig& config,
+                                   const SerialDefaults& defaults) {
+    SerialParams params;
+    params.device_id = config.device;
+    params.baud = config.baud > 0 ? config.baud : defaults.baud;
+
+    switch (config.data_bits) {
+        case DataBits::Seven: params.data_bits = 7; break;
+        case DataBits::Eight: params.data_bits = 8; break;
+        case DataBits::Default: params.data_bits = defaults.data_bits; break;
+    }
+    switch (config.stop_bits) {
+        case StopBits::One: params.stop_bits = 1; break;
+        case StopBits::Two: params.stop_bits = 2; break;
+        case StopBits::Default: params.stop_bits = defaults.stop_bits; break;
+    }
+    switch (config.parity) {
+        case Parity::None: params.parity = SerialParams::kNoParity; break;
+        case Parity::Odd: params.parity = SerialParams::kOdd; break;
+        case Parity::Even: params.parity = SerialParams::kEven; break;
+        case Parity::Default: params.parity = defaults.parity; break;
+    }
+    switch (config.handshake) {
+        case Handshake::None: params.flow = SerialParams::kNoFlow; break;
+        case Handshake::XonXoff: params.flow = SerialParams::kXonXoff; break;
+        case Handshake::Hardware: params.flow = SerialParams::kRtsCts; break;
+        case Handshake::Default: params.flow = defaults.flow; break;
+    }
+
+    // Hamlib's three -RIG_ECONF cases, re-derived because its own are
+    // unreachable for a network port. Each one is a setting that cannot
+    // do what it says: the flow-control driver and the PTT code would be
+    // driving the same wire.
+    const bool rts_held = config.rts != LineState::Default;
+    const bool dtr_held = config.dtr != LineState::Default;
+    if (rts_held && params.flow == SerialParams::kRtsCts) {
+        throw RigError("RTS cannot be held at a fixed level while hardware "
+                       "handshaking is using it");
+    }
+    if (config.ptt_method == PttMethod::Rts) {
+        if (params.flow == SerialParams::kRtsCts) {
+            throw RigError("PTT by RTS cannot share the line with hardware "
+                           "handshaking");
+        }
+        if (rts_held) {
+            throw RigError("PTT by RTS cannot share the line with a fixed RTS "
+                           "level");
+        }
+    }
+    if (config.ptt_method == PttMethod::Dtr && dtr_held) {
+        throw RigError("PTT by DTR cannot share the line with a fixed DTR level");
+    }
+    return params;
+}
+
 std::unique_ptr<RigBackend> make_bridged_backend(
     HamlibConfig config, std::shared_ptr<SerialTransport> transport,
     BackendFactory make_inner) {

--- a/native/core/rig/bridged.hpp
+++ b/native/core/rig/bridged.hpp
@@ -82,6 +82,21 @@ std::unique_ptr<RigBackend> make_bridged_backend(
     HamlibConfig config, std::shared_ptr<SerialTransport> transport,
     BackendFactory make_inner);
 
+// Turn a `HamlibConfig` into the line settings a transport has to be
+// given, filling every `Default` from what that Hamlib backend would
+// have used (`rig::serial_defaults`, in `sstvae_rig`).
+//
+// **It also carries Hamlib's control-line conflict checks, and it has
+// to.** `rig_open` refuses -RIG_ECONF for RTS held with hardware
+// handshake, for RTS held while PTT keys by RTS, and for DTR held while
+// PTT keys by DTR -- but all three sit inside `if (rp->type.rig ==
+// RIG_PORT_SERIAL)`, so on the bridged path they never run. Losing them
+// would mean a configuration that a desktop refuses at connect time
+// silently producing a radio that will not key on a phone. Throws
+// RigError with the pair named.
+SerialParams resolve_serial_params(const HamlibConfig& config,
+                                   const SerialDefaults& defaults);
+
 // Whether keying this configuration drives a control line rather than
 // sending a CAT command. Exposed because the app has to know: it is the
 // difference between a PTT that works over Bluetooth and one that

--- a/native/core/rig/bridged.hpp
+++ b/native/core/rig/bridged.hpp
@@ -1,0 +1,95 @@
+// A rig reached through a `SerialTransport` instead of a serial port.
+//
+// This is the piece that makes `docs/android.md`'s "no CAT on Android"
+// wrong. It composes three things that each already work:
+//
+//   * a `SerialTransport` -- USB or Bluetooth, from Java (transport.hpp)
+//   * a `LoopbackBridge` -- that transport as a socket (bridge.hpp)
+//   * whatever `RigBackend` the caller's factory builds, pointed at
+//     that socket's address rather than at a device path
+//
+// The result is an ordinary `RigBackend`, so `RigController` -- one
+// worker, PTT as priority work, `stop()` that detaches -- is used
+// unchanged, and so is every radio Hamlib knows.
+//
+// **Two jobs, and only two.** Hand the inner backend a loopback
+// endpoint in place of a device, and key DTR/RTS on the transport
+// rather than through Hamlib. Everything else about a rig -- the model,
+// the timeouts, reading frequency, CAT PTT, putting the radio into
+// PKT-USB on connect -- goes straight through, because it is all just
+// bytes on the link and the link is the only thing that changed.
+//
+// **The factory is a seam for the same reason `rx::Decoder` is.** It
+// keeps this file in `sstvae_core`, so the composition, the PTT
+// routing and the no-bridge shortcut are all tested in a build with no
+// libhamlib at all (`native/tests/test_rig_bridged.cpp`, against a stub
+// inner backend). `native/tests/test_rig_hamlib.cpp` is the complement
+// that holds the real thing.
+
+#ifndef SSTVAE_RIG_BRIDGED_HPP
+#define SSTVAE_RIG_BRIDGED_HPP
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "rig/backend.hpp"
+#include "rig/bridge.hpp"
+#include "rig/hamlib.hpp"
+#include "rig/transport.hpp"
+
+namespace sstvae::rig {
+
+// Builds the backend that actually talks to Hamlib, given a config
+// whose `device` has been rewritten to point wherever it should.
+//
+// `rig/hamlib.hpp` is included above for `HamlibConfig` alone -- that
+// header declares plain structs and three free functions and pulls in
+// nothing from libhamlib, which is what lets `sstvae_core` name the
+// configuration type without linking the implementation of it.
+using BackendFactory =
+    std::function<std::unique_ptr<RigBackend>(const HamlibConfig&)>;
+
+// Wrap `transport` and hand the result to `make_inner`.
+//
+// **The presence of a transport is the decision, not the shape of the
+// device string.** The first draft sniffed `config.device` with
+// `is_network_device` and branched on that, which is wrong in a way
+// worth recording: an app-level device identifier like
+// `usb:1a86:7523` contains no slash and does not start with `com`, so
+// Hamlib's own rules read it as a *hostname* -- and the bridge was
+// skipped for exactly the devices it exists to serve. The caller
+// already knows which the operator picked, because a picker offered
+// them the choice; a heuristic can only guess, and has to guess on a
+// string that was never a device path to begin with.
+//
+// So: no transport means the operator chose a network rig, and Hamlib
+// dials `config.device` itself -- one code path covering both model 2
+// (NET rigctl, sharing a radio with a station PC) and a native backend
+// pointed at a ser2net-style server, because in Hamlib they *are* one
+// code path. A transport means the operator chose a USB or Bluetooth
+// device, and `config.device` is replaced by the bridge's loopback
+// address.
+//
+// `is_network_device` survives as the *validation* of that choice: with
+// no transport, a device Hamlib will not read as a host is refused here
+// rather than becoming a failed connection later.
+//
+// Throws RigError for a combination that cannot work, at build time
+// rather than at `open()`, because it is a programming error rather
+// than an operating one.
+std::unique_ptr<RigBackend> make_bridged_backend(
+    HamlibConfig config, std::shared_ptr<SerialTransport> transport,
+    BackendFactory make_inner);
+
+// Whether keying this configuration drives a control line rather than
+// sending a CAT command. Exposed because the app has to know: it is the
+// difference between a PTT that works over Bluetooth and one that
+// cannot.
+inline bool ptt_uses_control_line(PttMethod method) {
+    return method == PttMethod::Dtr || method == PttMethod::Rts;
+}
+
+}  // namespace sstvae::rig
+
+#endif

--- a/native/core/rig/hamlib.cpp
+++ b/native/core/rig/hamlib.cpp
@@ -297,6 +297,55 @@ std::vector<RigModel> list_models() {
     return models;
 }
 
+SerialDefaults serial_defaults(int model) {
+    load_backends_once();
+
+    struct Search {
+        int model;
+        SerialDefaults out;
+        bool found = false;
+    } search{model, SerialDefaults{}, false};
+
+    // `rig_list_foreach` rather than a `RIG*`: there is no
+    // `rig_get_caps_int` token for the serial fields, and reading them
+    // out of an initialised RIG would mean dereferencing a pointer whose
+    // struct carries pthread members -- the thing CLAUDE.md forbids on
+    // Windows. `struct rig_caps` has none, which is why it is the one
+    // Hamlib struct this file reads through.
+    rig_list_foreach(
+        [](const struct rig_caps* caps, rig_ptr_t data) -> int {
+            auto* s = static_cast<Search*>(data);
+            if (static_cast<int>(caps->rig_model) != s->model) return 1;
+            s->found = true;
+            // `serial_rate_max`, not a mean or a minimum: `rig_init`
+            // takes the default from that field and its own comment
+            // says "fastest !". Matching it is the whole point -- a
+            // different choice here would make a bridged rig run at a
+            // different speed than the same rig on a desktop.
+            if (caps->serial_rate_max > 0) s->out.baud = caps->serial_rate_max;
+            if (caps->serial_data_bits > 0) s->out.data_bits = caps->serial_data_bits;
+            if (caps->serial_stop_bits > 0) s->out.stop_bits = caps->serial_stop_bits;
+            switch (caps->serial_parity) {
+                case RIG_PARITY_ODD: s->out.parity = SerialParams::kOdd; break;
+                case RIG_PARITY_EVEN: s->out.parity = SerialParams::kEven; break;
+                default: s->out.parity = SerialParams::kNoParity; break;
+            }
+            switch (caps->serial_handshake) {
+                case RIG_HANDSHAKE_HARDWARE: s->out.flow = SerialParams::kRtsCts; break;
+                case RIG_HANDSHAKE_XONXOFF: s->out.flow = SerialParams::kXonXoff; break;
+                default: s->out.flow = SerialParams::kNoFlow; break;
+            }
+            return 0;  // stop
+        },
+        &search);
+
+    // A model Hamlib does not know is a configuration the operator has
+    // to fix anyway, and `rig_init` will refuse it a moment later with a
+    // better message than this function could give. 9600 8-N-1 rather
+    // than throwing, so a settings screen can still render.
+    return search.out;
+}
+
 std::unique_ptr<RigBackend> make_hamlib_backend(const HamlibConfig& config) {
     return std::make_unique<HamlibBackend>(config);
 }

--- a/native/core/rig/hamlib.hpp
+++ b/native/core/rig/hamlib.hpp
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include "rig/backend.hpp"
+#include "rig/transport.hpp"
 
 namespace sstvae::rig {
 
@@ -122,6 +123,21 @@ struct HamlibConfig {
 };
 
 std::unique_ptr<RigBackend> make_hamlib_backend(const HamlibConfig& config);
+
+// What this backend would have set a serial port to, had it been given
+// one.
+//
+// Read straight out of `struct rig_caps`, which is where `rig_init`
+// takes them from -- including the deliberate choice of
+// `serial_rate_max` ("fastest!") as the default rate. It exists for the
+// bridged path, where Hamlib never touches the hardware and so cannot
+// apply them itself; see `SerialParams` in `rig/transport.hpp`.
+//
+// `rig_caps` is the one Hamlib struct this project reads through, for
+// the reason `description()` records: it has no pthread members, so the
+// Windows shim's type sizes cannot silently misplace its fields.
+// Falls back to 9600 8-N-1 for a model Hamlib does not know.
+SerialDefaults serial_defaults(int model);
 
 // Hamlib's version string, for an about box or a bug report.
 std::string hamlib_version();

--- a/native/core/rig/transport.hpp
+++ b/native/core/rig/transport.hpp
@@ -58,6 +58,43 @@ namespace sstvae::rig {
 // out a read timeout. `set_dtr`/`set_rts` may overlap a read or a
 // write: on USB they are control transfers, on a separate endpoint
 // from the data.
+// The line settings a transport actually has to be given.
+//
+// **Not the same shape as `HamlibConfig`'s, and the difference is the
+// point.** There, `Default` means *do not set the token* and leave the
+// backend's own value -- right for almost every rig, and the reason
+// those are enums with a Default member rather than guesses at 8-N-1.
+// Over a socket that promise cannot be kept by inaction: Hamlib applies
+// its per-rig defaults in `serial_open`, which a network port never
+// reaches, so a transport given nothing would run at whatever the USB
+// chip powered up with. `bridged.hpp`'s `resolve_serial_params` closes
+// that by asking Hamlib what it *would* have used -- so "the backend's
+// own value" keeps meaning the same thing on a phone as on a desktop.
+struct SerialParams {
+    std::string device_id;
+    int baud = 9600;
+    int data_bits = 8;
+    int stop_bits = 1;
+
+    enum Parity { kNoParity = 0, kOdd = 1, kEven = 2 };
+    int parity = kNoParity;
+
+    enum Flow { kNoFlow = 0, kRtsCts = 1, kXonXoff = 2 };
+    int flow = kNoFlow;
+};
+
+// What a given Hamlib backend would have configured a serial port with.
+// Filled by `rig::serial_defaults(model)` in `sstvae_rig`; a plain
+// struct of ints here so `sstvae_core` can carry it with no libhamlib.
+// The `parity` and `flow` encodings are `SerialParams`'s.
+struct SerialDefaults {
+    int baud = 9600;
+    int data_bits = 8;
+    int stop_bits = 1;
+    int parity = SerialParams::kNoParity;
+    int flow = SerialParams::kNoFlow;
+};
+
 class SerialTransport {
 public:
     virtual ~SerialTransport() = default;

--- a/native/core/rig/transport.hpp
+++ b/native/core/rig/transport.hpp
@@ -1,0 +1,110 @@
+// A byte pipe to a radio that is not a serial port.
+//
+// **Why this exists at all.** `docs/android.md` recorded rig control as
+// dropping "for a structural reason, not a scoping one": Hamlib's
+// serial layer opens a *path*, and Android hands an unprivileged app no
+// `/dev/ttyUSB0`, so using it would mean patching a pinned dependency.
+// The premise is right and the conclusion was wrong, because Hamlib
+// does not actually require a serial port. `rig_open()` runs the
+// configured pathname through `parse_hoststr()` -- which explicitly
+// rejects `/dev/...` and `COM*` and accepts `host:port` -- and on a
+// match sets `type.rig = RIG_PORT_NETWORK` for **any** model, not just
+// model 2. `port_open()` then dispatches to `network_open()`. That is
+// the mechanism behind the well-worn `rigctld -m <native model> -r
+// <ser2net host>:4001` recipe, and it means a socket is a first-class
+// transport for every backend Hamlib has.
+//
+// So: this interface is the byte pipe, `bridge.hpp` turns one into a
+// loopback socket, and `bridged.hpp` hands Hamlib that socket's
+// address. Nothing is patched, no backend is reimplemented, and the
+// radio list on a phone is the radio list on the desktop -- which is
+// the property worth all of this, since "which radios work" differing
+// per platform is exactly what `native/cmake/hamlib.cmake` pins a
+// version to avoid.
+//
+// **Qt-free and Hamlib-free on purpose**, and in `sstvae_core` rather
+// than `sstvae_rig`: the whole mechanism is then testable in a
+// `--no-rig` build against a fake transport, which is the same trade
+// `rx::Decoder` makes so the receive loop tests need no onnxruntime.
+
+#ifndef SSTVAE_RIG_TRANSPORT_HPP
+#define SSTVAE_RIG_TRANSPORT_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "rig/backend.hpp"
+
+namespace sstvae::rig {
+
+// One end of a serial-shaped link: USB CDC/FTDI/CP210x through the
+// Android USB host API, or an RFCOMM socket to a Bluetooth radio.
+//
+// **Errors are `RigError`**, the same type `RigBackend` throws, because
+// everything above here reports rig trouble one way and an operator
+// cannot act on the distinction between "the radio refused" and "the
+// cable fell out" any differently.
+//
+// **Threading contract, and it is load-bearing.** `read()` and
+// `write()` are called concurrently, from two different threads, for
+// the whole life of a session -- see `bridge.hpp` for why one thread
+// per direction is what avoids an idle poll loop on a phone. Both
+// Android transports satisfy this naturally (separate USB endpoints;
+// `BluetoothSocket`'s input and output streams are independent), which
+// is the only reason it is allowed to be a requirement. `close()` may
+// be called from a third thread while a `read()` is blocked, and
+// **must wake it** -- that is how a session shuts down without waiting
+// out a read timeout. `set_dtr`/`set_rts` may overlap a read or a
+// write: on USB they are control transfers, on a separate endpoint
+// from the data.
+class SerialTransport {
+public:
+    virtual ~SerialTransport() = default;
+
+    // Acquire the device and apply the line settings.
+    //
+    // Deliberately *not* done by whoever constructs the transport: this
+    // blocks, sometimes for seconds, and the entire point of
+    // `RigController` is that nothing which blocks on a radio happens
+    // anywhere but its worker thread. Permission prompts are the
+    // caller's problem and must be settled before this is reached --
+    // they need a UI thread and an activity, which a rig worker has
+    // neither of.
+    virtual void open() = 0;
+
+    // Release it. Called from the pump's teardown and must not throw;
+    // by then there is nobody left to tell, exactly as with
+    // `RigBackend::close`. Must be idempotent, and must unblock a
+    // concurrent `read()`.
+    virtual void close() noexcept = 0;
+
+    // Up to `n` bytes, blocking at most `timeout_ms`. Returns the count,
+    // which is 0 on a timeout -- **a timeout is not an error**, it is
+    // the ordinary state of a radio nobody has asked anything.
+    // Returning 0 forever is what an idle link looks like.
+    virtual std::size_t read(std::uint8_t* dst, std::size_t n, int timeout_ms) = 0;
+
+    // All `n` bytes, or throw. CAT commands are short and a partial
+    // write is a corrupt command, so there is no short-write case worth
+    // handing upward.
+    virtual void write(const std::uint8_t* src, std::size_t n) = 0;
+
+    // Modem control lines, for the PTT methods that key a radio by
+    // asserting one.
+    //
+    // **These cannot go through Hamlib on this path and that is not an
+    // oversight.** `ser_set_dtr` is a `TIOCMSET` ioctl; the descriptor
+    // Hamlib holds here is a socket, so the ioctl simply fails. The
+    // line has to be driven on the transport itself, which is why
+    // `bridged.cpp` intercepts DTR/RTS keying instead of delegating it.
+    virtual void set_dtr(bool on) = 0;
+    virtual void set_rts(bool on) = 0;
+
+    // For status text: "USB CP2102 (Silicon Labs)", "BT: FT-891".
+    virtual std::string description() const = 0;
+};
+
+}  // namespace sstvae::rig
+
+#endif

--- a/native/tests/CMakeLists.txt
+++ b/native/tests/CMakeLists.txt
@@ -111,6 +111,21 @@ target_link_libraries(test_rig PRIVATE sstvae_core)
 target_include_directories(test_rig PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME rig COMMAND test_rig)
 
+# The loopback bridge and the backend that composes it -- the mechanism
+# that gives a phone CAT control without patching Hamlib. Both link
+# sstvae_core only, so they run in a --no-rig build: the composition,
+# the PTT routing and the byte pumping are all covered with no
+# libhamlib present, exactly as the controller's threading already is.
+add_executable(test_rig_bridge test_rig_bridge.cpp)
+target_link_libraries(test_rig_bridge PRIVATE sstvae_core)
+target_include_directories(test_rig_bridge PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME rig_bridge COMMAND test_rig_bridge)
+
+add_executable(test_rig_bridged test_rig_bridged.cpp)
+target_link_libraries(test_rig_bridged PRIVATE sstvae_core)
+target_include_directories(test_rig_bridged PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME rig_bridged COMMAND test_rig_bridged)
+
 # The libhamlib backend itself, exercised against Hamlib's own dummy
 # rig (model 1) -- the same trick CLAUDE.md uses for the Python side,
 # and the only way to run open/PTT/frequency with no radio attached.
@@ -163,13 +178,17 @@ set_tests_properties(tx_engine PROPERTIES TIMEOUT 180)
 set_tests_properties(golden npy modem_roundtrip ringbuffer audio rig
                      checkpoint
                      PROPERTIES TIMEOUT 300)
+# These two carry their own watchdogs, which name the wedged step. The
+# ctest bound is the backstop for a wedge before main or after it
+# returns, where an in-process watchdog cannot fire at all.
+set_tests_properties(rig_bridge rig_bridged PROPERTIES TIMEOUT 180)
 if(TARGET sstvae_rig)
-  # Shorter than the rest on purpose: this one carries its own 60 s
+  # Shorter than the rest on purpose: this one carries its own 120 s
   # watchdog, so reaching the ctest bound at all already means the
   # watchdog never got to run -- the process was wedged before main or
-  # after it returned. 120 s is enough to establish that without
+  # after it returned. 240 s is enough to establish that without
   # spending the job on it.
-  set_tests_properties(rig_hamlib PROPERTIES TIMEOUT 120)
+  set_tests_properties(rig_hamlib PROPERTIES TIMEOUT 240)
 endif()
 
 # Overlay rendering needs QtGui; the library is optional, so the test

--- a/native/tests/test_rig.cpp
+++ b/native/tests/test_rig.cpp
@@ -16,6 +16,7 @@
 // TIMEOUT reports, and which is a far better signal than a threshold
 // someone has to keep tuning.
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -308,6 +309,49 @@ void test_keying_is_not_stuck_behind_status_chatter() {
     controller.stop();
 }
 
+void test_a_ptt_function_survives_a_reconnect() {
+    // **The property the Android reconnect rests on.** When a USB cable
+    // is pulled and replugged, the app rebuilds the backend and calls
+    // `start()` again on the *same* controller. A `TxEngine` may already
+    // be holding the `Ptt` from before -- so if that lambda were bound
+    // to the session or the backend rather than to the controller, a
+    // reconnect would silently disarm the one operation that must never
+    // fail, and only mid-over would anyone find out.
+    auto first = std::make_shared<Probe>();
+    first->open_gate();
+    auto second = std::make_shared<Probe>();
+    second->open_gate();
+
+    rig::RigController controller;
+    controller.start(make(first));
+
+    // Taken before the reconnect, exactly as the transmit engine takes
+    // it before an over.
+    const std::function<void(bool)> ptt = controller.ptt_function();
+    ptt(true);
+    ptt(false);
+
+    controller.start(make(second));  // the reconnect
+
+    bool threw = false;
+    try {
+        ptt(true);
+        ptt(false);
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    check::is_true(!threw, "rig/reconnect: an old Ptt still keys after a restart");
+
+    const auto keyed = [](const std::vector<std::string>& calls) {
+        return std::count(calls.begin(), calls.end(), std::string("ptt-on"));
+    };
+    check::equal(keyed(second->call_log()), 1L,
+                 "rig/reconnect: ...and keys the *new* backend");
+    check::equal(keyed(first->call_log()), 1L,
+                 "rig/reconnect: ...not the superseded one");
+    controller.stop();
+}
+
 void test_keying_without_a_session_is_an_error_not_a_hang() {
     // TxEngine turns this into "PTT on failed", which is exactly right
     // for a transmission that cannot key the radio -- and much better
@@ -431,6 +475,7 @@ int main() {
     try {
         test_backoff_arithmetic();
         test_keying_without_a_session_is_an_error_not_a_hang();
+        test_a_ptt_function_survives_a_reconnect();
         test_polling_publishes_frequency_and_status();
         test_a_rig_that_cannot_be_opened_reports_and_stops();
         test_stop_does_not_wait_for_a_wedged_rig();

--- a/native/tests/test_rig_bridge.cpp
+++ b/native/tests/test_rig_bridge.cpp
@@ -1,0 +1,425 @@
+// The loopback bridge: a serial transport presented to Hamlib as a
+// socket.
+//
+// No libhamlib here on purpose -- this is `sstvae_core` only, so the
+// whole mechanism is covered in a `--no-rig` build. What is under test
+// is the plumbing that Hamlib will sit on top of: that bytes cross in
+// both directions unmodified, that a shutdown does not wait out a read
+// timeout, and that our reading of a device string is Hamlib's reading
+// of it.
+//
+// **Nothing here asserts on elapsed time.** A bridge that failed to
+// wake a blocked read would hang rather than run slowly, and the ctest
+// TIMEOUT reports that with the watchdog naming the step -- which is
+// the same trade `test_rig.cpp` makes and for the same reason.
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
+#  include <winsock2.h>
+#  include <ws2tcpip.h>
+#else
+#  include <arpa/inet.h>
+#  include <netinet/in.h>
+#  include <sys/socket.h>
+#  include <unistd.h>
+#endif
+
+#include "check.hpp"
+#include "rig/bridge.hpp"
+
+using namespace sstvae;
+
+namespace {
+
+// --- a radio made of two queues --------------------------------------------
+
+// Everything the test needs to see, kept alive independently of the
+// transport so assertions still work after the bridge has taken it.
+struct Probe {
+    std::mutex m;
+    std::condition_variable cv;
+
+    int opens = 0;
+    int closes = 0;
+    bool closed = false;
+    bool fail_open = false;
+
+    std::vector<std::uint8_t> written;   // what the bridge sent to the "rig"
+    std::deque<std::uint8_t> to_deliver; // what the "rig" will answer with
+    std::vector<std::string> lines;      // set_dtr/set_rts, in order
+
+    void deliver(const std::string& s) {
+        {
+            std::lock_guard<std::mutex> lock(m);
+            for (char c : s) to_deliver.push_back(static_cast<std::uint8_t>(c));
+        }
+        cv.notify_all();
+    }
+
+    std::string written_text() {
+        std::lock_guard<std::mutex> lock(m);
+        return std::string(written.begin(), written.end());
+    }
+
+    bool wait_for_written(const std::string& want, double seconds = 5.0) {
+        std::unique_lock<std::mutex> lock(m);
+        return cv.wait_for(lock, std::chrono::duration<double>(seconds), [&] {
+            return std::string(written.begin(), written.end()).find(want) !=
+                   std::string::npos;
+        });
+    }
+};
+
+class FakeTransport : public rig::SerialTransport {
+public:
+    explicit FakeTransport(std::shared_ptr<Probe> probe) : probe_(std::move(probe)) {}
+
+    void open() override {
+        std::lock_guard<std::mutex> lock(probe_->m);
+        if (probe_->fail_open) throw rig::RigError("no such device");
+        probe_->opens++;
+        probe_->closed = false;
+    }
+
+    // Closing wakes a blocked read: the contract `SerialTransport`
+    // states, and the one the bridge's shutdown depends on.
+    void close() noexcept override {
+        {
+            std::lock_guard<std::mutex> lock(probe_->m);
+            if (!probe_->closed) probe_->closes++;
+            probe_->closed = true;
+        }
+        probe_->cv.notify_all();
+    }
+
+    std::size_t read(std::uint8_t* dst, std::size_t n, int timeout_ms) override {
+        std::unique_lock<std::mutex> lock(probe_->m);
+        probe_->cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [&] {
+            return !probe_->to_deliver.empty() || probe_->closed;
+        });
+        if (probe_->closed) return 0;
+        std::size_t i = 0;
+        while (i < n && !probe_->to_deliver.empty()) {
+            dst[i++] = probe_->to_deliver.front();
+            probe_->to_deliver.pop_front();
+        }
+        return i;
+    }
+
+    void write(const std::uint8_t* src, std::size_t n) override {
+        {
+            std::lock_guard<std::mutex> lock(probe_->m);
+            if (probe_->closed) throw rig::RigError("write after close");
+            probe_->written.insert(probe_->written.end(), src, src + n);
+        }
+        probe_->cv.notify_all();
+    }
+
+    void set_dtr(bool on) override { note(on ? "dtr=1" : "dtr=0"); }
+    void set_rts(bool on) override { note(on ? "rts=1" : "rts=0"); }
+
+    std::string description() const override { return "fake rig"; }
+
+private:
+    void note(const std::string& what) {
+        std::lock_guard<std::mutex> lock(probe_->m);
+        probe_->lines.push_back(what);
+    }
+    std::shared_ptr<Probe> probe_;
+};
+
+// --- a client, standing in for Hamlib --------------------------------------
+
+#ifdef _WIN32
+using socket_t = SOCKET;
+constexpr socket_t kBad = INVALID_SOCKET;
+void close_socket(socket_t s) { ::closesocket(s); }
+void start_sockets() {
+    static bool done = false;
+    if (!done) {
+        WSADATA d;
+        ::WSAStartup(MAKEWORD(2, 2), &d);
+        done = true;
+    }
+}
+#else
+using socket_t = int;
+constexpr socket_t kBad = -1;
+void close_socket(socket_t s) { ::close(s); }
+void start_sockets() {}
+#endif
+
+class Client {
+public:
+    explicit Client(int port) {
+        start_sockets();
+        fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+        if (fd_ == kBad) throw std::runtime_error("client socket");
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = htons(static_cast<std::uint16_t>(port));
+        if (::connect(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+            close_socket(fd_);
+            throw std::runtime_error("client connect");
+        }
+    }
+    ~Client() { disconnect(); }
+
+    void disconnect() {
+        if (fd_ != kBad) {
+            close_socket(fd_);
+            fd_ = kBad;
+        }
+    }
+
+    void send_text(const std::string& s) {
+        ::send(fd_, s.data(), static_cast<int>(s.size()), 0);
+    }
+
+    // Read until `n` bytes or a few seconds pass. Blocking with a
+    // deadline enforced by the ctest timeout rather than by a timer
+    // here: a bridge that never delivers is a hang, and a hang is the
+    // signal.
+    std::string receive(std::size_t n) {
+        std::string out;
+        char buf[256];
+        while (out.size() < n) {
+            const auto got = ::recv(fd_, buf, static_cast<int>(sizeof(buf)), 0);
+            if (got <= 0) break;
+            out.append(buf, static_cast<std::size_t>(got));
+        }
+        return out;
+    }
+
+private:
+    socket_t fd_ = kBad;
+};
+
+// --- tests ------------------------------------------------------------------
+
+void test_endpoint_is_loopback_with_an_ephemeral_port() {
+    auto probe = std::make_shared<Probe>();
+    rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
+    bridge.start();
+
+    const std::string endpoint = bridge.endpoint();
+    check::is_true(endpoint.rfind("127.0.0.1:", 0) == 0,
+                   "bridge: binds loopback, not every interface (" + endpoint + ")");
+    check::is_true(bridge.port() > 0, "bridge: the kernel chose a port");
+    check::equal(endpoint, "127.0.0.1:" + std::to_string(bridge.port()),
+                 "bridge: endpoint and port agree");
+    {
+        std::lock_guard<std::mutex> lock(probe->m);
+        check::equal(probe->opens, 1, "bridge: start() opened the transport");
+    }
+}
+
+void test_bytes_cross_from_hamlib_to_the_radio() {
+    auto probe = std::make_shared<Probe>();
+    rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
+    bridge.start();
+
+    Client client(bridge.port());
+    client.send_text("FA;");
+    check::is_true(probe->wait_for_written("FA;"),
+                   "bridge: a CAT command reaches the transport");
+    check::is_true(bridge.connected(), "bridge: reports the client connected");
+}
+
+void test_bytes_cross_from_the_radio_to_hamlib() {
+    auto probe = std::make_shared<Probe>();
+    rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
+    bridge.start();
+
+    Client client(bridge.port());
+    // Wait until the pump is actually connected before answering, so
+    // this tests delivery rather than a race with accept().
+    client.send_text("FA;");
+    check::is_true(probe->wait_for_written("FA;"), "bridge: (setup) command arrived");
+
+    probe->deliver("FA00014074000;");
+    check::equal(client.receive(14), std::string("FA00014074000;"),
+                 "bridge: the rig's answer reaches Hamlib");
+}
+
+void test_binary_bytes_are_not_mangled() {
+    // Yaesu and Icom CAT are binary, not ASCII: a NUL or a 0xFE in the
+    // middle of a command is ordinary traffic. A bridge that treated
+    // its buffer as a C string would pass every ASCII test and lose
+    // half the radios Hamlib supports.
+    auto probe = std::make_shared<Probe>();
+    rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
+    bridge.start();
+
+    Client client(bridge.port());
+    const std::string icom("\xFE\xFE\x94\xE0\x03\x00\xFD", 7);
+    client.send_text(icom);
+    check::is_true(probe->wait_for_written(icom),
+                   "bridge: NUL and high bytes survive the crossing");
+
+    const std::string reply("\xFE\xFE\xE0\x94\x00\x60\x40\x07\x14\x00\xFD", 11);
+    probe->deliver(reply);
+    check::equal(client.receive(reply.size()), reply,
+                 "bridge: a binary answer survives the crossing");
+}
+
+void test_a_client_hanging_up_ends_the_session() {
+    auto probe = std::make_shared<Probe>();
+    rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
+    bridge.start();
+
+    {
+        Client client(bridge.port());
+        client.send_text("ID;");
+        check::is_true(probe->wait_for_written("ID;"), "bridge: (setup) connected");
+    }
+    // The pump notices without being told, so a controller polling
+    // `connected()` can tell a rig that hung up from one that is quiet.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (bridge.connected() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    check::is_true(!bridge.connected(), "bridge: a disconnect is noticed");
+}
+
+void test_stopping_closes_the_transport_and_does_not_wait() {
+    auto probe = std::make_shared<Probe>();
+    {
+        rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
+        bridge.start();
+        Client client(bridge.port());
+        client.send_text("ID;");
+        check::is_true(probe->wait_for_written("ID;"), "bridge: (setup) connected");
+        // The pump-out thread is inside a blocked read right now. If
+        // stop() relied on the read timeout expiring rather than on
+        // close() waking it, this would still pass -- but if it relied
+        // on nothing at all it would hang, and the watchdog names it.
+        bridge.stop();
+    }
+    std::lock_guard<std::mutex> lock(probe->m);
+    check::equal(probe->closes, 1, "bridge: stop() closed the transport exactly once");
+}
+
+void test_a_session_that_ended_by_itself_still_releases_the_device() {
+    // The failure this pins: `stop()` used to return early when
+    // `stopping_` was already set, and a pump thread sets it itself
+    // when the far end hangs up. So an ordinary disconnect left the
+    // listener and the USB claim held for the life of the process --
+    // and nothing failed, which is the worst shape available.
+    auto probe = std::make_shared<Probe>();
+    {
+        rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
+        bridge.start();
+        {
+            Client client(bridge.port());
+            client.send_text("ID;");
+            check::is_true(probe->wait_for_written("ID;"), "bridge: (setup) connected");
+        }
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (bridge.connected() && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        bridge.stop();
+    }
+    std::lock_guard<std::mutex> lock(probe->m);
+    check::equal(probe->closes, 1,
+                 "bridge: a self-ended session still closes the transport");
+}
+
+void test_a_device_that_cannot_be_opened_fails_start() {
+    auto probe = std::make_shared<Probe>();
+    {
+        std::lock_guard<std::mutex> lock(probe->m);
+        probe->fail_open = true;
+    }
+    rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
+    bool threw = false;
+    try {
+        bridge.start();
+    } catch (const rig::RigError&) {
+        threw = true;
+    }
+    check::is_true(threw, "bridge: a device that will not open fails start()");
+    check::equal(bridge.port(), 0, "bridge: and no port is left listening");
+}
+
+void test_device_strings_are_read_the_way_hamlib_reads_them() {
+    // These are `parse_hoststr` in Hamlib's src/misc.c, case for case.
+    // Disagreeing means the app opens a bridge Hamlib will not connect
+    // to, or dials a hostname while a radio sits idle.
+    struct Case {
+        const char* device;
+        bool network;
+        const char* why;
+    };
+    const Case cases[] = {
+        {"127.0.0.1:4532", true, "an address with a port"},
+        {"localhost:4532", true, "a name with a port"},
+        {"192.168.1.5:4001", true, "a ser2net server"},
+        {"[::1]:4532", true, "bracketed IPv6"},
+        {"shack.example.com", true, "a bare hostname -- Hamlib accepts this"},
+        {"/dev/ttyUSB0", false, "a Linux device path"},
+        {"/dev/cu.usbserial-1420", false, "a macOS device path"},
+        {"COM3", false, "a Windows port"},
+        {"com12", false, "a Windows port, lower case"},
+        {"\\\\.\\COM17", false, "an escaped Windows port"},
+        {"", false, "nothing at all"},
+    };
+    for (const Case& c : cases) {
+        check::equal(rig::is_network_device(c.device), c.network,
+                     std::string("is_network_device: ") + c.why + " (" + c.device + ")");
+    }
+}
+
+}  // namespace
+
+int main() {
+    check::report_crashes_instead_of_prompting();
+    // ~90x the measured runtime, per CLAUDE.md: expiring can then only
+    // mean wedged, never "slower than I guessed".
+    check::Watchdog watchdog(120.0, "rig bridge");
+    try {
+        check::current_step.store("endpoint");
+        test_endpoint_is_loopback_with_an_ephemeral_port();
+        check::current_step.store("to_radio");
+        test_bytes_cross_from_hamlib_to_the_radio();
+        check::current_step.store("from_radio");
+        test_bytes_cross_from_the_radio_to_hamlib();
+        check::current_step.store("binary");
+        test_binary_bytes_are_not_mangled();
+        check::current_step.store("hangup");
+        test_a_client_hanging_up_ends_the_session();
+        check::current_step.store("stop");
+        test_stopping_closes_the_transport_and_does_not_wait();
+        check::current_step.store("stop_after_self_end");
+        test_a_session_that_ended_by_itself_still_releases_the_device();
+        check::current_step.store("open_failure");
+        test_a_device_that_cannot_be_opened_fails_start();
+        check::current_step.store("device_strings");
+        test_device_strings_are_read_the_way_hamlib_reads_them();
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "FATAL: %s\n", e.what());
+        return 1;
+    }
+    return check::report("rig bridge");
+}

--- a/native/tests/test_rig_bridged.cpp
+++ b/native/tests/test_rig_bridged.cpp
@@ -1,0 +1,365 @@
+// Composing a transport, a bridge and a rig backend.
+//
+// The inner backend is a stub, which is the point: `sstvae_core` only,
+// so the decisions this file makes -- when to bridge at all, what
+// device string the rig ends up configured with, and which of the two
+// PTT paths a keying request takes -- are all covered in a build with
+// no libhamlib. `test_rig_hamlib.cpp` is where the real Hamlib meets a
+// real socket.
+
+#include <cstdio>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "check.hpp"
+#include "rig/bridge.hpp"
+#include "rig/bridged.hpp"
+
+using namespace sstvae;
+
+namespace {
+
+struct Probe {
+    std::mutex m;
+    int transport_opens = 0;
+    int transport_closes = 0;
+    std::vector<std::string> lines;   // set_dtr / set_rts, in order
+    std::vector<std::string> inner;   // what the stub backend was told
+    rig::HamlibConfig seen{};         // the config the factory received
+    bool factory_called = false;
+
+    std::vector<std::string> line_log() {
+        std::lock_guard<std::mutex> lock(m);
+        return lines;
+    }
+    std::vector<std::string> inner_log() {
+        std::lock_guard<std::mutex> lock(m);
+        return inner;
+    }
+};
+
+class StubTransport : public rig::SerialTransport {
+public:
+    explicit StubTransport(std::shared_ptr<Probe> probe) : probe_(std::move(probe)) {}
+    void open() override {
+        std::lock_guard<std::mutex> lock(probe_->m);
+        probe_->transport_opens++;
+    }
+    void close() noexcept override {
+        std::lock_guard<std::mutex> lock(probe_->m);
+        probe_->transport_closes++;
+    }
+    std::size_t read(std::uint8_t*, std::size_t, int) override { return 0; }
+    void write(const std::uint8_t*, std::size_t) override {}
+    void set_dtr(bool on) override { note(on ? "dtr=1" : "dtr=0"); }
+    void set_rts(bool on) override { note(on ? "rts=1" : "rts=0"); }
+    std::string description() const override { return "USB CP2102"; }
+
+private:
+    void note(const std::string& what) {
+        std::lock_guard<std::mutex> lock(probe_->m);
+        probe_->lines.push_back(what);
+    }
+    std::shared_ptr<Probe> probe_;
+};
+
+class StubBackend : public rig::RigBackend {
+public:
+    explicit StubBackend(std::shared_ptr<Probe> probe) : probe_(std::move(probe)) {}
+    void open() override { note("open"); }
+    void close() noexcept override { note("close"); }
+    void set_ptt(bool on) override { note(on ? "ptt=1" : "ptt=0"); }
+    double frequency_hz() override {
+        note("freq");
+        return 14'230'000.0;
+    }
+    std::string description() const override { return "Elecraft K4"; }
+
+private:
+    void note(const std::string& what) {
+        std::lock_guard<std::mutex> lock(probe_->m);
+        probe_->inner.push_back(what);
+    }
+    std::shared_ptr<Probe> probe_;
+};
+
+rig::BackendFactory factory_for(const std::shared_ptr<Probe>& probe) {
+    return [probe](const rig::HamlibConfig& config) -> std::unique_ptr<rig::RigBackend> {
+        std::lock_guard<std::mutex> lock(probe->m);
+        probe->seen = config;
+        probe->factory_called = true;
+        return std::make_unique<StubBackend>(probe);
+    };
+}
+
+rig::HamlibConfig usb_config() {
+    rig::HamlibConfig config;
+    config.model = 2043;  // any native backend; the number is not read here
+    config.device = "usb:1a86:7523";  // an app-level device id, not a path
+    config.baud = 38400;
+    return config;
+}
+
+// --- tests ------------------------------------------------------------------
+
+void test_a_host_is_dialled_directly_with_no_bridge() {
+    // The operator chose a network rig, so there is no transport and
+    // Hamlib opens the socket itself. Putting a bridge in that path
+    // would mean two of our threads shuttling bytes between two sockets
+    // for no reason -- and it is the *same* Hamlib code path either
+    // way, which is what makes NET rigctl and a ser2net-style server
+    // one feature rather than two.
+    auto probe = std::make_shared<Probe>();
+    rig::HamlibConfig config;
+    config.model = rig::MODEL_NET_RIGCTL;
+    config.device = "192.168.1.20:4532";
+
+    auto backend = rig::make_bridged_backend(config, nullptr, factory_for(probe));
+    backend->open();
+
+    std::lock_guard<std::mutex> lock(probe->m);
+    check::equal(probe->seen.device, std::string("192.168.1.20:4532"),
+                 "bridged: a host reaches the rig unchanged");
+    check::equal(probe->transport_opens, 0,
+                 "bridged: and nothing was opened for it");
+}
+
+void test_a_transport_is_what_asks_for_a_bridge_not_the_string() {
+    // The regression this pins, which the first draft had. A USB device
+    // identifier is not a path and does not start with `com`, so
+    // Hamlib's own rules -- and therefore `is_network_device` -- read it
+    // as a hostname. Branching on that skipped the bridge for exactly
+    // the devices it exists to serve, and the app then tried to resolve
+    // `usb:1a86:7523` as a DNS name.
+    check::is_true(rig::is_network_device("usb:1a86:7523"),
+                   "bridged: a device id does look like a host to Hamlib's rules");
+
+    auto probe = std::make_shared<Probe>();
+    auto backend = rig::make_bridged_backend(usb_config(),
+                                             std::make_shared<StubTransport>(probe),
+                                             factory_for(probe));
+    backend->open();
+    std::lock_guard<std::mutex> lock(probe->m);
+    check::equal(probe->transport_opens, 1,
+                 "bridged: ...and it is bridged anyway, because a transport was given");
+    check::is_true(probe->seen.device != "usb:1a86:7523",
+                   "bridged: the device id never reaches Hamlib");
+}
+
+void test_a_device_gets_a_bridge_and_the_rig_gets_its_address() {
+    auto probe = std::make_shared<Probe>();
+    auto backend = rig::make_bridged_backend(usb_config(),
+                                             std::make_shared<StubTransport>(probe),
+                                             factory_for(probe));
+    backend->open();
+
+    std::string device;
+    {
+        std::lock_guard<std::mutex> lock(probe->m);
+        device = probe->seen.device;
+        check::equal(probe->transport_opens, 1, "bridged: the transport was opened");
+    }
+    check::is_true(device.rfind("127.0.0.1:", 0) == 0,
+                   "bridged: the rig is pointed at the bridge (" + device + ")");
+    check::is_true(rig::is_network_device(device),
+                   "bridged: and Hamlib will read that as a network address");
+
+    check::equal(backend->frequency_hz(), 14'230'000.0,
+                 "bridged: frequency goes straight through");
+}
+
+void test_the_serial_speed_still_reaches_the_rig_config() {
+    // Not because Hamlib will use it -- over a socket it will not, the
+    // transport owns the line settings -- but because nothing here may
+    // quietly rewrite a field it does not own. Only `device` and the
+    // PTT method change.
+    auto probe = std::make_shared<Probe>();
+    auto backend = rig::make_bridged_backend(usb_config(),
+                                             std::make_shared<StubTransport>(probe),
+                                             factory_for(probe));
+    backend->open();
+    std::lock_guard<std::mutex> lock(probe->m);
+    check::equal(probe->seen.baud, 38400, "bridged: baud is passed along untouched");
+    check::equal(probe->seen.model, 2043, "bridged: so is the model");
+}
+
+void test_cat_keying_goes_through_the_rig() {
+    auto probe = std::make_shared<Probe>();
+    rig::HamlibConfig config = usb_config();
+    config.ptt_method = rig::PttMethod::Cat;
+
+    auto backend = rig::make_bridged_backend(config, std::make_shared<StubTransport>(probe),
+                                             factory_for(probe));
+    backend->open();
+    backend->set_ptt(true);
+    backend->set_ptt(false);
+
+    const std::vector<std::string> want{"open", "ptt=1", "ptt=0"};
+    check::equal(probe->inner_log().size(), want.size(),
+                 "bridged: CAT keying is a CAT command");
+    check::is_true(probe->inner_log() == want, "bridged: ...in that order");
+    check::is_true(probe->line_log().empty(),
+                   "bridged: and no control line is touched");
+    std::lock_guard<std::mutex> lock(probe->m);
+    check::is_true(probe->seen.ptt_method == rig::PttMethod::Cat,
+                   "bridged: the rig is told to key by CAT");
+}
+
+void test_dtr_keying_drives_the_transport_and_hamlib_is_told_not_to() {
+    // The trap this pins. Hamlib's `ser_set_dtr` is a TIOCMSET ioctl,
+    // and over this transport the descriptor it holds is a socket -- so
+    // asking Hamlib to key DTR fails, and it fails at the moment
+    // somebody presses transmit. The line has to be driven here, and
+    // Hamlib has to be told to keep its hands off, which is the value
+    // `Vox` carries (hamlib.cpp maps it to ptt_type "None").
+    auto probe = std::make_shared<Probe>();
+    rig::HamlibConfig config = usb_config();
+    config.ptt_method = rig::PttMethod::Dtr;
+
+    auto backend = rig::make_bridged_backend(config, std::make_shared<StubTransport>(probe),
+                                             factory_for(probe));
+    backend->open();
+    backend->set_ptt(true);
+    backend->set_ptt(false);
+
+    const std::vector<std::string> want{"dtr=0", "dtr=1", "dtr=0"};
+    check::is_true(probe->line_log() == want,
+                   "bridged: DTR is parked unkeyed, then keyed, then released");
+    const std::vector<std::string> inner{"open"};
+    check::is_true(probe->inner_log() == inner,
+                   "bridged: and the rig is never asked to key");
+    std::lock_guard<std::mutex> lock(probe->m);
+    check::is_true(probe->seen.ptt_method == rig::PttMethod::Vox,
+                   "bridged: Hamlib is configured not to key at all");
+}
+
+void test_rts_keying_drives_the_other_line() {
+    auto probe = std::make_shared<Probe>();
+    rig::HamlibConfig config = usb_config();
+    config.ptt_method = rig::PttMethod::Rts;
+
+    auto backend = rig::make_bridged_backend(config, std::make_shared<StubTransport>(probe),
+                                             factory_for(probe));
+    backend->open();
+    backend->set_ptt(true);
+
+    const std::vector<std::string> want{"rts=0", "rts=1"};
+    check::is_true(probe->line_log() == want, "bridged: RTS keys the radio");
+}
+
+void test_a_parked_line_is_held_but_never_the_keying_one() {
+    // An interface that steals its power from a control line needs it
+    // held for the session. The line that keys the radio is the one
+    // exception: parking *that* high would put the transmitter on from
+    // the moment the app connects, which is the worst thing in this
+    // file.
+    auto probe = std::make_shared<Probe>();
+    rig::HamlibConfig config = usb_config();
+    config.ptt_method = rig::PttMethod::Rts;
+    config.dtr = rig::LineState::High;
+    config.rts = rig::LineState::High;
+
+    auto backend = rig::make_bridged_backend(config, std::make_shared<StubTransport>(probe),
+                                             factory_for(probe));
+    backend->open();
+
+    const std::vector<std::string> want{"dtr=1", "rts=0"};
+    check::is_true(probe->line_log() == want,
+                   "bridged: DTR is parked high, RTS is left unkeyed");
+}
+
+void test_closing_releases_the_rig_before_the_link() {
+    // Some backends write a last command in `rig_close` -- restoring a
+    // mode they changed on connect. Pulling the bridge first would turn
+    // that orderly close into a broken pipe on the way out.
+    auto probe = std::make_shared<Probe>();
+    {
+        auto backend = rig::make_bridged_backend(usb_config(),
+                                                 std::make_shared<StubTransport>(probe),
+                                                 factory_for(probe));
+        backend->open();
+        backend->close();
+    }
+    const std::vector<std::string> want{"open", "close"};
+    check::is_true(probe->inner_log() == want, "bridged: the rig is closed");
+    std::lock_guard<std::mutex> lock(probe->m);
+    check::equal(probe->transport_closes, 1,
+                 "bridged: and the device is released exactly once");
+}
+
+void test_a_serial_path_with_no_transport_is_refused() {
+    // The validation `is_network_device` is left doing: with no
+    // transport the string has to be something Hamlib will dial, and a
+    // device path is not. Refused here rather than as a failed
+    // connection minutes later.
+    auto probe = std::make_shared<Probe>();
+    rig::HamlibConfig config;
+    config.device = "/dev/ttyUSB0";
+    bool threw = false;
+    try {
+        auto backend = rig::make_bridged_backend(config, nullptr, factory_for(probe));
+    } catch (const rig::RigError&) {
+        threw = true;
+    }
+    check::is_true(threw,
+                   "bridged: a device path with nothing to open it is refused up front");
+    std::lock_guard<std::mutex> lock(probe->m);
+    check::is_true(!probe->factory_called, "bridged: and no rig is built");
+}
+
+void test_a_rig_that_will_not_open_releases_the_device() {
+    auto probe = std::make_shared<Probe>();
+    rig::BackendFactory failing = [](const rig::HamlibConfig&) -> std::unique_ptr<rig::RigBackend> {
+        throw rig::RigError("the rig refused");
+    };
+    auto backend = rig::make_bridged_backend(usb_config(),
+                                             std::make_shared<StubTransport>(probe), failing);
+    bool threw = false;
+    try {
+        backend->open();
+    } catch (const rig::RigError&) {
+        threw = true;
+    }
+    check::is_true(threw, "bridged: a rig that will not open reports it");
+    std::lock_guard<std::mutex> lock(probe->m);
+    check::equal(probe->transport_closes, 1,
+                 "bridged: and the USB claim is not left held");
+}
+
+}  // namespace
+
+int main() {
+    check::report_crashes_instead_of_prompting();
+    check::Watchdog watchdog(120.0, "rig bridged");
+    try {
+        check::current_step.store("host_direct");
+        test_a_host_is_dialled_directly_with_no_bridge();
+        check::current_step.store("transport_decides");
+        test_a_transport_is_what_asks_for_a_bridge_not_the_string();
+        check::current_step.store("device_bridged");
+        test_a_device_gets_a_bridge_and_the_rig_gets_its_address();
+        check::current_step.store("passthrough");
+        test_the_serial_speed_still_reaches_the_rig_config();
+        check::current_step.store("cat_ptt");
+        test_cat_keying_goes_through_the_rig();
+        check::current_step.store("dtr_ptt");
+        test_dtr_keying_drives_the_transport_and_hamlib_is_told_not_to();
+        check::current_step.store("rts_ptt");
+        test_rts_keying_drives_the_other_line();
+        check::current_step.store("parked_lines");
+        test_a_parked_line_is_held_but_never_the_keying_one();
+        check::current_step.store("close_order");
+        test_closing_releases_the_rig_before_the_link();
+        check::current_step.store("no_transport");
+        test_a_serial_path_with_no_transport_is_refused();
+        check::current_step.store("rig_open_failure");
+        test_a_rig_that_will_not_open_releases_the_device();
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "FATAL: %s\n", e.what());
+        return 1;
+    }
+    return check::report("rig bridged");
+}

--- a/native/tests/test_rig_bridged.cpp
+++ b/native/tests/test_rig_bridged.cpp
@@ -17,6 +17,7 @@
 #include "check.hpp"
 #include "rig/bridge.hpp"
 #include "rig/bridged.hpp"
+#include "rig/transport.hpp"
 
 using namespace sstvae;
 
@@ -310,6 +311,109 @@ void test_a_serial_path_with_no_transport_is_refused() {
     check::is_true(!probe->factory_called, "bridged: and no rig is built");
 }
 
+void test_default_line_settings_come_from_the_backend() {
+    // `Default` on the desktop means *do not set the token*, leaving
+    // Hamlib's own per-rig value. Over a socket that promise cannot be
+    // kept by inaction -- Hamlib applies those in `serial_open`, which a
+    // network port never reaches -- so the resolver has to fill them in
+    // from what that backend would have used. Anything else and a
+    // bridged rig runs at a different speed than the same rig on a
+    // desktop, which is exactly the kind of difference that reads as a
+    // flaky cable.
+    rig::SerialDefaults defaults;
+    defaults.baud = 38400;
+    defaults.data_bits = 8;
+    defaults.stop_bits = 2;
+    defaults.parity = rig::SerialParams::kEven;
+    defaults.flow = rig::SerialParams::kRtsCts;
+
+    rig::HamlibConfig config;
+    config.device = "usb:10c4:ea60";
+    const rig::SerialParams p = rig::resolve_serial_params(config, defaults);
+
+    check::equal(p.device_id, std::string("usb:10c4:ea60"),
+                 "resolve: the device is carried through");
+    check::equal(p.baud, 38400, "resolve: Default baud is the backend's");
+    check::equal(p.stop_bits, 2, "resolve: so are the stop bits");
+    check::equal(p.parity, static_cast<int>(rig::SerialParams::kEven),
+                 "resolve: and the parity");
+    check::equal(p.flow, static_cast<int>(rig::SerialParams::kRtsCts),
+                 "resolve: and the handshake");
+}
+
+void test_an_explicit_line_setting_wins() {
+    rig::SerialDefaults defaults;
+    defaults.baud = 38400;
+    defaults.stop_bits = 2;
+    defaults.parity = rig::SerialParams::kEven;
+
+    rig::HamlibConfig config;
+    config.device = "usb:10c4:ea60";
+    config.baud = 9600;
+    config.data_bits = rig::DataBits::Seven;
+    config.stop_bits = rig::StopBits::One;
+    config.parity = rig::Parity::Odd;
+    config.handshake = rig::Handshake::None;
+
+    const rig::SerialParams p = rig::resolve_serial_params(config, defaults);
+    check::equal(p.baud, 9600, "resolve: an explicit rate overrides the default");
+    check::equal(p.data_bits, 7, "resolve: ...and the data bits");
+    check::equal(p.stop_bits, 1, "resolve: ...and the stop bits");
+    check::equal(p.parity, static_cast<int>(rig::SerialParams::kOdd),
+                 "resolve: ...and the parity");
+    check::equal(p.flow, static_cast<int>(rig::SerialParams::kNoFlow),
+                 "resolve: ...and the handshake");
+}
+
+void test_control_line_conflicts_are_refused() {
+    // Hamlib refuses all three of these with -RIG_ECONF -- and every
+    // one of its checks sits inside `if (rp->type.rig ==
+    // RIG_PORT_SERIAL)`, so on this path they never run. Losing them
+    // would mean a configuration a desktop rejects at connect time
+    // silently producing a radio that will not key on a phone.
+    const auto refused = [](const rig::HamlibConfig& config, const char* what) {
+        try {
+            (void)rig::resolve_serial_params(config, rig::SerialDefaults{});
+        } catch (const rig::RigError&) {
+            check::is_true(true, what);
+            return;
+        }
+        check::fail(what, "it was accepted");
+    };
+
+    rig::HamlibConfig rts_and_handshake;
+    rts_and_handshake.rts = rig::LineState::High;
+    rts_and_handshake.handshake = rig::Handshake::Hardware;
+    refused(rts_and_handshake, "resolve: RTS held with hardware handshaking is refused");
+
+    rig::HamlibConfig ptt_and_handshake;
+    ptt_and_handshake.ptt_method = rig::PttMethod::Rts;
+    ptt_and_handshake.handshake = rig::Handshake::Hardware;
+    refused(ptt_and_handshake, "resolve: PTT by RTS with hardware handshaking is refused");
+
+    rig::HamlibConfig ptt_and_held_rts;
+    ptt_and_held_rts.ptt_method = rig::PttMethod::Rts;
+    ptt_and_held_rts.rts = rig::LineState::Low;
+    refused(ptt_and_held_rts, "resolve: PTT by RTS with a fixed RTS level is refused");
+
+    rig::HamlibConfig ptt_and_held_dtr;
+    ptt_and_held_dtr.ptt_method = rig::PttMethod::Dtr;
+    ptt_and_held_dtr.dtr = rig::LineState::High;
+    refused(ptt_and_held_dtr, "resolve: PTT by DTR with a fixed DTR level is refused");
+
+    // ...and the same pairs on the *other* line are fine, so the checks
+    // are not simply refusing anything with two settings in it.
+    rig::HamlibConfig fine;
+    fine.ptt_method = rig::PttMethod::Dtr;
+    fine.rts = rig::LineState::High;
+    try {
+        (void)rig::resolve_serial_params(fine, rig::SerialDefaults{});
+        check::is_true(true, "resolve: DTR keying with RTS parked is allowed");
+    } catch (const rig::RigError&) {
+        check::fail("resolve: DTR keying with RTS parked is allowed", "it was refused");
+    }
+}
+
 void test_a_rig_that_will_not_open_releases_the_device() {
     auto probe = std::make_shared<Probe>();
     rig::BackendFactory failing = [](const rig::HamlibConfig&) -> std::unique_ptr<rig::RigBackend> {
@@ -355,6 +459,12 @@ int main() {
         test_closing_releases_the_rig_before_the_link();
         check::current_step.store("no_transport");
         test_a_serial_path_with_no_transport_is_refused();
+        check::current_step.store("resolve_defaults");
+        test_default_line_settings_come_from_the_backend();
+        check::current_step.store("resolve_explicit");
+        test_an_explicit_line_setting_wins();
+        check::current_step.store("resolve_conflicts");
+        test_control_line_conflicts_are_refused();
         check::current_step.store("rig_open_failure");
         test_a_rig_that_will_not_open_releases_the_device();
     } catch (const std::exception& e) {

--- a/native/tests/test_rig_hamlib.cpp
+++ b/native/tests/test_rig_hamlib.cpp
@@ -11,17 +11,28 @@
 // configuration path works, that errors arrive as `RigError` with
 // something readable in them, and that `list_models()` returns the
 // structured data that replaced parsing `rigctld -l`.
+//
+// It also carries the one claim the Android rig support rests on: that
+// a *native* Hamlib backend -- a Kenwood, not model 2 -- will speak its
+// own CAT protocol over a socket, so a device that can never be a
+// `/dev/ttyUSB0` is still every radio Hamlib knows. See
+// "a Kenwood on the end of a SerialTransport" below.
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdio>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "check.hpp"
+#include "rig/bridged.hpp"
 #include "rig/controller.hpp"
 #include "rig/hamlib.hpp"
 
@@ -194,6 +205,291 @@ void test_the_controller_drives_a_real_backend() {
 //
 // This test drives a real library that opens ports and starts threads,
 // so its plausible failure mode is not "wrong answer" but "never
+// --- a Kenwood on the end of a SerialTransport ------------------------------
+//
+// **This is the evidence the whole Android CAT design rests on**, and
+// it is why it is here rather than in `test_rig_bridge.cpp`: everything
+// else about the bridge is checked against a stub, but the claim being
+// made is about *Hamlib*, so nothing short of the real library
+// establishes it.
+//
+// The claim: Hamlib will speak a native backend's own CAT protocol over
+// a socket, so a phone -- which can never hand Hamlib a `/dev/ttyUSB0`
+// -- still reaches every radio Hamlib supports. `rig_open()` puts the
+// configured pathname through `parse_hoststr()` and, on a `host:port`
+// match, sets `RIG_PORT_NETWORK` for **any** model. That is the
+// mechanism behind `rigctld -m <native model> -r <ser2net host>:4001`,
+// and `docs/android.md` was wrong to conclude that Hamlib's serial
+// layer made rig control structurally impossible there.
+//
+// So: model 2014 is a Kenwood TS-2000, a genuine serial backend with no
+// idea it is not on a wire. It gets a `LoopbackBridge` in front of a
+// transport that answers Kenwood commands, and the assertions are on
+// what the *radio* received -- because "Hamlib returned the frequency"
+// could be satisfied by a cache, while `FA;` arriving at the far end
+// could not.
+namespace {
+
+constexpr int MODEL_TS2000 = 2014;
+
+// The radio's side of the link, kept alive independently of the
+// transport so the test can still read it after the backend has taken
+// ownership.
+struct Kenwood {
+    std::mutex m;
+    std::condition_variable cv;
+    bool closed = false;
+
+    long long freq = 14'074'000;
+    std::vector<std::string> commands;   // every command, in order
+    std::deque<char> pending;            // bytes waiting to go back
+    int dtr = -1;                        // -1 = never set
+    int rts = -1;
+
+    void reply(const std::string& text) {
+        for (char c : text) pending.push_back(c);
+        cv.notify_all();
+    }
+
+    // Called with `m` held.
+    void handle(const std::string& command) {
+        commands.push_back(command);
+        if (command == "ID") {
+            reply("ID019;");  // the TS-2000's identifier
+        } else if (command == "FA") {
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "FA%011lld;", freq);
+            reply(buf);
+        } else if (command == "IF") {
+            // **Exactly 37 characters before the terminator.** Kenwood
+            // backends default `caps->if_len` to 37 and reject anything
+            // else as a protocol error, which is what an approximately
+            // right reply cost here: `rig_get_freq` failed inside
+            // `kenwood_get_vfo_if` having already read the frequency
+            // correctly. The tail is Hamlib's own `simulators/`
+            // canonical reply with our frequency in the first field.
+            char buf[64];
+            std::snprintf(buf, sizeof(buf),
+                          "IF%011lld1000+0000000000030000000;", freq);
+            reply(buf);
+        } else if (command == "PS") {
+            reply("PS1;");
+        } else if (command == "TX" || command == "RX") {
+            // A real TS-2000 answers neither; the state change is the
+            // whole reply.
+        } else {
+            reply("?;");  // what a Kenwood says to a command it lacks
+        }
+    }
+
+    std::vector<std::string> log() {
+        std::lock_guard<std::mutex> lock(m);
+        return commands;
+    }
+
+    bool saw(const std::string& want) {
+        std::lock_guard<std::mutex> lock(m);
+        return std::find(commands.begin(), commands.end(), want) != commands.end();
+    }
+
+    bool wait_for(const std::string& want, double seconds = 5.0) {
+        std::unique_lock<std::mutex> lock(m);
+        return cv.wait_for(lock, std::chrono::duration<double>(seconds), [&] {
+            return std::find(commands.begin(), commands.end(), want) != commands.end();
+        });
+    }
+};
+
+class KenwoodTransport : public rig::SerialTransport {
+public:
+    explicit KenwoodTransport(std::shared_ptr<Kenwood> radio) : radio_(std::move(radio)) {}
+
+    void open() override {
+        std::lock_guard<std::mutex> lock(radio_->m);
+        radio_->closed = false;
+    }
+
+    void close() noexcept override {
+        {
+            std::lock_guard<std::mutex> lock(radio_->m);
+            radio_->closed = true;
+        }
+        radio_->cv.notify_all();
+    }
+
+    std::size_t read(std::uint8_t* dst, std::size_t n, int timeout_ms) override {
+        std::unique_lock<std::mutex> lock(radio_->m);
+        radio_->cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [&] {
+            return !radio_->pending.empty() || radio_->closed;
+        });
+        if (radio_->closed) return 0;
+        std::size_t i = 0;
+        while (i < n && !radio_->pending.empty()) {
+            dst[i++] = static_cast<std::uint8_t>(radio_->pending.front());
+            radio_->pending.pop_front();
+        }
+        return i;
+    }
+
+    void write(const std::uint8_t* src, std::size_t n) override {
+        {
+            std::lock_guard<std::mutex> lock(radio_->m);
+            for (std::size_t i = 0; i < n; i++) {
+                const char c = static_cast<char>(src[i]);
+                if (c == ';') {
+                    radio_->handle(partial_);
+                    partial_.clear();
+                } else {
+                    partial_.push_back(c);
+                }
+            }
+        }
+        radio_->cv.notify_all();
+    }
+
+    void set_dtr(bool on) override {
+        std::lock_guard<std::mutex> lock(radio_->m);
+        radio_->dtr = on ? 1 : 0;
+    }
+    void set_rts(bool on) override {
+        std::lock_guard<std::mutex> lock(radio_->m);
+        radio_->rts = on ? 1 : 0;
+    }
+
+    std::string description() const override { return "USB CP2102"; }
+
+private:
+    std::shared_ptr<Kenwood> radio_;
+    // Only touched from the bridge's single pump-in thread, and always
+    // under the radio's lock in `write`.
+    std::string partial_;
+};
+
+std::unique_ptr<rig::RigBackend> bridged(rig::HamlibConfig config,
+                                         const std::shared_ptr<Kenwood>& radio) {
+    // A real Kenwood answers `TX;` and `RX;` with nothing at all, and
+    // this fake is faithful about that -- so Hamlib waits out its read
+    // timeout on every keying command. At the stock 1000 ms that is
+    // most of these tests' runtime, and a slow test is a test whose
+    // watchdog has to be loose enough to be useless. The link here is a
+    // loopback socket to an in-process fake, so 200 ms is still two
+    // orders of magnitude more than it can need.
+    config.timeout_ms = 200;
+    return rig::make_bridged_backend(
+        config, std::make_shared<KenwoodTransport>(radio),
+        [](const rig::HamlibConfig& c) { return rig::make_hamlib_backend(c); });
+}
+
+
+
+void test_a_native_backend_works_over_a_socket() {
+    auto radio = std::make_shared<Kenwood>();
+    rig::HamlibConfig config;
+    config.model = MODEL_TS2000;
+    config.ptt_method = rig::PttMethod::Cat;
+    // Deliberately not a path and not a host: on Android the operator
+    // picks a device from a list and this is its identifier. What the
+    // bridge hands Hamlib is a loopback address instead.
+    config.device = "usb:10c4:ea60";
+
+    auto backend = bridged(config, radio);
+    backend->open();
+
+    // Hamlib opened a *Kenwood* over a socket. `ID;` is the TS-2000
+    // backend's own handshake, so its arrival is the proof: nothing in
+    // the bridge knows what a Kenwood is.
+    check::is_true(radio->saw("ID"),
+                   "hamlib/bridge: a native backend handshakes over the socket");
+
+    check::equal(backend->frequency_hz(), 14'074'000.0,
+                 "hamlib/bridge: and reads the frequency the radio reported");
+    check::is_true(radio->saw("FA"),
+                   "hamlib/bridge: ...by actually asking for it");
+
+    backend->set_ptt(true);
+    check::is_true(radio->wait_for("TX"),
+                   "hamlib/bridge: CAT keying reaches the radio");
+    backend->set_ptt(false);
+    check::is_true(radio->wait_for("RX"),
+                   "hamlib/bridge: and unkeying does too");
+
+    backend->close();
+    std::lock_guard<std::mutex> lock(radio->m);
+    check::is_true(radio->closed, "hamlib/bridge: closing releases the device");
+}
+
+void test_dtr_keying_never_reaches_hamlib() {
+    // The one thing that cannot go over this transport. `ser_set_dtr`
+    // is a TIOCMSET ioctl and Hamlib is holding a socket, so a DTR
+    // keying request handed to Hamlib fails -- at the moment somebody
+    // presses transmit, which is the worst time to discover it. The
+    // line is driven on the transport instead, and Hamlib is configured
+    // not to key at all.
+    auto radio = std::make_shared<Kenwood>();
+    rig::HamlibConfig config;
+    config.model = MODEL_TS2000;
+    config.ptt_method = rig::PttMethod::Dtr;
+    config.device = "usb:10c4:ea60";
+
+    auto backend = bridged(config, radio);
+    backend->open();
+    {
+        std::lock_guard<std::mutex> lock(radio->m);
+        check::equal(radio->dtr, 0, "hamlib/bridge: DTR is parked unkeyed on open");
+    }
+
+    backend->set_ptt(true);
+    {
+        std::lock_guard<std::mutex> lock(radio->m);
+        check::equal(radio->dtr, 1, "hamlib/bridge: DTR keying drives the line");
+    }
+    check::is_true(!radio->saw("TX"),
+                   "hamlib/bridge: and sends no CAT keying command");
+
+    backend->set_ptt(false);
+    std::lock_guard<std::mutex> lock(radio->m);
+    check::equal(radio->dtr, 0, "hamlib/bridge: unkeying releases it");
+}
+
+void test_the_controller_drives_a_bridged_rig() {
+    // The same threading design, over the new transport: nothing about
+    // RigController changed to make this work, which is the property
+    // `docs/android.md` predicted would hold and the reason a CAT
+    // backend could be added later without restructuring anything.
+    auto radio = std::make_shared<Kenwood>();
+    rig::HamlibConfig config;
+    config.model = MODEL_TS2000;
+    config.device = "usb:10c4:ea60";
+
+    std::mutex m;
+    std::condition_variable cv;
+    std::optional<double> reported;
+
+    rig::RigController controller(
+        [&](std::optional<double> hz) {
+            {
+                std::lock_guard<std::mutex> lock(m);
+                if (hz) reported = hz;
+            }
+            cv.notify_all();
+        },
+        {});
+    rig::RigConfig rig_config;
+    rig_config.poll_interval_s = 0.05;
+    controller.start(bridged(config, radio), rig_config);
+
+    std::unique_lock<std::mutex> lock(m);
+    const bool got = cv.wait_for(lock, std::chrono::seconds(10),
+                                 [&] { return reported.has_value(); });
+    check::is_true(got, "hamlib/bridge: the controller polls a bridged rig");
+    if (got) {
+        check::equal(*reported, 14'074'000.0,
+                     "hamlib/bridge: and publishes what it read");
+    }
+}
+
+}  // namespace
+
 // returns" -- and a hang with no output tells you nothing at all except
 // on which platform it happened. Printing alone was not enough: ctest
 // holds a test's output until it finishes, so a live log shows nothing
@@ -210,14 +506,22 @@ void test_the_controller_drives_a_real_backend() {
 int main() {
     check::report_crashes_instead_of_prompting();
 
-    // ~90x the measured runtime (0.65 s on Linux). Sized so that
-    // expiring can only mean wedged, and so it fires well inside the
-    // ctest TIMEOUT -- the two are not redundant, they answer different
-    // questions. If the watchdog fires, a step is stuck and it says
-    // which. If ctest times out instead, with this test's "ok:" line in
-    // the captured output, then everything finished and the wedge is in
-    // process teardown -- which is a different bug in a different place.
-    const check::Watchdog watchdog(60.0, "hamlib backend");
+    // ~23x the measured runtime (5.2 s on Linux, up from 0.65 s when
+    // the bridged tests were added). Sized so that expiring can only
+    // mean wedged, and so it fires well inside the ctest TIMEOUT -- the
+    // two are not redundant, they answer different questions. If the
+    // watchdog fires, a step is stuck and it says which. If ctest times
+    // out instead, with this test's "ok:" line in the captured output,
+    // then everything finished and the wedge is in process teardown --
+    // which is a different bug in a different place.
+    //
+    // A smaller multiple than CLAUDE.md's ~90x, deliberately: most of
+    // this test's runtime is Hamlib waiting out deliberate read
+    // timeouts on commands a Kenwood does not answer, and a wall-clock
+    // wait does not get slower on a slower machine the way a
+    // compute-bound test does. The part that *does* scale is well under
+    // a second.
+    const check::Watchdog watchdog(120.0, "hamlib backend");
 
     try {
         STEP(test_list_models);
@@ -226,6 +530,9 @@ int main() {
         STEP(test_an_unknown_model_is_refused_readably);
         STEP(test_using_a_closed_rig_reports_rather_than_crashes);
         STEP(test_the_controller_drives_a_real_backend);
+        STEP(test_a_native_backend_works_over_a_socket);
+        STEP(test_dtr_keying_never_reaches_hamlib);
+        STEP(test_the_controller_drives_a_bridged_rig);
         check::current_step = "reporting";
         std::fprintf(stderr, "-- done\n");
         std::fflush(stderr);

--- a/native/tests/test_rig_hamlib.cpp
+++ b/native/tests/test_rig_hamlib.cpp
@@ -418,6 +418,33 @@ void test_a_native_backend_works_over_a_socket() {
     check::is_true(radio->closed, "hamlib/bridge: closing releases the device");
 }
 
+void test_serial_defaults_come_from_the_backend_caps() {
+    // The other half of the bridged path's line settings. `rig_init`
+    // takes a serial port's defaults from `struct rig_caps`, and its own
+    // comment on the rate says "fastest !" -- so this reads
+    // `serial_rate_max`, deliberately, rather than picking something
+    // more conservative. A different choice would make a bridged rig run
+    // at a different speed than the same rig on a desktop.
+    const rig::SerialDefaults ts2000 = rig::serial_defaults(MODEL_TS2000);
+    check::is_true(ts2000.baud > 0,
+                   "hamlib/defaults: a real backend reports a rate (" +
+                       std::to_string(ts2000.baud) + ")");
+    check::is_true(ts2000.data_bits == 7 || ts2000.data_bits == 8,
+                   "hamlib/defaults: and a plausible word length");
+    check::is_true(ts2000.stop_bits == 1 || ts2000.stop_bits == 2,
+                   "hamlib/defaults: and a plausible stop-bit count");
+
+    // A model Hamlib does not know is a configuration the operator has
+    // to fix anyway, and `rig_init` will refuse it a moment later with a
+    // better message. Falling back rather than throwing is what lets a
+    // settings screen still render while it is wrong.
+    const rig::SerialDefaults unknown = rig::serial_defaults(999999);
+    check::equal(unknown.baud, 9600,
+                 "hamlib/defaults: an unknown model falls back to 9600");
+    check::equal(unknown.data_bits, 8, "hamlib/defaults: ...8 data bits");
+    check::equal(unknown.stop_bits, 1, "hamlib/defaults: ...1 stop bit");
+}
+
 void test_dtr_keying_never_reaches_hamlib() {
     // The one thing that cannot go over this transport. `ser_set_dtr`
     // is a TIOCMSET ioctl and Hamlib is holding a socket, so a DTR
@@ -531,6 +558,7 @@ int main() {
         STEP(test_using_a_closed_rig_reports_rather_than_crashes);
         STEP(test_the_controller_drives_a_real_backend);
         STEP(test_a_native_backend_works_over_a_socket);
+        STEP(test_serial_defaults_come_from_the_backend_caps);
         STEP(test_dtr_keying_never_reaches_hamlib);
         STEP(test_the_controller_drives_a_bridged_rig);
         check::current_step = "reporting";

--- a/native/third_party/usb-serial-for-android/LICENSE
+++ b/native/third_party/usb-serial-for-android/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2011-2013 Google Inc.
+Copyright (c) 2013 Mike Wakerly
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/native/third_party/usb-serial-for-android/README.md
+++ b/native/third_party/usb-serial-for-android/README.md
@@ -42,9 +42,42 @@ this file**, not bumping a version string. Do it deliberately, in step
 with checking that `SerialBridge.java` still compiles -- upstream has
 changed the `read` and flow-control signatures within the 3.x series.
 
+## `shim/` — one class Gradle would have generated
+
+Gradle synthesises a `BuildConfig` per Android *module*, in that module's
+own package. Consumed as an `.aar` you get
+`com.hoho.android.usbserial.BuildConfig` for free; compiling the sources
+into an app, Gradle generates one for `org.cleverdomain.sstvae` and none
+at all for the library's package — so `Ch34xSerialDriver` and
+`ProlificSerialDriver` fail to compile on an import, and only during a
+full Gradle run.
+
+`shim/com/hoho/android/usbserial/BuildConfig.java` supplies it. It is in
+`shim/` rather than in `java/` precisely so `java/` stays a byte-for-byte
+drop of the release: an edit in there would have to be diffed back out
+at every update, which is the sort of thing that gets forgotten once and
+then silently reverted.
+
+`DEBUG` is `false`, and that is the correct value rather than a
+convenient one. The single place upstream reads it
+(`Ch34xSerialDriver:206`) is a test-only escape hatch that strips a bit
+from the requested baud rate — upstream's own comment says "for testing
+purpose bypass dedicated baud rate handling". False is what a release
+build of the library compiles to. `ProlificSerialDriver` imports the
+class and never reads it.
+
+It is deliberately *not* wired to the app's own `BuildConfig`: AGP 8
+does not generate one unless `android.buildFeatures.buildConfig` is
+enabled, so that would trade a compile error we understand for one that
+would have to be rediscovered.
+
+Nothing else in `java/` depends on generated code — no `R.` references,
+and the only import outside `java.*`, `android.*` and `com.hoho.*` is
+`androidx.annotation.IntDef`.
+
 ## Build integration
 
-`native/android-app/CMakeLists.txt` stages `java/` into the assembled
+`native/android-app/CMakeLists.txt` stages `java/` and `shim/` into the assembled
 `QT_ANDROID_PACKAGE_SOURCE_DIR`, alongside the app's own Java and the
 audio and rig layers'. It is the only Android-only entry in
 `third_party/`, so nothing else in the tree references it and the

--- a/native/third_party/usb-serial-for-android/README.md
+++ b/native/third_party/usb-serial-for-android/README.md
@@ -1,0 +1,56 @@
+# usb-serial-for-android (vendored)
+
+The Java sources of https://github.com/mik3y/usb-serial-for-android,
+tag `3.11.0` (commit `16d84116a03880a7842a9439b83f5f62ac892df2`),
+fetched 2026-08-22. MIT -- see `LICENSE`, which is upstream's own file.
+19 files, ~4200 lines, under `java/com/hoho/android/usbserial/`.
+
+## What it is for
+
+Android hands an unprivileged app no `/dev/ttyUSB0`. USB serial goes
+through the USB host API, which gives you bulk endpoints and nothing
+else -- so *every* chip-level protocol has to be implemented on top:
+FTDI's modem-status prefix on every packet, CP210x's vendor control
+requests, CH34x's undocumented register writes, PL2303's several
+incompatible generations, and CDC-ACM's line-coding descriptors. This
+library is that work, and it is the standard answer for it in the ham
+software that already runs on Android.
+
+`core/rig/android/SerialBridge.java` uses it: `UsbSerialProber` to find
+and probe devices, and `UsbSerialPort` for `read`/`write`/
+`setParameters`/`setDTR`/`setRTS`/`setFlowControl`. `setDTR` and
+`setRTS` are load-bearing rather than incidental -- they are how PTT is
+asserted on the bridged path, where Hamlib is holding a socket and its
+own `ser_set_dtr` (a `TIOCMSET` ioctl) cannot work.
+
+## Why vendored rather than a Gradle dependency
+
+Qt's generated `build.gradle` already carries
+`implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])`,
+so dropping an `.aar` in would have worked with no template surgery.
+It was not done, for the reason `tools/make_installer.sh` declines
+`choco install nsis`: the artifact is published on JitPack, which
+**builds on demand from a git tag** rather than serving a fixed file.
+That makes a build's success a property of a third-party build
+service's current state, which is the thing pinning exists to prevent
+-- and there is no `repo1.maven.org` copy to pin instead. Vendoring
+4200 lines of Java is the smaller cost, and it is the same trade
+`../easyexif` and `../stb` already record.
+
+The consequence to know about: **updating means replacing `java/` and
+this file**, not bumping a version string. Do it deliberately, in step
+with checking that `SerialBridge.java` still compiles -- upstream has
+changed the `read` and flow-control signatures within the 3.x series.
+
+## Build integration
+
+`native/android-app/CMakeLists.txt` stages `java/` into the assembled
+`QT_ANDROID_PACKAGE_SOURCE_DIR`, alongside the app's own Java and the
+audio and rig layers'. It is the only Android-only entry in
+`third_party/`, so nothing else in the tree references it and the
+desktop build never sees it.
+
+Its one external dependency is `androidx.annotation.IntDef`, which
+arrives transitively through the `androidx.core` dependency Qt's own
+template already declares. Nothing else outside `java.*` and
+`android.*` is imported.

--- a/native/third_party/usb-serial-for-android/REUSE.toml
+++ b/native/third_party/usb-serial-for-android/REUSE.toml
@@ -10,6 +10,14 @@ path = "java/**"
 SPDX-FileCopyrightText = "Copyright 2011-2013 Google Inc., Copyright 2013 Mike Wakerly and contributors"
 SPDX-License-Identifier = "MIT"
 
+# `shim/` is ours, sitting in their package namespace because Java
+# requires it to. Annotated rather than left to the root LICENSE so a
+# scanner does not read a third_party/ path as third-party code.
+[[annotations]]
+path = "shim/**"
+SPDX-FileCopyrightText = "Copyright the SSTVAE authors"
+SPDX-License-Identifier = "Artistic-2.0"
+
 [[annotations]]
 path = ["LICENSE", "README.md"]
 SPDX-FileCopyrightText = "Copyright 2011-2013 Google Inc., Copyright 2013 Mike Wakerly and contributors"

--- a/native/third_party/usb-serial-for-android/REUSE.toml
+++ b/native/third_party/usb-serial-for-android/REUSE.toml
@@ -1,0 +1,16 @@
+version = 1
+
+# Upstream's own MIT terms, recorded here rather than in the root
+# NOTICE: that file is exhaustively about the branding artwork, which is
+# licensed and *not* sublicensed onward. This is the opposite case -- a
+# redistributor may ship these files freely, provided the MIT notice in
+# LICENSE goes with them.
+[[annotations]]
+path = "java/**"
+SPDX-FileCopyrightText = "Copyright 2011-2013 Google Inc., Copyright 2013 Mike Wakerly and contributors"
+SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = ["LICENSE", "README.md"]
+SPDX-FileCopyrightText = "Copyright 2011-2013 Google Inc., Copyright 2013 Mike Wakerly and contributors"
+SPDX-License-Identifier = "MIT"

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -1,0 +1,451 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.util.Log;
+
+import com.hoho.android.usbserial.util.HexDump;
+import com.hoho.android.usbserial.util.MonotonicClock;
+import com.hoho.android.usbserial.util.UsbUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * USB CDC/ACM serial driver implementation.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ * @see <a
+ *      href="http://www.usb.org/developers/devclass_docs/usbcdc11.pdf">Universal
+ *      Serial Bus Class Definitions for Communication Devices, v1.1</a>
+ */
+public class CdcAcmSerialDriver implements UsbSerialDriver {
+
+    public static final int USB_SUBCLASS_ACM = 2;
+
+    private final String TAG = CdcAcmSerialDriver.class.getSimpleName();
+
+    private final UsbDevice mDevice;
+    private final List<UsbSerialPort> mPorts;
+
+    public CdcAcmSerialDriver(UsbDevice device) {
+        mDevice = device;
+        mPorts = new ArrayList<>();
+        int ports = countPorts(device);
+        for (int port = 0; port < ports; port++) {
+            mPorts.add(new CdcAcmSerialPort(mDevice, port));
+        }
+        if (mPorts.size() == 0) {
+            mPorts.add(new CdcAcmSerialPort(mDevice, -1));
+        }
+    }
+
+    @SuppressWarnings({"unused"})
+    public static boolean probe(UsbDevice device) {
+        return countPorts(device) > 0;
+    }
+
+    private static int countPorts(UsbDevice device) {
+        int controlInterfaceCount = 0;
+        int dataInterfaceCount = 0;
+        for (int i = 0; i < device.getInterfaceCount(); i++) {
+            if (device.getInterface(i).getInterfaceClass() == UsbConstants.USB_CLASS_COMM &&
+                    device.getInterface(i).getInterfaceSubclass() == USB_SUBCLASS_ACM)
+                controlInterfaceCount++;
+            if (device.getInterface(i).getInterfaceClass() == UsbConstants.USB_CLASS_CDC_DATA)
+                dataInterfaceCount++;
+        }
+        return Math.min(controlInterfaceCount, dataInterfaceCount);
+    }
+
+    @Override
+    public UsbDevice getDevice() {
+        return mDevice;
+    }
+
+    @Override
+    public List<UsbSerialPort> getPorts() {
+        return mPorts;
+    }
+
+    public class CdcAcmSerialPort extends CommonUsbSerialPort {
+
+        private UsbInterface mControlInterface;
+        private UsbInterface mDataInterface;
+
+        private UsbEndpoint mControlEndpoint;
+
+        private int mControlIndex;
+
+        private boolean mRts = false;
+        private boolean mDtr = false;
+
+        private static final int USB_RECIP_INTERFACE = 0x01;
+        private static final int USB_RT_ACM = UsbConstants.USB_TYPE_CLASS | USB_RECIP_INTERFACE;
+
+        private static final int SET_LINE_CODING = 0x20;  // USB CDC 1.1 section 6.2
+        private static final int GET_LINE_CODING = 0x21;
+        private static final int SET_CONTROL_LINE_STATE = 0x22;
+        private static final int SEND_BREAK = 0x23;
+
+        private static final int NOTIFICATION_REQUEST_TYPE = 0xA1;
+        private static final int SERIAL_STATE = 0x20;
+        private static final int SERIAL_STATE_PACKET_SIZE = 10;
+        private static final int SERIAL_STATE_FLAG_CD = 0x01;
+        private static final int SERIAL_STATE_FLAG_DSR = 0x02;
+        private static final int SERIAL_STATE_FLAG_RI = 0x08;
+
+        private volatile int mSerialState = 0;
+        private volatile Thread mReadControlLinesThread = null;
+        private final Object mReadControlLinesThreadLock = new Object();
+        private boolean mStopReadControlLinesThread = false;
+        private Exception mReadControlLinesException = null;
+
+        public CdcAcmSerialPort(UsbDevice device, int portNumber) {
+            super(device, portNumber);
+        }
+
+        @Override
+        public UsbSerialDriver getDriver() {
+            return CdcAcmSerialDriver.this;
+        }
+
+        @Override
+        protected void openInt() throws IOException {
+            Log.d(TAG, "interfaces:");
+            for (int i = 0; i < mDevice.getInterfaceCount(); i++) {
+                Log.d(TAG, mDevice.getInterface(i).toString());
+            }
+            if (mPortNumber == -1) {
+                Log.d(TAG,"device might be castrated ACM device, trying single interface logic");
+                openSingleInterface();
+            } else {
+                Log.d(TAG,"trying default interface logic");
+                openInterface();
+            }
+        }
+
+        private void openSingleInterface() throws IOException {
+            // the following code is inspired by the cdc-acm driver in the linux kernel
+
+            mControlIndex = 0;
+            mControlInterface = mDevice.getInterface(0);
+            mDataInterface = mDevice.getInterface(0);
+            if (!mConnection.claimInterface(mControlInterface, true)) {
+                throw new IOException("Could not claim shared control/data interface");
+            }
+
+            for (int i = 0; i < mControlInterface.getEndpointCount(); ++i) {
+                UsbEndpoint ep = mControlInterface.getEndpoint(i);
+                if ((ep.getDirection() == UsbConstants.USB_DIR_IN) && (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_INT)) {
+                    mControlEndpoint = ep;
+                } else if ((ep.getDirection() == UsbConstants.USB_DIR_IN) && (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK)) {
+                    mReadEndpoint = ep;
+                } else if ((ep.getDirection() == UsbConstants.USB_DIR_OUT) && (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK)) {
+                    mWriteEndpoint = ep;
+                }
+            }
+            if (mControlEndpoint == null) {
+                throw new IOException("No control endpoint");
+            }
+        }
+
+        private void openInterface() throws IOException {
+
+            mControlInterface = null;
+            mDataInterface = null;
+            int j = getInterfaceIdFromDescriptors();
+            Log.d(TAG, "interface count=" + mDevice.getInterfaceCount() + ", IAD=" + j);
+            if (j >= 0) {
+                for (int i = 0; i < mDevice.getInterfaceCount(); i++) {
+                    UsbInterface usbInterface = mDevice.getInterface(i);
+                    if (usbInterface.getId() == j || usbInterface.getId() == j+1) {
+                        if (usbInterface.getInterfaceClass() == UsbConstants.USB_CLASS_COMM &&
+                                usbInterface.getInterfaceSubclass() == USB_SUBCLASS_ACM) {
+                            mControlIndex = usbInterface.getId();
+                            mControlInterface = usbInterface;
+                        }
+                        if (usbInterface.getInterfaceClass() == UsbConstants.USB_CLASS_CDC_DATA) {
+                            mDataInterface = usbInterface;
+                        }
+                    }
+                }
+            }
+            if (mControlInterface == null || mDataInterface == null) {
+                Log.d(TAG, "no IAD fallback");
+                int controlInterfaceCount = 0;
+                int dataInterfaceCount = 0;
+                for (int i = 0; i < mDevice.getInterfaceCount(); i++) {
+                    UsbInterface usbInterface = mDevice.getInterface(i);
+                    if (usbInterface.getInterfaceClass() == UsbConstants.USB_CLASS_COMM &&
+                            usbInterface.getInterfaceSubclass() == USB_SUBCLASS_ACM) {
+                        if (controlInterfaceCount == mPortNumber) {
+                            mControlIndex = usbInterface.getId();
+                            mControlInterface = usbInterface;
+                        }
+                        controlInterfaceCount++;
+                    }
+                    if (usbInterface.getInterfaceClass() == UsbConstants.USB_CLASS_CDC_DATA) {
+                        if (dataInterfaceCount == mPortNumber) {
+                            mDataInterface = usbInterface;
+                        }
+                        dataInterfaceCount++;
+                    }
+                }
+            }
+
+            if(mControlInterface == null) {
+                throw new IOException("No control interface");
+            }
+            Log.d(TAG, "Control interface id " + mControlInterface.getId());
+
+            if (!mConnection.claimInterface(mControlInterface, true)) {
+                throw new IOException("Could not claim control interface");
+            }
+            mControlEndpoint = mControlInterface.getEndpoint(0);
+            if (mControlEndpoint.getDirection() != UsbConstants.USB_DIR_IN || mControlEndpoint.getType() != UsbConstants.USB_ENDPOINT_XFER_INT) {
+                throw new IOException("Invalid control endpoint");
+            }
+
+            if(mDataInterface == null) {
+                throw new IOException("No data interface");
+            }
+            Log.d(TAG, "data interface id " + mDataInterface.getId());
+            if (!mConnection.claimInterface(mDataInterface, true)) {
+                throw new IOException("Could not claim data interface");
+            }
+            for (int i = 0; i < mDataInterface.getEndpointCount(); i++) {
+                UsbEndpoint ep = mDataInterface.getEndpoint(i);
+                if (ep.getDirection() == UsbConstants.USB_DIR_IN && ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK)
+                    mReadEndpoint = ep;
+                if (ep.getDirection() == UsbConstants.USB_DIR_OUT && ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK)
+                    mWriteEndpoint = ep;
+            }
+        }
+
+        private int getInterfaceIdFromDescriptors() {
+            ArrayList<byte[]> descriptors = UsbUtils.getDescriptors(mConnection);
+            Log.d(TAG, "USB descriptor:");
+            for(byte[] descriptor : descriptors)
+                Log.d(TAG, HexDump.toHexString(descriptor));
+
+            if (descriptors.size() > 0 &&
+                    descriptors.get(0).length == 18 &&
+                    descriptors.get(0)[1] == 1 && // bDescriptorType
+                    descriptors.get(0)[4] == (byte)(UsbConstants.USB_CLASS_MISC) && //bDeviceClass
+                    descriptors.get(0)[5] == 2 && // bDeviceSubClass
+                    descriptors.get(0)[6] == 1) { // bDeviceProtocol
+                // is IAD device, see https://www.usb.org/sites/default/files/iadclasscode_r10.pdf
+                int port = -1;
+                for (int d = 1; d < descriptors.size(); d++) {
+                    if (descriptors.get(d).length == 8 &&
+                            descriptors.get(d)[1] == 0x0b && // bDescriptorType == IAD
+                            descriptors.get(d)[4] == UsbConstants.USB_CLASS_COMM && // bFunctionClass == CDC
+                            descriptors.get(d)[5] == USB_SUBCLASS_ACM) { // bFunctionSubClass == ACM
+                        port++;
+                        if (port == mPortNumber &&
+                                descriptors.get(d)[3] == 2) { // bInterfaceCount
+                            return descriptors.get(d)[2]; // bFirstInterface
+                        }
+                    }
+                }
+            }
+            return -1;
+        }
+
+        private int sendAcmControlMessage(int request, int value, byte[] buf) throws IOException {
+            int len = mConnection.controlTransfer(
+                    USB_RT_ACM, request, value, mControlIndex, buf, buf != null ? buf.length : 0, 5000);
+            if(len < 0) {
+                throw new IOException("controlTransfer failed");
+            }
+            return len;
+        }
+
+        private void readControlLinesThreadFunction() {
+            try {
+                byte[] buffer = new byte[Math.max(SERIAL_STATE_PACKET_SIZE, mControlEndpoint.getMaxPacketSize())];
+                while (!mStopReadControlLinesThread && mConnection!=null) {
+                    long endTime = MonotonicClock.millis() + 500;
+                    int readBytesCount = mConnection.bulkTransfer(mControlEndpoint, buffer, buffer.length, 500);
+                    if (readBytesCount == -1) {
+                        testConnection(MonotonicClock.millis() < endTime);
+                        continue;
+                    }
+                    if (readBytesCount != SERIAL_STATE_PACKET_SIZE) continue;
+                    if (buffer[0] != (byte)NOTIFICATION_REQUEST_TYPE) continue;
+                    if (buffer[1] != SERIAL_STATE) continue;
+                    int index = ((buffer[5] & 0xff) << 8) | (buffer[4] & 0xff);
+                    if (index != mControlIndex) continue;
+                    int payloadLength = ((buffer[7] & 0xff) << 8) | (buffer[6] & 0xff);
+                    if (payloadLength < 2) continue;
+                    mSerialState = ((buffer[9] & 0xff) << 8) | (buffer[8] & 0xff);
+                    Log.d(TAG, "control line state " + Arrays.toString(buffer));
+                }
+            } catch (Exception e) {
+                mReadControlLinesException = e;
+            }
+        }
+
+        private int getSerialState() throws IOException {
+            if(mConnection == null)
+                throw new IOException("connection closed");
+            if (mReadControlLinesThread == null) {
+                synchronized (mReadControlLinesThreadLock) {
+                    if (mReadControlLinesThread == null) {
+                        mSerialState = 0;
+                        mReadControlLinesThread = new Thread(this::readControlLinesThreadFunction);
+                        mReadControlLinesThread.setDaemon(true);
+                        mReadControlLinesThread.start();
+                    }
+                }
+            }
+            if (mReadControlLinesException != null) {
+                throw new IOException(mReadControlLinesException);
+            }
+            return mSerialState;
+        }
+
+        @Override
+        protected void closeInt() {
+            try {
+                synchronized (mReadControlLinesThreadLock) {
+                    if (mReadControlLinesThread != null) {
+                        try {
+                            mStopReadControlLinesThread = true;
+                            mReadControlLinesThread.join();
+                        } catch (Exception e) {
+                            Log.w(TAG, "An error occurred while waiting for control line read thread", e);
+                        }
+                        mStopReadControlLinesThread = false;
+                        mReadControlLinesThread = null;
+                        mReadControlLinesException = null;
+                    }
+                }
+                mConnection.releaseInterface(mControlInterface);
+                mConnection.releaseInterface(mDataInterface);
+            } catch(Exception ignored) {}
+        }
+
+        @Override
+        public void setParameters(int baudRate, int dataBits, int stopBits, @Parity int parity) throws IOException {
+            if(baudRate <= 0) {
+                throw new IllegalArgumentException("Invalid baud rate: " + baudRate);
+            }
+            if(dataBits < DATABITS_5 || dataBits > DATABITS_8) {
+                throw new IllegalArgumentException("Invalid data bits: " + dataBits);
+            }
+            byte stopBitsByte;
+            switch (stopBits) {
+                case STOPBITS_1: stopBitsByte = 0; break;
+                case STOPBITS_1_5: stopBitsByte = 1; break;
+                case STOPBITS_2: stopBitsByte = 2; break;
+                default: throw new IllegalArgumentException("Invalid stop bits: " + stopBits);
+            }
+
+            byte parityBitesByte;
+            switch (parity) {
+                case PARITY_NONE: parityBitesByte = 0; break;
+                case PARITY_ODD: parityBitesByte = 1; break;
+                case PARITY_EVEN: parityBitesByte = 2; break;
+                case PARITY_MARK: parityBitesByte = 3; break;
+                case PARITY_SPACE: parityBitesByte = 4; break;
+                default: throw new IllegalArgumentException("Invalid parity: " + parity);
+            }
+            byte[] msg = {
+                    (byte) ( baudRate & 0xff),
+                    (byte) ((baudRate >> 8 ) & 0xff),
+                    (byte) ((baudRate >> 16) & 0xff),
+                    (byte) ((baudRate >> 24) & 0xff),
+                    stopBitsByte,
+                    parityBitesByte,
+                    (byte) dataBits};
+            sendAcmControlMessage(SET_LINE_CODING, 0, msg);
+        }
+
+        @Override
+        public boolean getDTR() throws IOException {
+            return mDtr;
+        }
+
+        @Override
+        public void setDTR(boolean value) throws IOException {
+            mDtr = value;
+            setDtrRts();
+        }
+
+        @Override
+        public boolean getRTS() throws IOException {
+            return mRts;
+        }
+
+        @Override
+        public boolean getCD() throws IOException {
+            return (getSerialState() & SERIAL_STATE_FLAG_CD) != 0;
+        }
+
+        @Override
+        public boolean getDSR() throws IOException {
+            return (getSerialState() & SERIAL_STATE_FLAG_DSR) != 0;
+        }
+
+        @Override
+        public boolean getRI() throws IOException {
+            return (getSerialState() & SERIAL_STATE_FLAG_RI) != 0;
+        }
+
+        @Override
+        public void setRTS(boolean value) throws IOException {
+            mRts = value;
+            setDtrRts();
+        }
+
+        private void setDtrRts() throws IOException {
+            int value = (mRts ? 0x2 : 0) | (mDtr ? 0x1 : 0);
+            sendAcmControlMessage(SET_CONTROL_LINE_STATE, value, null);
+        }
+
+        @Override
+        public EnumSet<ControlLine> getControlLines() throws IOException {
+            int serialState = getSerialState();
+            EnumSet<ControlLine> set = EnumSet.noneOf(ControlLine.class);
+            if(mRts) set.add(ControlLine.RTS);
+            // no CTS
+            if(mDtr) set.add(ControlLine.DTR);
+            if((serialState & SERIAL_STATE_FLAG_DSR) != 0) set.add(ControlLine.DSR);
+            if((serialState & SERIAL_STATE_FLAG_CD) != 0) set.add(ControlLine.CD);
+            if((serialState & SERIAL_STATE_FLAG_RI) != 0) set.add(ControlLine.RI);
+            return set;
+        }
+
+        @Override
+        public EnumSet<ControlLine> getSupportedControlLines() throws IOException {
+            return EnumSet.of(ControlLine.RTS, ControlLine.DTR, ControlLine.DSR, ControlLine.CD, ControlLine.RI);
+        }
+
+        @Override
+        public void setBreak(boolean value) throws IOException {
+            sendAcmControlMessage(SEND_BREAK, value ? 0xffff : 0, null);
+        }
+
+    }
+
+    @SuppressWarnings({"unused"})
+    public static Map<Integer, int[]> getSupportedDevices() {
+        return new LinkedHashMap<>();
+    }
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java
@@ -1,0 +1,387 @@
+/* Copyright 2014 Andreas Butti
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.util.Log;
+
+import com.hoho.android.usbserial.BuildConfig;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Ch34xSerialDriver implements UsbSerialDriver {
+
+    private static final String TAG = Ch34xSerialDriver.class.getSimpleName();
+
+    private final UsbDevice mDevice;
+    private final UsbSerialPort mPort;
+
+    private static final int LCR_ENABLE_RX   = 0x80;
+    private static final int LCR_ENABLE_TX   = 0x40;
+    private static final int LCR_MARK_SPACE  = 0x20;
+    private static final int LCR_PAR_EVEN    = 0x10;
+    private static final int LCR_ENABLE_PAR  = 0x08;
+    private static final int LCR_STOP_BITS_2 = 0x04;
+    private static final int LCR_CS8         = 0x03;
+    private static final int LCR_CS7         = 0x02;
+    private static final int LCR_CS6         = 0x01;
+    private static final int LCR_CS5         = 0x00;
+
+    private static final int GCL_CTS = 0x01;
+    private static final int GCL_DSR = 0x02;
+    private static final int GCL_RI  = 0x04;
+    private static final int GCL_CD  = 0x08;
+    private static final int SCL_DTR = 0x20;
+    private static final int SCL_RTS = 0x40;
+
+    public Ch34xSerialDriver(UsbDevice device) {
+        mDevice = device;
+        mPort = new Ch340SerialPort(mDevice, 0);
+    }
+
+    @Override
+    public UsbDevice getDevice() {
+        return mDevice;
+    }
+
+    @Override
+    public List<UsbSerialPort> getPorts() {
+        return Collections.singletonList(mPort);
+    }
+
+    public class Ch340SerialPort extends CommonUsbSerialPort {
+
+        private static final int USB_TIMEOUT_MILLIS = 5000;
+
+        private final int DEFAULT_BAUD_RATE = 9600;
+
+        private boolean dtr = false;
+        private boolean rts = false;
+
+        public Ch340SerialPort(UsbDevice device, int portNumber) {
+            super(device, portNumber);
+        }
+
+        @Override
+        public UsbSerialDriver getDriver() {
+            return Ch34xSerialDriver.this;
+        }
+
+        @Override
+        protected void openInt() throws IOException {
+            for (int i = 0; i < mDevice.getInterfaceCount(); i++) {
+                UsbInterface usbIface = mDevice.getInterface(i);
+                if (!mConnection.claimInterface(usbIface, true)) {
+                    throw new IOException("Could not claim data interface");
+                }
+            }
+
+            UsbInterface dataIface = mDevice.getInterface(mDevice.getInterfaceCount() - 1);
+            for (int i = 0; i < dataIface.getEndpointCount(); i++) {
+                UsbEndpoint ep = dataIface.getEndpoint(i);
+                if (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK) {
+                    if (ep.getDirection() == UsbConstants.USB_DIR_IN) {
+                        mReadEndpoint = ep;
+                    } else {
+                        mWriteEndpoint = ep;
+                    }
+                }
+            }
+
+            initialize();
+            setBaudRate(DEFAULT_BAUD_RATE);
+        }
+
+        @Override
+        protected void closeInt() {
+            try {
+                for (int i = 0; i < mDevice.getInterfaceCount(); i++)
+                    mConnection.releaseInterface(mDevice.getInterface(i));
+            } catch(Exception ignored) {}
+        }
+
+        private int controlOut(int request, int value, int index) {
+            final int REQTYPE_HOST_TO_DEVICE = UsbConstants.USB_TYPE_VENDOR | UsbConstants.USB_DIR_OUT;
+            return mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, request,
+                    value, index, null, 0, USB_TIMEOUT_MILLIS);
+        }
+
+
+        private int controlIn(int request, int value, int index, byte[] buffer) {
+            final int REQTYPE_DEVICE_TO_HOST = UsbConstants.USB_TYPE_VENDOR | UsbConstants.USB_DIR_IN;
+            return mConnection.controlTransfer(REQTYPE_DEVICE_TO_HOST, request,
+                    value, index, buffer, buffer.length, USB_TIMEOUT_MILLIS);
+        }
+
+
+        private void checkState(String msg, int request, int value, int[] expected) throws IOException {
+            byte[] buffer = new byte[expected.length];
+            int ret = controlIn(request, value, 0, buffer);
+
+            if (ret < 0) {
+                throw new IOException("Failed send cmd [" + msg + "]");
+            }
+
+            if (ret != expected.length) {
+                throw new IOException("Expected " + expected.length + " bytes, but get " + ret + " [" + msg + "]");
+            }
+
+            for (int i = 0; i < expected.length; i++) {
+                if (expected[i] == -1) {
+                    continue;
+                }
+
+                int current = buffer[i] & 0xff;
+                if (expected[i] != current) {
+                    throw new IOException("Expected 0x" + Integer.toHexString(expected[i]) + " byte, but get 0x" + Integer.toHexString(current) + " [" + msg + "]");
+                }
+            }
+        }
+
+        private void setControlLines() throws IOException {
+            if (controlOut(0xa4, ~((dtr ? SCL_DTR : 0) | (rts ? SCL_RTS : 0)), 0) < 0) {
+                throw new IOException("Failed to set control lines");
+            }
+        }
+
+        private byte getStatus() throws IOException {
+            byte[] buffer = new byte[2];
+            int ret = controlIn(0x95, 0x0706, 0, buffer);
+            if (ret < 0)
+                throw new IOException("Error getting control lines");
+            return buffer[0];
+        }
+
+        private void initialize() throws IOException {
+            checkState("init #1", 0x5f, 0, new int[]{-1 /* 0x27, 0x30 */, 0x00});
+
+            if (controlOut(0xa1, 0, 0) < 0) {
+                throw new IOException("Init failed: #2");
+            }
+
+            setBaudRate(DEFAULT_BAUD_RATE);
+
+            checkState("init #4", 0x95, 0x2518, new int[]{-1 /* 0x56, c3*/, 0x00});
+
+            if (controlOut(0x9a, 0x2518, LCR_ENABLE_RX | LCR_ENABLE_TX | LCR_CS8) < 0) {
+                throw new IOException("Init failed: #5");
+            }
+
+            checkState("init #6", 0x95, 0x0706, new int[]{-1/*0xf?*/, -1/*0xec,0xee*/});
+
+            if (controlOut(0xa1, 0x501f, 0xd90a) < 0) {
+                throw new IOException("Init failed: #7");
+            }
+
+            setBaudRate(DEFAULT_BAUD_RATE);
+
+            setControlLines();
+
+            checkState("init #10", 0x95, 0x0706, new int[]{-1/* 0x9f, 0xff*/, -1/*0xec,0xee*/});
+        }
+
+
+        private void setBaudRate(int baudRate) throws IOException {
+            long factor;
+            long divisor;
+
+            if (baudRate == 921600) {
+                divisor = 7;
+                factor = 0xf300;
+            } else {
+                final long BAUDBASE_FACTOR = 1532620800;
+                final int BAUDBASE_DIVMAX = 3;
+
+                if(BuildConfig.DEBUG && (baudRate & (3<<29)) == (1<<29))
+                    baudRate &= ~(1<<29); // for testing purpose bypass dedicated baud rate handling
+                factor = BAUDBASE_FACTOR / baudRate;
+                divisor = BAUDBASE_DIVMAX;
+                while ((factor > 0xfff0) && divisor > 0) {
+                    factor >>= 3;
+                    divisor--;
+                }
+                if (factor > 0xfff0) {
+                    throw new UnsupportedOperationException("Unsupported baud rate: " + baudRate);
+                }
+                factor = 0x10000 - factor;
+            }
+
+            divisor |= 0x0080; // else ch341a waits until buffer full
+            int val1 = (int) ((factor & 0xff00) | divisor);
+            int val2 = (int) (factor & 0xff);
+            Log.d(TAG, String.format("baud rate=%d, 0x1312=0x%04x, 0x0f2c=0x%04x", baudRate, val1, val2));
+            int ret = controlOut(0x9a, 0x1312, val1);
+            if (ret < 0) {
+                throw new IOException("Error setting baud rate: #1)");
+            }
+            ret = controlOut(0x9a, 0x0f2c, val2);
+            if (ret < 0) {
+                throw new IOException("Error setting baud rate: #2");
+            }
+        }
+
+        @Override
+        public void setParameters(int baudRate, int dataBits, int stopBits, @Parity int parity) throws IOException {
+            if(baudRate <= 0) {
+                throw new IllegalArgumentException("Invalid baud rate: " + baudRate);
+            }
+            setBaudRate(baudRate);
+
+            int lcr = LCR_ENABLE_RX | LCR_ENABLE_TX;
+
+            switch (dataBits) {
+                case DATABITS_5:
+                    lcr |= LCR_CS5;
+                    break;
+                case DATABITS_6:
+                    lcr |= LCR_CS6;
+                    break;
+                case DATABITS_7:
+                    lcr |= LCR_CS7;
+                    break;
+                case DATABITS_8:
+                    lcr |= LCR_CS8;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid data bits: " + dataBits);
+            }
+
+            switch (parity) {
+                case PARITY_NONE:
+                    break;
+                case PARITY_ODD:
+                    lcr |= LCR_ENABLE_PAR;
+                    break;
+                case PARITY_EVEN:
+                    lcr |= LCR_ENABLE_PAR | LCR_PAR_EVEN;
+                    break;
+                case PARITY_MARK:
+                    lcr |= LCR_ENABLE_PAR | LCR_MARK_SPACE;
+                    break;
+                case PARITY_SPACE:
+                    lcr |= LCR_ENABLE_PAR | LCR_MARK_SPACE | LCR_PAR_EVEN;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid parity: " + parity);
+            }
+
+            switch (stopBits) {
+                case STOPBITS_1:
+                    break;
+                case STOPBITS_1_5:
+                    throw new UnsupportedOperationException("Unsupported stop bits: 1.5");
+                case STOPBITS_2:
+                    lcr |= LCR_STOP_BITS_2;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid stop bits: " + stopBits);
+            }
+
+            int ret = controlOut(0x9a, 0x2518, lcr);
+            if (ret < 0) {
+                throw new IOException("Error setting control byte");
+            }
+        }
+
+        @Override
+        public boolean getCD() throws IOException {
+            return (getStatus() & GCL_CD) == 0;
+        }
+
+        @Override
+        public boolean getCTS() throws IOException {
+            return (getStatus() & GCL_CTS) == 0;
+        }
+
+        @Override
+        public boolean getDSR() throws IOException {
+            return (getStatus() & GCL_DSR) == 0;
+        }
+
+        @Override
+        public boolean getDTR() throws IOException {
+            return dtr;
+        }
+
+        @Override
+        public void setDTR(boolean value) throws IOException {
+            dtr = value;
+            setControlLines();
+        }
+
+        @Override
+        public boolean getRI() throws IOException {
+            return (getStatus() & GCL_RI) == 0;
+        }
+
+        @Override
+        public boolean getRTS() throws IOException {
+            return rts;
+        }
+
+        @Override
+        public void setRTS(boolean value) throws IOException {
+            rts = value;
+            setControlLines();
+        }
+
+        @Override
+        public EnumSet<ControlLine> getControlLines() throws IOException {
+            int status = getStatus();
+            EnumSet<ControlLine> set = EnumSet.noneOf(ControlLine.class);
+            if(rts) set.add(ControlLine.RTS);
+            if((status & GCL_CTS) == 0) set.add(ControlLine.CTS);
+            if(dtr) set.add(ControlLine.DTR);
+            if((status & GCL_DSR) == 0) set.add(ControlLine.DSR);
+            if((status & GCL_CD) == 0) set.add(ControlLine.CD);
+            if((status & GCL_RI) == 0) set.add(ControlLine.RI);
+            return set;
+        }
+
+        @Override
+        public EnumSet<ControlLine> getSupportedControlLines() throws IOException {
+            return EnumSet.allOf(ControlLine.class);
+        }
+
+        @Override
+        public void setBreak(boolean value) throws IOException {
+            byte[] req = new byte[2];
+            if(controlIn(0x95, 0x1805, 0, req) < 0) {
+                throw new IOException("Error getting BREAK condition");
+            }
+            if(value) {
+                req[0] &= ~1;
+                req[1] &= ~0x40;
+            } else {
+                req[0] |= 1;
+                req[1] |= 0x40;
+            }
+            int val = (req[1] & 0xff) << 8 | (req[0] & 0xff);
+            if(controlOut(0x9a, 0x1805, val) < 0) {
+                throw new IOException("Error setting BREAK condition");
+            }
+        }
+    }
+
+    @SuppressWarnings({"unused"})
+    public static Map<Integer, int[]> getSupportedDevices() {
+        final Map<Integer, int[]> supportedDevices = new LinkedHashMap<>();
+        supportedDevices.put(UsbId.VENDOR_QINHENG, new int[]{
+                UsbId.QINHENG_CH340,
+                UsbId.QINHENG_CH341A,
+        });
+        return supportedDevices;
+    }
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/ChromeCcdSerialDriver.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/ChromeCcdSerialDriver.java
@@ -1,0 +1,91 @@
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.util.Log;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+
+public class ChromeCcdSerialDriver implements UsbSerialDriver{
+
+    private final String TAG = ChromeCcdSerialDriver.class.getSimpleName();
+
+    private final UsbDevice mDevice;
+    private final List<UsbSerialPort> mPorts;
+
+    @Override
+    public UsbDevice getDevice() {
+        return mDevice;
+    }
+
+    @Override
+    public List<UsbSerialPort> getPorts() {
+        return mPorts;
+    }
+
+    public ChromeCcdSerialDriver(UsbDevice mDevice) {
+        this.mDevice = mDevice;
+        mPorts = new ArrayList<UsbSerialPort>();
+        for (int i = 0; i < 3; i++)
+            mPorts.add(new ChromeCcdSerialPort(mDevice, i));
+    }
+
+    public class ChromeCcdSerialPort extends CommonUsbSerialPort {
+        private UsbInterface mDataInterface;
+
+        public ChromeCcdSerialPort(UsbDevice device, int portNumber) {
+            super(device, portNumber);
+        }
+
+        @Override
+        protected void openInt() throws IOException {
+            Log.d(TAG, "claiming interfaces, count=" + mDevice.getInterfaceCount());
+            mDataInterface = mDevice.getInterface(mPortNumber);
+            if (!mConnection.claimInterface(mDataInterface, true)) {
+                throw new IOException("Could not claim shared control/data interface");
+            }
+            Log.d(TAG, "endpoint count=" + mDataInterface.getEndpointCount());
+            for (int i = 0; i < mDataInterface.getEndpointCount(); ++i) {
+                UsbEndpoint ep = mDataInterface.getEndpoint(i);
+                if ((ep.getDirection() == UsbConstants.USB_DIR_IN) && (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK)) {
+                    mReadEndpoint = ep;
+                } else if ((ep.getDirection() == UsbConstants.USB_DIR_OUT) && (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK)) {
+                    mWriteEndpoint = ep;
+                }
+            }
+        }
+
+        @Override
+        protected void closeInt() {
+            try {
+                mConnection.releaseInterface(mDataInterface);
+            } catch(Exception ignored) {}
+        }
+
+        @Override
+        public UsbSerialDriver getDriver() {
+            return ChromeCcdSerialDriver.this;
+        }
+
+        @Override
+        public void setParameters(int baudRate, int dataBits, int stopBits, int parity) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public static Map<Integer, int[]> getSupportedDevices() {
+        final Map<Integer, int[]> supportedDevices = new LinkedHashMap<>();
+        supportedDevices.put(UsbId.VENDOR_GOOGLE, new int[]{
+                UsbId.GOOGLE_CR50,
+        });
+        return supportedDevices;
+    }
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
@@ -1,0 +1,438 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbRequest;
+import android.os.Build;
+import android.util.Log;
+
+import com.hoho.android.usbserial.util.MonotonicClock;
+import com.hoho.android.usbserial.util.UsbUtils;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.Objects;
+
+/**
+ * A base class shared by several driver implementations.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+public abstract class CommonUsbSerialPort implements UsbSerialPort {
+
+    public static boolean DEBUG = false;
+
+    private static final String TAG = CommonUsbSerialPort.class.getSimpleName();
+    private static final int MAX_READ_SIZE = 16 * 1024; // = old bulkTransfer limit prior to Android 9
+
+    protected final UsbDevice mDevice;
+    protected final int mPortNumber;
+
+    // non-null when open()
+    protected UsbDeviceConnection mConnection;
+    protected UsbEndpoint mReadEndpoint;
+    protected UsbEndpoint mWriteEndpoint;
+    protected UsbRequest mReadRequest;
+    protected LinkedList<UsbRequest> mReadQueueRequests;
+    private int mReadQueueBufferCount;
+    private int mReadQueueBufferSize;
+    protected FlowControl mFlowControl = FlowControl.NONE;
+    protected UsbUtils.Supplier<UsbRequest> mUsbRequestSupplier = UsbRequest::new; // override for testing
+
+    /**
+     * Internal write buffer.
+     *  Guarded by {@link #mWriteBufferLock}.
+     *  Default length = mReadEndpoint.getMaxPacketSize()
+     **/
+    protected byte[] mWriteBuffer;
+    protected final Object mWriteBufferLock = new Object();
+
+
+    public CommonUsbSerialPort(UsbDevice device, int portNumber) {
+        mDevice = device;
+        mPortNumber = portNumber;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("<%s device_name=%s device_id=%s port_number=%s>",
+                getClass().getSimpleName(), mDevice.getDeviceName(),
+                mDevice.getDeviceId(), mPortNumber);
+    }
+
+    @Override
+    public UsbDevice getDevice() {
+        return mDevice;
+    }
+
+    @Override
+    public int getPortNumber() {
+        return mPortNumber;
+    }
+
+    @Override
+    public UsbEndpoint getWriteEndpoint() { return mWriteEndpoint; }
+
+    @Override
+    public UsbEndpoint getReadEndpoint() { return mReadEndpoint; }
+
+    /**
+     * Returns the device serial number
+     *  @return serial number
+     */
+    @Override
+    public String getSerial() {
+        return mConnection.getSerial();
+    }
+
+    /**
+     * Sets the size of the internal buffer used to exchange data with the USB
+     * stack for write operations.  Most users should not need to change this.
+     *
+     * @param bufferSize the size in bytes, <= 0 resets original size
+     */
+    public final void setWriteBufferSize(int bufferSize) {
+        synchronized (mWriteBufferLock) {
+            if (bufferSize <= 0) {
+                if (mWriteEndpoint != null) {
+                    bufferSize = mWriteEndpoint.getMaxPacketSize();
+                } else {
+                    mWriteBuffer = null;
+                    return;
+                }
+            }
+            if (mWriteBuffer != null && bufferSize == mWriteBuffer.length) {
+                return;
+            }
+            mWriteBuffer = new byte[bufferSize];
+        }
+    }
+
+    @Override
+    public void setReadQueue(int bufferCount, int bufferSize) {
+        if (bufferCount < 0) {
+            throw new IllegalArgumentException("Invalid bufferCount");
+        }
+        if (bufferSize < 0) {
+            throw new IllegalArgumentException("Invalid bufferSize");
+        }
+        if(isOpen()) {
+            if (bufferCount < mReadQueueBufferCount) {
+                throw new IllegalStateException("Cannot reduce bufferCount when port is open");
+            }
+            if (bufferSize == 0) {
+                bufferSize = mReadEndpoint.getMaxPacketSize();
+            }
+            if (mReadQueueBufferSize == 0) {
+                mReadQueueBufferSize = mReadEndpoint.getMaxPacketSize();
+            }
+            if (mReadQueueBufferCount != 0 && bufferSize != mReadQueueBufferSize) {
+                throw new IllegalStateException("Cannot change bufferSize when port is open");
+            }
+            if (bufferCount > 0) {
+                if (mReadQueueRequests == null) {
+                    mReadQueueRequests = new LinkedList<>();
+                }
+                for (int i = mReadQueueRequests.size(); i < bufferCount; i++) {
+                    ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
+                    UsbRequest request = mUsbRequestSupplier.get();
+                    request.initialize(mConnection, mReadEndpoint);
+                    request.setClientData(buffer);
+                    request.queue(buffer, bufferSize);
+                    mReadQueueRequests.add(request);
+                }
+            }
+        }
+        mReadQueueBufferCount = bufferCount;
+        mReadQueueBufferSize = bufferSize;
+    }
+
+    @Override
+    public int getReadQueueBufferCount() { return mReadQueueBufferCount; }
+    @Override
+    public int getReadQueueBufferSize() { return mReadQueueBufferSize; }
+
+    private boolean useReadQueue() { return mReadQueueBufferCount != 0; }
+
+    @Override
+    public void open(UsbDeviceConnection connection) throws IOException {
+        if (mConnection != null) {
+            throw new IOException("Already open");
+        }
+        if(connection == null) {
+            throw new IllegalArgumentException("Connection is null");
+        }
+        mConnection = connection;
+        boolean ok = false;
+        try {
+            openInt();
+            if (mReadEndpoint == null || mWriteEndpoint == null) {
+                throw new IOException("Could not get read & write endpoints");
+            }
+            mReadRequest = mUsbRequestSupplier.get();
+            mReadRequest.initialize(mConnection, mReadEndpoint);
+            setReadQueue(mReadQueueBufferCount, mReadQueueBufferSize); // fill mReadQueueRequests
+            ok = true;
+        } finally {
+            if (!ok) {
+                try {
+                    close();
+                } catch (Exception ignored) {}
+            }
+        }
+    }
+
+    protected abstract void openInt() throws IOException;
+
+    @Override
+    public void close() throws IOException {
+        if (mConnection == null) {
+            throw new IOException("Already closed");
+        }
+        UsbRequest readRequest = mReadRequest;
+        mReadRequest = null;
+        try {
+            readRequest.cancel();
+        } catch(Exception ignored) {}
+        if(mReadQueueRequests != null) {
+            for(UsbRequest readQueueRequest : mReadQueueRequests) {
+                try {
+                    readQueueRequest.cancel();
+                } catch(Exception ignored) {}
+            }
+            mReadQueueRequests = null;
+        }
+        try {
+            closeInt();
+        } catch(Exception ignored) {}
+        try {
+            mConnection.close();
+        } catch(Exception ignored) {}
+        mConnection = null;
+    }
+
+    protected abstract void closeInt();
+
+    /**
+     * use simple USB request supported by all devices to test if connection is still valid
+     */
+    protected void testConnection(boolean full) throws IOException {
+        testConnection(full, "USB get_status request failed");
+    }
+
+    protected void testConnection(boolean full, String msg) throws IOException {
+        if(mReadRequest == null) {
+            throw new IOException("Connection closed");
+        }
+        if(!full) {
+            return;
+        }
+        byte[] buf = new byte[2];
+        int len = mConnection.controlTransfer(0x80 /*DEVICE*/, 0 /*GET_STATUS*/, 0, 0, buf, buf.length, 200);
+        if(len < 0)
+            throw new IOException(msg);
+    }
+
+    @Override
+    public int read(final byte[] dest, final int timeout) throws IOException {
+        if(dest.length == 0) {
+            throw new IllegalArgumentException("Read buffer too small");
+        }
+        return read(dest, dest.length, timeout);
+    }
+
+    @Override
+    public int read(final byte[] dest, final int length, final int timeout) throws IOException {return read(dest, length, timeout, true);}
+
+    protected int read(final byte[] dest, int length, final int timeout, boolean testConnection) throws IOException {
+        testConnection(false);
+        if(length <= 0) {
+            throw new IllegalArgumentException("Read length too small");
+        }
+        length = Math.min(length, dest.length);
+        final int nread;
+        if (timeout != 0) {
+            if(useReadQueue()) {
+                throw new IllegalStateException("Cannot use timeout!=0 if readQueue is enabled");
+            }
+            // bulkTransfer will cause data loss with short timeout + high baud rates + continuous transfer
+            //   https://stackoverflow.com/questions/9108548/android-usb-host-bulktransfer-is-losing-data
+            // but mConnection.requestWait(timeout) available since Android 8.0 es even worse,
+            // as it crashes with short timeout, e.g.
+            //   A/libc: Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x276a in tid 29846 (pool-2-thread-1), pid 29618 (.usbserial.test)
+            //     /system/lib64/libusbhost.so (usb_request_wait+192)
+            //     /system/lib64/libandroid_runtime.so (android_hardware_UsbDeviceConnection_request_wait(_JNIEnv*, _jobject*, long)+84)
+            // data loss / crashes were observed with timeout up to 200 msec
+            long endTime = testConnection ? MonotonicClock.millis() + timeout : 0;
+            int readMax = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) ? length : Math.min(length, MAX_READ_SIZE);
+            nread = mConnection.bulkTransfer(mReadEndpoint, dest, readMax, timeout);
+            // Android error propagation is improvable:
+            //  nread == -1 can be: timeout, connection lost, buffer too small, ???
+            if(nread == -1 && testConnection)
+                testConnection(MonotonicClock.millis() < endTime);
+
+        } else {
+            ByteBuffer buf = null;
+            if(useReadQueue()) {
+                if (length != mReadQueueBufferSize) {
+                    throw new IllegalStateException("Cannot use different length if readQueue is enabled");
+                }
+            } else {
+                buf = ByteBuffer.wrap(dest, 0, length);
+                if (!mReadRequest.queue(buf, length)) {
+                    throw new IOException("Queueing USB request failed");
+                }
+            }
+            final UsbRequest response = mConnection.requestWait();
+            if (response == null) {
+                throw new IOException("Waiting for USB request failed");
+            }
+            if(useReadQueue()) {
+                buf = (ByteBuffer) response.getClientData();
+                System.arraycopy(buf.array(), 0, dest, 0, buf.position());
+                if(mReadRequest != null) { // re-queue if connection not closed
+                    if (!response.queue(buf, buf.capacity())) {
+                        throw new IOException("Queueing USB request failed");
+                    }
+                }
+            }
+            nread = Objects.requireNonNull(buf).position();
+            // Android error propagation is improvable:
+            //   response != null & nread == 0 can be: connection lost, buffer too small, ???
+            if(nread == 0) {
+                testConnection(true);
+            }
+        }
+        return Math.max(nread, 0);
+    }
+
+    @Override
+    public void write(byte[] src, int timeout) throws IOException {write(src, src.length, timeout);}
+
+    @Override
+    public void write(final byte[] src, int length, final int timeout) throws IOException {
+        int offset = 0;
+        long startTime = MonotonicClock.millis();
+        length = Math.min(length, src.length);
+
+        testConnection(false);
+        while (offset < length) {
+            int requestTimeout;
+            final int requestLength;
+            final int actualLength;
+
+            synchronized (mWriteBufferLock) {
+                final byte[] writeBuffer;
+
+                if (mWriteBuffer == null) {
+                    mWriteBuffer = new byte[mWriteEndpoint.getMaxPacketSize()];
+                }
+                requestLength = Math.min(length - offset, mWriteBuffer.length);
+                if (offset == 0) {
+                    writeBuffer = src;
+                } else {
+                    // bulkTransfer does not support offsets, make a copy.
+                    System.arraycopy(src, offset, mWriteBuffer, 0, requestLength);
+                    writeBuffer = mWriteBuffer;
+                }
+                if (timeout == 0 || offset == 0) {
+                    requestTimeout = timeout;
+                } else {
+                    requestTimeout = (int)(startTime + timeout - MonotonicClock.millis());
+                    if(requestTimeout == 0)
+                        requestTimeout = -1;
+                }
+                if (requestTimeout < 0) {
+                    actualLength = -2;
+                } else {
+                    actualLength = mConnection.bulkTransfer(mWriteEndpoint, writeBuffer, requestLength, requestTimeout);
+                }
+            }
+            long elapsed = MonotonicClock.millis() - startTime;
+            if (DEBUG) {
+                Log.d(TAG, "Wrote " + actualLength + "/" + requestLength + " offset " + offset + "/" + length + " time " + elapsed + "/" + requestTimeout);
+            }
+            if (actualLength <= 0) {
+                String msg = "Error writing " + requestLength + " bytes at offset " + offset + " of total " + src.length + " after " + elapsed + "msec, rc=" + actualLength;
+                if (timeout != 0) {
+                    // could be buffer full because: writing too fast, stopped by flow control
+                    testConnection(elapsed < timeout, msg);
+                    throw new SerialTimeoutException(msg, offset);
+                } else {
+                    throw new IOException(msg);
+
+                }
+            }
+            offset += actualLength;
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        return mReadRequest != null;
+    }
+
+    @Override
+    public abstract void setParameters(int baudRate, int dataBits, int stopBits, @Parity int parity) throws IOException;
+
+    @Override
+    public boolean getCD() throws IOException { throw new UnsupportedOperationException(); }
+
+    @Override
+    public boolean getCTS() throws IOException { throw new UnsupportedOperationException(); }
+
+    @Override
+    public boolean getDSR() throws IOException { throw new UnsupportedOperationException(); }
+
+    @Override
+    public boolean getDTR() throws IOException { throw new UnsupportedOperationException(); }
+
+    @Override
+    public void setDTR(boolean value) throws IOException { throw new UnsupportedOperationException(); }
+
+    @Override
+    public boolean getRI() throws IOException { throw new UnsupportedOperationException(); }
+
+    @Override
+    public boolean getRTS() throws IOException { throw new UnsupportedOperationException(); }
+
+    @Override
+    public void setRTS(boolean value) throws IOException { throw new UnsupportedOperationException(); }
+
+    @Override
+    public EnumSet<ControlLine> getControlLines() throws IOException { throw new UnsupportedOperationException(); }
+
+    @Override
+    public EnumSet<ControlLine> getSupportedControlLines() throws IOException { return EnumSet.noneOf(ControlLine.class); }
+
+    @Override
+    public void setFlowControl(FlowControl flowcontrol) throws IOException {
+        if (flowcontrol != FlowControl.NONE)
+            throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FlowControl getFlowControl() { return mFlowControl; }
+
+    @Override
+    public EnumSet<FlowControl> getSupportedFlowControl() { return EnumSet.of(FlowControl.NONE); }
+
+    @Override
+    public boolean getXON() throws IOException { throw new UnsupportedOperationException(); }
+
+    @Override
+    public void purgeHwBuffers(boolean purgeWriteBuffers, boolean purgeReadBuffers) throws IOException { throw new UnsupportedOperationException(); }
+
+    @Override
+    public void setBreak(boolean value) throws IOException { throw new UnsupportedOperationException(); }
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriver.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriver.java
@@ -1,0 +1,412 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Cp21xxSerialDriver implements UsbSerialDriver {
+
+    private static final String TAG = Cp21xxSerialDriver.class.getSimpleName();
+
+    private final UsbDevice mDevice;
+    private final List<UsbSerialPort> mPorts;
+
+    public Cp21xxSerialDriver(UsbDevice device) {
+        mDevice = device;
+        mPorts = new ArrayList<>();
+        for( int port = 0; port < device.getInterfaceCount(); port++) {
+            mPorts.add(new Cp21xxSerialPort(mDevice, port));
+        }
+    }
+
+    @Override
+    public UsbDevice getDevice() {
+        return mDevice;
+    }
+
+    @Override
+    public List<UsbSerialPort> getPorts() {
+        return mPorts;
+    }
+
+    public class Cp21xxSerialPort extends CommonUsbSerialPort {
+
+        private static final int USB_WRITE_TIMEOUT_MILLIS = 5000;
+
+        /*
+         * Configuration Request Types
+         */
+        private static final int REQTYPE_HOST_TO_DEVICE = 0x41;
+        private static final int REQTYPE_DEVICE_TO_HOST = 0xc1;
+
+        /*
+         * Configuration Request Codes
+         */
+        private static final int SILABSER_IFC_ENABLE_REQUEST_CODE = 0x00;
+        private static final int SILABSER_SET_LINE_CTL_REQUEST_CODE = 0x03;
+        private static final int SILABSER_SET_BREAK_REQUEST_CODE = 0x05;
+        private static final int SILABSER_SET_MHS_REQUEST_CODE = 0x07;
+        private static final int SILABSER_GET_MDMSTS_REQUEST_CODE = 0x08;
+        private static final int SILABSER_SET_XON_REQUEST_CODE = 0x09;
+        private static final int SILABSER_SET_XOFF_REQUEST_CODE = 0x0A;
+        private static final int SILABSER_GET_COMM_STATUS_REQUEST_CODE = 0x10;
+        private static final int SILABSER_FLUSH_REQUEST_CODE = 0x12;
+        private static final int SILABSER_SET_FLOW_REQUEST_CODE = 0x13;
+        private static final int SILABSER_SET_CHARS_REQUEST_CODE = 0x19;
+        private static final int SILABSER_SET_BAUDRATE_REQUEST_CODE = 0x1E;
+
+        private static final int FLUSH_READ_CODE = 0x0a;
+        private static final int FLUSH_WRITE_CODE = 0x05;
+
+        /*
+         * SILABSER_IFC_ENABLE_REQUEST_CODE
+         */
+        private static final int UART_ENABLE = 0x0001;
+        private static final int UART_DISABLE = 0x0000;
+
+        /*
+         * SILABSER_SET_MHS_REQUEST_CODE
+         */
+        private static final int DTR_ENABLE = 0x101;
+        private static final int DTR_DISABLE = 0x100;
+        private static final int RTS_ENABLE = 0x202;
+        private static final int RTS_DISABLE = 0x200;
+
+        /*
+        * SILABSER_GET_MDMSTS_REQUEST_CODE
+         */
+        private static final int STATUS_DTR = 0x01;
+        private static final int STATUS_RTS = 0x02;
+        private static final int STATUS_CTS = 0x10;
+        private static final int STATUS_DSR = 0x20;
+        private static final int STATUS_RI = 0x40;
+        private static final int STATUS_CD = 0x80;
+
+
+        private boolean dtr = false;
+        private boolean rts = false;
+
+        // second port of Cp2105 has limited baudRate, dataBits, stopBits, parity
+        // unsupported baudrate returns error at controlTransfer(), other parameters are silently ignored
+        private boolean mIsRestrictedPort;
+
+        public Cp21xxSerialPort(UsbDevice device, int portNumber) {
+            super(device, portNumber);
+        }
+
+        @Override
+        public UsbSerialDriver getDriver() {
+            return Cp21xxSerialDriver.this;
+        }
+
+        private void setConfigSingle(int request, int value) throws IOException {
+            int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, request, value,
+                    mPortNumber, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != 0) {
+                throw new IOException("Control transfer failed: " + request + " / " + value + " -> " + result);
+            }
+        }
+
+        private byte getStatus() throws IOException {
+            byte[] buffer = new byte[1];
+            int result = mConnection.controlTransfer(REQTYPE_DEVICE_TO_HOST, SILABSER_GET_MDMSTS_REQUEST_CODE, 0,
+                    mPortNumber, buffer, buffer.length, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != buffer.length) {
+                throw new IOException("Control transfer failed: " + SILABSER_GET_MDMSTS_REQUEST_CODE + " / " + 0 + " -> " + result);
+            }
+            return buffer[0];
+        }
+
+        @Override
+        protected void openInt() throws IOException {
+            mIsRestrictedPort = mDevice.getInterfaceCount() == 2 && mPortNumber == 1;
+            if(mPortNumber >= mDevice.getInterfaceCount()) {
+                throw new IOException("Unknown port number");
+            }
+            UsbInterface dataIface = mDevice.getInterface(mPortNumber);
+            if (!mConnection.claimInterface(dataIface, true)) {
+                throw new IOException("Could not claim interface " + mPortNumber);
+            }
+            for (int i = 0; i < dataIface.getEndpointCount(); i++) {
+                UsbEndpoint ep = dataIface.getEndpoint(i);
+                if (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK) {
+                    if (ep.getDirection() == UsbConstants.USB_DIR_IN) {
+                        mReadEndpoint = ep;
+                    } else {
+                        mWriteEndpoint = ep;
+                    }
+                }
+            }
+
+            setConfigSingle(SILABSER_IFC_ENABLE_REQUEST_CODE, UART_ENABLE);
+            setConfigSingle(SILABSER_SET_MHS_REQUEST_CODE, (dtr ? DTR_ENABLE : DTR_DISABLE) | (rts ? RTS_ENABLE : RTS_DISABLE));
+            setFlowControl(mFlowControl);
+        }
+
+        @Override
+        protected void closeInt() {
+            try {
+                setConfigSingle(SILABSER_IFC_ENABLE_REQUEST_CODE, UART_DISABLE);
+            } catch (Exception ignored) {}
+            try {
+                mConnection.releaseInterface(mDevice.getInterface(mPortNumber));
+            } catch(Exception ignored) {}
+        }
+
+        private void setBaudRate(int baudRate) throws IOException {
+            byte[] data = new byte[] {
+                    (byte) ( baudRate & 0xff),
+                    (byte) ((baudRate >> 8 ) & 0xff),
+                    (byte) ((baudRate >> 16) & 0xff),
+                    (byte) ((baudRate >> 24) & 0xff)
+            };
+            int ret = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SILABSER_SET_BAUDRATE_REQUEST_CODE,
+                    0, mPortNumber, data, 4, USB_WRITE_TIMEOUT_MILLIS);
+            if (ret < 0) {
+                throw new IOException("Error setting baud rate");
+            }
+        }
+
+        @Override
+        public void setParameters(int baudRate, int dataBits, int stopBits, @Parity int parity) throws IOException {
+            if(baudRate <= 0) {
+                throw new IllegalArgumentException("Invalid baud rate: " + baudRate);
+            }
+            setBaudRate(baudRate);
+
+            int configDataBits = 0;
+            switch (dataBits) {
+                case DATABITS_5:
+                    if(mIsRestrictedPort)
+                        throw new UnsupportedOperationException("Unsupported data bits: " + dataBits);
+                    configDataBits |= 0x0500;
+                    break;
+                case DATABITS_6:
+                    if(mIsRestrictedPort)
+                        throw new UnsupportedOperationException("Unsupported data bits: " + dataBits);
+                    configDataBits |= 0x0600;
+                    break;
+                case DATABITS_7:
+                    if(mIsRestrictedPort)
+                        throw new UnsupportedOperationException("Unsupported data bits: " + dataBits);
+                    configDataBits |= 0x0700;
+                    break;
+                case DATABITS_8:
+                    configDataBits |= 0x0800;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid data bits: " + dataBits);
+            }
+            
+            switch (parity) {
+                case PARITY_NONE:
+                    break;
+                case PARITY_ODD:
+                    configDataBits |= 0x0010;
+                    break;
+                case PARITY_EVEN:
+                    configDataBits |= 0x0020;
+                    break;
+                case PARITY_MARK:
+                    if(mIsRestrictedPort)
+                        throw new UnsupportedOperationException("Unsupported parity: mark");
+                    configDataBits |= 0x0030;
+                    break;
+                case PARITY_SPACE:
+                    if(mIsRestrictedPort)
+                        throw new UnsupportedOperationException("Unsupported parity: space");
+                    configDataBits |= 0x0040;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid parity: " + parity);
+            }
+            
+            switch (stopBits) {
+                case STOPBITS_1:
+                    break;
+                case STOPBITS_1_5:
+                    throw new UnsupportedOperationException("Unsupported stop bits: 1.5");
+                case STOPBITS_2:
+                    if(mIsRestrictedPort)
+                        throw new UnsupportedOperationException("Unsupported stop bits: 2");
+                    configDataBits |= 2;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid stop bits: " + stopBits);
+            }
+            setConfigSingle(SILABSER_SET_LINE_CTL_REQUEST_CODE, configDataBits);
+        }
+
+        @Override
+        public boolean getCD() throws IOException {
+            return (getStatus() & STATUS_CD) != 0;
+        }
+
+        @Override
+        public boolean getCTS() throws IOException {
+            return (getStatus() & STATUS_CTS) != 0;
+        }
+
+        @Override
+        public boolean getDSR() throws IOException {
+            return (getStatus() & STATUS_DSR) != 0;
+        }
+
+        @Override
+        public boolean getDTR() throws IOException {
+            return dtr;
+        }
+
+        @Override
+        public void setDTR(boolean value) throws IOException {
+            dtr = value;
+            setConfigSingle(SILABSER_SET_MHS_REQUEST_CODE, dtr ? DTR_ENABLE : DTR_DISABLE);
+        }
+
+        @Override
+        public boolean getRI() throws IOException {
+            return (getStatus() & STATUS_RI) != 0;
+        }
+
+        @Override
+        public boolean getRTS() throws IOException {
+            return rts;
+        }
+
+        @Override
+        public void setRTS(boolean value) throws IOException {
+            rts = value;
+            setConfigSingle(SILABSER_SET_MHS_REQUEST_CODE, rts ? RTS_ENABLE : RTS_DISABLE);
+        }
+
+        @Override
+        public EnumSet<ControlLine> getControlLines() throws IOException {
+            byte status = getStatus();
+            EnumSet<ControlLine> set = EnumSet.noneOf(ControlLine.class);
+            //if(rts) set.add(ControlLine.RTS);                      // configured value
+            if((status & STATUS_RTS) != 0) set.add(ControlLine.RTS); // actual value
+            if((status & STATUS_CTS) != 0) set.add(ControlLine.CTS);
+            //if(dtr) set.add(ControlLine.DTR);                      // configured value
+            if((status & STATUS_DTR) != 0) set.add(ControlLine.DTR); // actual value
+            if((status & STATUS_DSR) != 0) set.add(ControlLine.DSR);
+            if((status & STATUS_CD) != 0) set.add(ControlLine.CD);
+            if((status & STATUS_RI) != 0) set.add(ControlLine.RI);
+            return set;
+        }
+
+        @Override
+        public EnumSet<ControlLine> getSupportedControlLines() throws IOException {
+            return EnumSet.allOf(ControlLine.class);
+        }
+
+        @Override
+        public boolean getXON() throws IOException {
+            byte[] buffer = new byte[0x13];
+            int result = mConnection.controlTransfer(REQTYPE_DEVICE_TO_HOST, SILABSER_GET_COMM_STATUS_REQUEST_CODE, 0,
+                    mPortNumber, buffer, buffer.length, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != buffer.length) {
+                throw new IOException("Control transfer failed: " + SILABSER_GET_COMM_STATUS_REQUEST_CODE + " -> " + result);
+            }
+            return (buffer[4] & 8) == 0;
+        }
+
+        /**
+         * emulate external XON/OFF
+         * @throws IOException
+         */
+        public void setXON(boolean value) throws IOException {
+            setConfigSingle(value ? SILABSER_SET_XON_REQUEST_CODE : SILABSER_SET_XOFF_REQUEST_CODE, 0);
+        }
+
+        @Override
+        public void setFlowControl(FlowControl flowControl) throws IOException {
+            byte[] data = new byte[16];
+            if(flowControl == FlowControl.RTS_CTS) {
+                data[4] |=  0b1000_0000; // RTS
+                data[0] |=  0b0000_1000; // CTS
+            } else {
+                if(rts)
+                    data[4] |= 0b0100_0000;
+            }
+            if(flowControl == FlowControl.DTR_DSR) {
+                data[0] |= 0b0000_0010; // DTR
+                data[0] |= 0b0001_0000; // DSR
+            } else {
+                if(dtr)
+                    data[0] |= 0b0000_0001;
+            }
+            if(flowControl == FlowControl.XON_XOFF) {
+                byte[] chars = new byte[]{0, 0, 0, 0, CHAR_XON, CHAR_XOFF};
+                int ret = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SILABSER_SET_CHARS_REQUEST_CODE,
+                        0, mPortNumber, chars, chars.length, USB_WRITE_TIMEOUT_MILLIS);
+                if (ret != chars.length) {
+                    throw new IOException("Error setting XON/XOFF chars");
+                }
+                data[4] |= 0b0000_0011;
+                data[7] |= 0b1000_0000;
+                data[8] = (byte)128;
+                data[12] = (byte)128;
+            }
+            if(flowControl == FlowControl.XON_XOFF_INLINE) {
+                throw new UnsupportedOperationException();
+            }
+            int ret = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SILABSER_SET_FLOW_REQUEST_CODE,
+                    0, mPortNumber, data, data.length, USB_WRITE_TIMEOUT_MILLIS);
+            if (ret != data.length) {
+                throw new IOException("Error setting flow control");
+            }
+            if(flowControl == FlowControl.XON_XOFF) {
+                setXON(true);
+            }
+            mFlowControl = flowControl;
+        }
+
+        @Override
+        public EnumSet<FlowControl> getSupportedFlowControl() {
+            return EnumSet.of(FlowControl.NONE, FlowControl.RTS_CTS, FlowControl.DTR_DSR, FlowControl.XON_XOFF);
+        }
+
+        @Override
+        // note: only working on some devices, on other devices ignored w/o error
+        public void purgeHwBuffers(boolean purgeWriteBuffers, boolean purgeReadBuffers) throws IOException {
+            int value = (purgeReadBuffers ? FLUSH_READ_CODE : 0)
+                    | (purgeWriteBuffers ? FLUSH_WRITE_CODE : 0);
+
+            if (value != 0) {
+                setConfigSingle(SILABSER_FLUSH_REQUEST_CODE, value);
+            }
+        }
+
+        @Override
+        public void setBreak(boolean value) throws IOException {
+            setConfigSingle(SILABSER_SET_BREAK_REQUEST_CODE, value ? 1 : 0);
+        }
+    }
+
+    @SuppressWarnings({"unused"})
+    public static Map<Integer, int[]> getSupportedDevices() {
+        final Map<Integer, int[]> supportedDevices = new LinkedHashMap<>();
+        supportedDevices.put(UsbId.VENDOR_SILABS,
+                new int[] {
+            UsbId.SILABS_CP2102, // same ID for CP2101, CP2103, CP2104, CP2109
+            UsbId.SILABS_CP2105,
+            UsbId.SILABS_CP2108,
+        });
+        return supportedDevices;
+    }
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
@@ -1,0 +1,478 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ * Copyright 2020 kai morich <mail@kai-morich.de>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.util.Log;
+
+import com.hoho.android.usbserial.util.MonotonicClock;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/*
+ * driver is implemented from various information scattered over FTDI documentation
+ *
+ * baud rate calculation https://www.ftdichip.com/Support/Documents/AppNotes/AN232B-05_BaudRates.pdf
+ * control bits https://www.ftdichip.com/Firmware/Precompiled/UM_VinculumFirmware_V205.pdf
+ * device type https://www.ftdichip.com/Support/Documents/AppNotes/AN_233_Java_D2XX_for_Android_API_User_Manual.pdf -> bvdDevice
+ *
+ */
+
+public class FtdiSerialDriver implements UsbSerialDriver {
+
+    private static final String TAG = FtdiSerialPort.class.getSimpleName();
+
+    private final UsbDevice mDevice;
+    private final List<UsbSerialPort> mPorts;
+
+    public FtdiSerialDriver(UsbDevice device) {
+        mDevice = device;
+        mPorts = new ArrayList<>();
+        for( int port = 0; port < device.getInterfaceCount(); port++) {
+            mPorts.add(new FtdiSerialPort(mDevice, port));
+        }
+    }
+
+    @Override
+    public UsbDevice getDevice() {
+        return mDevice;
+    }
+
+    @Override
+    public List<UsbSerialPort> getPorts() {
+        return mPorts;
+    }
+
+    public class FtdiSerialPort extends CommonUsbSerialPort {
+
+        private static final int USB_WRITE_TIMEOUT_MILLIS = 5000;
+        private static final int READ_HEADER_LENGTH = 2; // contains MODEM_STATUS
+
+        private static final int REQTYPE_HOST_TO_DEVICE = UsbConstants.USB_TYPE_VENDOR | UsbConstants.USB_DIR_OUT;
+        private static final int REQTYPE_DEVICE_TO_HOST = UsbConstants.USB_TYPE_VENDOR | UsbConstants.USB_DIR_IN;
+
+        private static final int RESET_REQUEST = 0;
+        private static final int MODEM_CONTROL_REQUEST = 1;
+        private static final int SET_FLOW_CONTROL_REQUEST = 2;
+        private static final int SET_BAUD_RATE_REQUEST = 3;
+        private static final int SET_DATA_REQUEST = 4;
+        private static final int GET_MODEM_STATUS_REQUEST = 5;
+        private static final int SET_LATENCY_TIMER_REQUEST = 9;
+        private static final int GET_LATENCY_TIMER_REQUEST = 10;
+
+        private static final int MODEM_CONTROL_DTR_ENABLE = 0x0101;
+        private static final int MODEM_CONTROL_DTR_DISABLE = 0x0100;
+        private static final int MODEM_CONTROL_RTS_ENABLE = 0x0202;
+        private static final int MODEM_CONTROL_RTS_DISABLE = 0x0200;
+        private static final int MODEM_STATUS_CTS = 0x10;
+        private static final int MODEM_STATUS_DSR = 0x20;
+        private static final int MODEM_STATUS_RI = 0x40;
+        private static final int MODEM_STATUS_CD = 0x80;
+        private static final int RESET_ALL = 0;
+        private static final int RESET_PURGE_RX = 1;
+        private static final int RESET_PURGE_TX = 2;
+
+        private boolean baudRateWithPort = false;
+        private boolean dtr = false;
+        private boolean rts = false;
+        private int breakConfig = 0;
+
+        public FtdiSerialPort(UsbDevice device, int portNumber) {
+            super(device, portNumber);
+        }
+
+        @Override
+        public UsbSerialDriver getDriver() {
+            return FtdiSerialDriver.this;
+        }
+
+
+        @Override
+        protected void openInt() throws IOException {
+            if (!mConnection.claimInterface(mDevice.getInterface(mPortNumber), true)) {
+                throw new IOException("Could not claim interface " + mPortNumber);
+            }
+            if (mDevice.getInterface(mPortNumber).getEndpointCount() < 2) {
+                throw new IOException("Not enough endpoints");
+            }
+            mReadEndpoint = mDevice.getInterface(mPortNumber).getEndpoint(0);
+            mWriteEndpoint = mDevice.getInterface(mPortNumber).getEndpoint(1);
+
+            int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, RESET_REQUEST,
+                    RESET_ALL, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != 0) {
+                throw new IOException("Reset failed: result=" + result);
+            }
+            result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, MODEM_CONTROL_REQUEST,
+                    (dtr ? MODEM_CONTROL_DTR_ENABLE : MODEM_CONTROL_DTR_DISABLE) |
+                            (rts ? MODEM_CONTROL_RTS_ENABLE : MODEM_CONTROL_RTS_DISABLE),
+                    mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != 0) {
+                throw new IOException("Init RTS,DTR failed: result=" + result);
+            }
+            setFlowControl(mFlowControl);
+
+            // mDevice.getVersion() would require API 23
+            byte[] rawDescriptors = mConnection.getRawDescriptors();
+            if(rawDescriptors == null || rawDescriptors.length < 14) {
+                throw new IOException("Could not get device descriptors");
+            }
+            int deviceType = rawDescriptors[13];
+            baudRateWithPort = deviceType == 7 || deviceType == 8 || deviceType == 9 // ...H devices
+                    || mDevice.getInterfaceCount() > 1; // FT2232C
+        }
+
+        @Override
+        protected void closeInt() {
+            try {
+                mConnection.releaseInterface(mDevice.getInterface(mPortNumber));
+            } catch(Exception ignored) {}
+        }
+
+        @Override
+        public int read(final byte[] dest, final int timeout) throws IOException
+        {
+            if(dest.length <= READ_HEADER_LENGTH) {
+                throw new IllegalArgumentException("Read buffer too small");
+                // could allocate larger buffer, including space for 2 header bytes, but this would
+                // result in buffers not being 64 byte aligned any more, causing data loss at continuous
+                // data transfer at high baud rates when buffers are fully filled.
+            }
+            return read(dest, dest.length, timeout);
+        }
+
+        @Override
+        public int read(final byte[] dest, int length, final int timeout) throws IOException {
+            if(length <= READ_HEADER_LENGTH) {
+                throw new IllegalArgumentException("Read length too small");
+                // could allocate larger buffer, including space for 2 header bytes, but this would
+                // result in buffers not being 64 byte aligned any more, causing data loss at continuous
+                // data transfer at high baud rates when buffers are fully filled.
+            }
+            length = Math.min(length, dest.length);
+            int nread;
+            if (timeout != 0) {
+                long endTime = MonotonicClock.millis() + timeout;
+                do {
+                    nread = super.read(dest, length, Math.max(1, (int)(endTime - MonotonicClock.millis())), false);
+                } while (nread == READ_HEADER_LENGTH && MonotonicClock.millis() < endTime);
+                if(nread <= 0)
+                    testConnection(MonotonicClock.millis() < endTime);
+            } else {
+                do {
+                    nread = super.read(dest, length, timeout);
+                } while (nread == READ_HEADER_LENGTH);
+            }
+            return readFilter(dest, nread);
+        }
+
+        protected int readFilter(byte[] buffer, int totalBytesRead) throws IOException {
+            final int maxPacketSize = mReadEndpoint.getMaxPacketSize();
+            int destPos = 0;
+            for(int srcPos = 0; srcPos < totalBytesRead; srcPos += maxPacketSize) {
+                int length = Math.min(srcPos + maxPacketSize, totalBytesRead) - (srcPos + READ_HEADER_LENGTH);
+                if (length < 0)
+                    throw new IOException("Expected at least " + READ_HEADER_LENGTH + " bytes");
+                System.arraycopy(buffer, srcPos + READ_HEADER_LENGTH, buffer, destPos, length);
+                destPos += length;
+            }
+            //Log.d(TAG, "read filter " + totalBytesRead + " -> " + destPos);
+            return destPos;
+        }
+
+        private void setBaudrate(int baudRate) throws IOException {
+            int divisor, subdivisor, effectiveBaudRate;
+            if (baudRate > 3500000) {
+                throw new UnsupportedOperationException("Baud rate too high");
+            } else if(baudRate >= 2500000) {
+                divisor = 0;
+                subdivisor = 0;
+                effectiveBaudRate = 3000000;
+            } else if(baudRate >= 1750000) {
+                divisor = 1;
+                subdivisor = 0;
+                effectiveBaudRate = 2000000;
+            } else {
+                divisor = (24000000 << 1) / baudRate;
+                divisor = (divisor + 1) >> 1; // round
+                subdivisor = divisor & 0x07;
+                divisor >>= 3;
+                if (divisor > 0x3fff) // exceeds bit 13 at 183 baud
+                    throw new UnsupportedOperationException("Baud rate too low");
+                effectiveBaudRate = (24000000 << 1) / ((divisor << 3) + subdivisor);
+                effectiveBaudRate = (effectiveBaudRate +1) >> 1;
+            }
+            double baudRateError = Math.abs(1.0 - (effectiveBaudRate / (double)baudRate));
+            if(baudRateError >= 0.031) // can happen only > 1.5Mbaud
+                throw new UnsupportedOperationException(String.format("Baud rate deviation %.1f%% is higher than allowed 3%%", baudRateError*100));
+            int value = divisor;
+            int index = 0;
+            switch(subdivisor) {
+                case 0:                              break; // 16,15,14 = 000 - sub-integer divisor = 0
+                case 4: value |= 0x4000;             break; // 16,15,14 = 001 - sub-integer divisor = 0.5
+                case 2: value |= 0x8000;             break; // 16,15,14 = 010 - sub-integer divisor = 0.25
+                case 1: value |= 0xc000;             break; // 16,15,14 = 011 - sub-integer divisor = 0.125
+                case 3: value |= 0x0000; index |= 1; break; // 16,15,14 = 100 - sub-integer divisor = 0.375
+                case 5: value |= 0x4000; index |= 1; break; // 16,15,14 = 101 - sub-integer divisor = 0.625
+                case 6: value |= 0x8000; index |= 1; break; // 16,15,14 = 110 - sub-integer divisor = 0.75
+                case 7: value |= 0xc000; index |= 1; break; // 16,15,14 = 111 - sub-integer divisor = 0.875
+            }
+            if(baudRateWithPort) {
+                index <<= 8;
+                index |= mPortNumber+1;
+            }
+            Log.d(TAG, String.format("baud rate=%d, effective=%d, error=%.1f%%, value=0x%04x, index=0x%04x, divisor=%d, subdivisor=%d",
+                    baudRate, effectiveBaudRate, baudRateError*100, value, index, divisor, subdivisor));
+
+            int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SET_BAUD_RATE_REQUEST,
+                    value, index, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != 0) {
+                throw new IOException("Setting baudrate failed: result=" + result);
+            }
+        }
+
+        @Override
+        public void setParameters(int baudRate, int dataBits, int stopBits, @Parity int parity) throws IOException {
+            if(baudRate <= 0) {
+                throw new IllegalArgumentException("Invalid baud rate: " + baudRate);
+            }
+            setBaudrate(baudRate);
+
+            int config = 0;
+            switch (dataBits) {
+                case DATABITS_5:
+                case DATABITS_6:
+                    throw new UnsupportedOperationException("Unsupported data bits: " + dataBits);
+                case DATABITS_7:
+                case DATABITS_8:
+                    config |= dataBits;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid data bits: " + dataBits);
+            }
+
+            switch (parity) {
+                case PARITY_NONE:
+                    break;
+                case PARITY_ODD:
+                    config |= 0x100;
+                    break;
+                case PARITY_EVEN:
+                    config |= 0x200;
+                    break;
+                case PARITY_MARK:
+                    config |= 0x300;
+                    break;
+                case PARITY_SPACE:
+                    config |= 0x400;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid parity: " + parity);
+            }
+
+            switch (stopBits) {
+                case STOPBITS_1:
+                    break;
+                case STOPBITS_1_5:
+                    throw new UnsupportedOperationException("Unsupported stop bits: 1.5");
+                case STOPBITS_2:
+                    config |= 0x1000;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid stop bits: " + stopBits);
+            }
+
+            int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SET_DATA_REQUEST,
+                    config, mPortNumber+1,null, 0, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != 0) {
+                throw new IOException("Setting parameters failed: result=" + result);
+            }
+            breakConfig = config;
+        }
+
+        private int getStatus() throws IOException {
+            byte[] data = new byte[2];
+            int result = mConnection.controlTransfer(REQTYPE_DEVICE_TO_HOST, GET_MODEM_STATUS_REQUEST,
+                    0, mPortNumber+1, data, data.length, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != data.length) {
+                throw new IOException("Get modem status failed: result=" + result);
+            }
+            return data[0];
+        }
+
+        @Override
+        public boolean getCD() throws IOException {
+            return (getStatus() & MODEM_STATUS_CD) != 0;
+        }
+
+        @Override
+        public boolean getCTS() throws IOException {
+            return (getStatus() & MODEM_STATUS_CTS) != 0;
+        }
+
+        @Override
+        public boolean getDSR() throws IOException {
+            return (getStatus() & MODEM_STATUS_DSR) != 0;
+        }
+
+        @Override
+        public boolean getDTR() throws IOException {
+            return dtr;
+        }
+
+        @Override
+        public void setDTR(boolean value) throws IOException {
+            int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, MODEM_CONTROL_REQUEST,
+                    value ? MODEM_CONTROL_DTR_ENABLE : MODEM_CONTROL_DTR_DISABLE, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != 0) {
+                throw new IOException("Set DTR failed: result=" + result);
+            }
+            dtr = value;
+        }
+
+        @Override
+        public boolean getRI() throws IOException {
+            return (getStatus() & MODEM_STATUS_RI) != 0;
+        }
+
+        @Override
+        public boolean getRTS() throws IOException {
+            return rts;
+        }
+
+        @Override
+        public void setRTS(boolean value) throws IOException {
+            int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, MODEM_CONTROL_REQUEST,
+                    value ? MODEM_CONTROL_RTS_ENABLE : MODEM_CONTROL_RTS_DISABLE, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != 0) {
+                throw new IOException("Set RTS failed: result=" + result);
+            }
+            rts = value;
+        }
+
+        @Override
+        public EnumSet<ControlLine> getControlLines() throws IOException {
+            int status = getStatus();
+            EnumSet<ControlLine> set = EnumSet.noneOf(ControlLine.class);
+            if(rts) set.add(ControlLine.RTS);
+            if((status & MODEM_STATUS_CTS) != 0) set.add(ControlLine.CTS);
+            if(dtr) set.add(ControlLine.DTR);
+            if((status & MODEM_STATUS_DSR) != 0) set.add(ControlLine.DSR);
+            if((status & MODEM_STATUS_CD) != 0) set.add(ControlLine.CD);
+            if((status & MODEM_STATUS_RI) != 0) set.add(ControlLine.RI);
+            return set;
+        }
+
+        @Override
+        public EnumSet<ControlLine> getSupportedControlLines() throws IOException {
+            return EnumSet.allOf(ControlLine.class);
+        }
+
+        @Override
+        public void setFlowControl(FlowControl flowControl) throws IOException {
+            int value = 0;
+            int index = mPortNumber+1;
+            switch (flowControl) {
+                case NONE:
+                    break;
+                case RTS_CTS:
+                    index |= 0x100;
+                    break;
+                case DTR_DSR:
+                    index |= 0x200;
+                    break;
+                case XON_XOFF_INLINE:
+                    value = CHAR_XON + (CHAR_XOFF << 8);
+                    index |= 0x400;
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+            int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SET_FLOW_CONTROL_REQUEST,
+                    value, index, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != 0)
+                throw new IOException("Set flow control failed: result=" + result);
+            mFlowControl = flowControl;
+        }
+
+        @Override
+        public EnumSet<FlowControl> getSupportedFlowControl() {
+            return EnumSet.of(FlowControl.NONE, FlowControl.RTS_CTS, FlowControl.DTR_DSR, FlowControl.XON_XOFF_INLINE);
+        }
+
+        @Override
+        public void purgeHwBuffers(boolean purgeWriteBuffers, boolean purgeReadBuffers) throws IOException {
+            if (purgeWriteBuffers) {
+                int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, RESET_REQUEST,
+                        RESET_PURGE_RX, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+                if (result != 0) {
+                    throw new IOException("Purge write buffer failed: result=" + result);
+                }
+            }
+
+            if (purgeReadBuffers) {
+                int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, RESET_REQUEST,
+                        RESET_PURGE_TX, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+                if (result != 0) {
+                    throw new IOException("Purge read buffer failed: result=" + result);
+                }
+            }
+        }
+
+        @Override
+        public void setBreak(boolean value) throws IOException {
+            int config = breakConfig;
+            if(value) config |= 0x4000;
+            int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SET_DATA_REQUEST,
+                    config, mPortNumber+1,null, 0, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != 0) {
+                throw new IOException("Setting BREAK failed: result=" + result);
+            }
+        }
+
+        public void setLatencyTimer(int latencyTime) throws IOException {
+            int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SET_LATENCY_TIMER_REQUEST,
+                    latencyTime, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != 0) {
+                throw new IOException("Set latency timer failed: result=" + result);
+            }
+        }
+
+        public int getLatencyTimer() throws IOException {
+            byte[] data = new byte[1];
+            int result = mConnection.controlTransfer(REQTYPE_DEVICE_TO_HOST, GET_LATENCY_TIMER_REQUEST,
+                    0, mPortNumber+1, data, data.length, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != data.length) {
+                throw new IOException("Get latency timer failed: result=" + result);
+            }
+            return data[0];
+        }
+
+    }
+
+    @SuppressWarnings({"unused"})
+    public static Map<Integer, int[]> getSupportedDevices() {
+        final Map<Integer, int[]> supportedDevices = new LinkedHashMap<>();
+        supportedDevices.put(UsbId.VENDOR_FTDI,
+                new int[] {
+                    UsbId.FTDI_FT232R,
+                    UsbId.FTDI_FT232H,
+                    UsbId.FTDI_FT2232H,
+                    UsbId.FTDI_FT4232H,
+                    UsbId.FTDI_FT231X,  // same ID for FT230X, FT231X, FT234XD
+                });
+        return supportedDevices;
+    }
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/GsmModemSerialDriver.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/GsmModemSerialDriver.java
@@ -1,0 +1,102 @@
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.util.Log;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GsmModemSerialDriver implements UsbSerialDriver{
+
+    private final String TAG = GsmModemSerialDriver.class.getSimpleName();
+
+    private final UsbDevice mDevice;
+    private final UsbSerialPort mPort;
+
+    @Override
+    public UsbDevice getDevice() {
+        return mDevice;
+    }
+
+    @Override
+    public List<UsbSerialPort> getPorts() {
+        return Collections.singletonList(mPort);
+    }
+
+    public GsmModemSerialDriver(UsbDevice mDevice) {
+        this.mDevice = mDevice;
+        mPort = new GsmModemSerialPort(mDevice, 0);
+    }
+
+    public class GsmModemSerialPort extends CommonUsbSerialPort {
+
+        private UsbInterface mDataInterface;
+
+        public GsmModemSerialPort(UsbDevice device, int portNumber) {
+            super(device, portNumber);
+        }
+
+        @Override
+        protected void openInt() throws IOException {
+            Log.d(TAG, "claiming interfaces, count=" + mDevice.getInterfaceCount());
+            mDataInterface = mDevice.getInterface(0);
+            if (!mConnection.claimInterface(mDataInterface, true)) {
+                throw new IOException("Could not claim shared control/data interface");
+            }
+            Log.d(TAG, "endpoint count=" + mDataInterface.getEndpointCount());
+            for (int i = 0; i < mDataInterface.getEndpointCount(); ++i) {
+                UsbEndpoint ep = mDataInterface.getEndpoint(i);
+                if ((ep.getDirection() == UsbConstants.USB_DIR_IN) && (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK)) {
+                    mReadEndpoint = ep;
+                } else if ((ep.getDirection() == UsbConstants.USB_DIR_OUT) && (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK)) {
+                    mWriteEndpoint = ep;
+                }
+            }
+            initGsmModem();
+        }
+
+        @Override
+        protected void closeInt() {
+            try {
+                mConnection.releaseInterface(mDataInterface);
+            } catch(Exception ignored) {}
+
+        }
+
+        private int initGsmModem() throws IOException {
+            int len = mConnection.controlTransfer(
+                    0x21, 0x22, 0x01, 0, null, 0, 5000);
+            if(len < 0) {
+                throw new IOException("init failed");
+            }
+            return len;
+        }
+
+        @Override
+        public UsbSerialDriver getDriver() {
+            return GsmModemSerialDriver.this;
+        }
+
+        @Override
+        public void setParameters(int baudRate, int dataBits, int stopBits, int parity) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    public static Map<Integer, int[]> getSupportedDevices() {
+        final Map<Integer, int[]> supportedDevices = new LinkedHashMap<>();
+        supportedDevices.put(UsbId.VENDOR_UNISOC, new int[]{
+                UsbId.FIBOCOM_L610,
+                UsbId.FIBOCOM_L612,
+        });
+        return supportedDevices;
+    }
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/ProbeTable.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/ProbeTable.java
@@ -1,0 +1,102 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbDevice;
+import android.util.Pair;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Maps (vendor id, product id) pairs to the corresponding serial driver,
+ * or invoke 'probe' method to check actual USB devices for matching interfaces.
+ */
+public class ProbeTable {
+
+    private final Map<Pair<Integer, Integer>, Class<? extends UsbSerialDriver>> mVidPidProbeTable =
+            new LinkedHashMap<>();
+    private final Map<Method, Class<? extends UsbSerialDriver>> mMethodProbeTable = new LinkedHashMap<>();
+
+    /**
+     * Adds or updates a (vendor, product) pair in the table.
+     *
+     * @param vendorId the USB vendor id
+     * @param productId the USB product id
+     * @param driverClass the driver class responsible for this pair
+     * @return {@code this}, for chaining
+     */
+    public ProbeTable addProduct(int vendorId, int productId,
+            Class<? extends UsbSerialDriver> driverClass) {
+        mVidPidProbeTable.put(Pair.create(vendorId, productId), driverClass);
+        return this;
+    }
+
+    /**
+     * Internal method to add all supported products from
+     * {@code getSupportedProducts} static method.
+     *
+     * @param driverClass to be added
+     */
+    @SuppressWarnings("unchecked")
+    void addDriver(Class<? extends UsbSerialDriver> driverClass) {
+        Method method;
+
+        try {
+            method = driverClass.getMethod("getSupportedDevices");
+        } catch (SecurityException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+
+        final Map<Integer, int[]> devices;
+        try {
+            devices = (Map<Integer, int[]>) method.invoke(null);
+        } catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+
+        for (Map.Entry<Integer, int[]> entry : devices.entrySet()) {
+            final int vendorId = entry.getKey();
+            for (int productId : entry.getValue()) {
+                addProduct(vendorId, productId, driverClass);
+            }
+        }
+
+        try {
+            method = driverClass.getMethod("probe", UsbDevice.class);
+            mMethodProbeTable.put(method, driverClass);
+        } catch (SecurityException | NoSuchMethodException ignored) {
+        }
+    }
+
+    /**
+     * Returns the driver for the given USB device, or {@code null} if no match.
+     *
+     * @param usbDevice the USB device to be probed
+     * @return the driver class matching this pair, or {@code null}
+     */
+    public Class<? extends UsbSerialDriver> findDriver(final UsbDevice usbDevice) {
+        final Pair<Integer, Integer> pair = Pair.create(usbDevice.getVendorId(), usbDevice.getProductId());
+        Class<? extends UsbSerialDriver> driverClass = mVidPidProbeTable.get(pair);
+        if (driverClass != null)
+            return driverClass;
+        for (Map.Entry<Method, Class<? extends UsbSerialDriver>> entry : mMethodProbeTable.entrySet()) {
+            try {
+                Method method = entry.getKey();
+                Object o = method.invoke(null, usbDevice);
+                if((boolean)o)
+                    return entry.getValue();
+            } catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return null;
+    }
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
@@ -1,0 +1,605 @@
+/*
+ * Ported to usb-serial-for-android by Felix Hädicke <felixhaedicke@web.de>
+ *
+ * Based on the pyprolific driver written by Emmanuel Blot <emmanuel.blot@free.fr>
+ * See https://github.com/eblot/pyftdi
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.util.Log;
+
+import com.hoho.android.usbserial.BuildConfig;
+import com.hoho.android.usbserial.util.MonotonicClock;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ProlificSerialDriver implements UsbSerialDriver {
+
+    private final String TAG = ProlificSerialDriver.class.getSimpleName();
+
+    private final static int[] standardBaudRates = {
+            75, 150, 300, 600, 1200, 1800, 2400, 3600, 4800, 7200, 9600,
+            14400, 19200, 28800, 38400, 57600, 115200, 230400, 460800,
+            614400, 921600, 1228800, 2457600, 3000000, 6000000
+    };
+    protected enum DeviceType { DEVICE_TYPE_01, DEVICE_TYPE_T, DEVICE_TYPE_HX, DEVICE_TYPE_HXN }
+
+    private final UsbDevice mDevice;
+    private final UsbSerialPort mPort;
+
+    public ProlificSerialDriver(UsbDevice device) {
+        mDevice = device;
+        mPort = new ProlificSerialPort(mDevice, 0);
+    }
+
+    @Override
+    public List<UsbSerialPort> getPorts() {
+        return Collections.singletonList(mPort);
+    }
+
+    @Override
+    public UsbDevice getDevice() {
+        return mDevice;
+    }
+
+    class ProlificSerialPort extends CommonUsbSerialPort {
+
+        private static final int USB_READ_TIMEOUT_MILLIS = 1000;
+        private static final int USB_WRITE_TIMEOUT_MILLIS = 5000;
+
+        private static final int USB_RECIP_INTERFACE = 0x01;
+
+        private static final int VENDOR_READ_REQUEST = 0x01;
+        private static final int VENDOR_WRITE_REQUEST = 0x01;
+        private static final int VENDOR_READ_HXN_REQUEST = 0x81;
+        private static final int VENDOR_WRITE_HXN_REQUEST = 0x80;
+
+        private static final int VENDOR_OUT_REQTYPE = UsbConstants.USB_DIR_OUT | UsbConstants.USB_TYPE_VENDOR;
+        private static final int VENDOR_IN_REQTYPE = UsbConstants.USB_DIR_IN | UsbConstants.USB_TYPE_VENDOR;
+        private static final int CTRL_OUT_REQTYPE = UsbConstants.USB_DIR_OUT | UsbConstants.USB_TYPE_CLASS | USB_RECIP_INTERFACE;
+
+        private static final int WRITE_ENDPOINT = 0x02;
+        private static final int READ_ENDPOINT = 0x83;
+        private static final int INTERRUPT_ENDPOINT = 0x81;
+
+        private static final int RESET_HXN_REQUEST = 0x07;
+        private static final int FLUSH_RX_REQUEST = 0x08;
+        private static final int FLUSH_TX_REQUEST = 0x09;
+        private static final int SET_LINE_REQUEST = 0x20; // same as CDC SET_LINE_CODING
+        private static final int SET_CONTROL_REQUEST = 0x22; // same as CDC SET_CONTROL_LINE_STATE
+        private static final int SEND_BREAK_REQUEST = 0x23; // same as CDC SEND_BREAK
+        private static final int GET_CONTROL_HXN_REQUEST = 0x80;
+        private static final int GET_CONTROL_REQUEST = 0x87;
+        private static final int STATUS_NOTIFICATION = 0xa1; // similar to CDC SERIAL_STATE but different length
+
+        /* RESET_HXN_REQUEST */
+        private static final int RESET_HXN_RX_PIPE = 1;
+        private static final int RESET_HXN_TX_PIPE = 2;
+
+        /* SET_CONTROL_REQUEST */
+        private static final int CONTROL_DTR = 0x01;
+        private static final int CONTROL_RTS = 0x02;
+
+        /* GET_CONTROL_REQUEST */
+        private static final int GET_CONTROL_FLAG_CD = 0x02;
+        private static final int GET_CONTROL_FLAG_DSR = 0x04;
+        private static final int GET_CONTROL_FLAG_RI = 0x01;
+        private static final int GET_CONTROL_FLAG_CTS = 0x08;
+
+        /* GET_CONTROL_HXN_REQUEST */
+        private static final int GET_CONTROL_HXN_FLAG_CD = 0x40;
+        private static final int GET_CONTROL_HXN_FLAG_DSR = 0x20;
+        private static final int GET_CONTROL_HXN_FLAG_RI = 0x80;
+        private static final int GET_CONTROL_HXN_FLAG_CTS = 0x08;
+
+        /* interrupt endpoint read */
+        private static final int STATUS_FLAG_CD = 0x01;
+        private static final int STATUS_FLAG_DSR = 0x02;
+        private static final int STATUS_FLAG_RI = 0x08;
+        private static final int STATUS_FLAG_CTS = 0x80;
+
+        private static final int STATUS_BUFFER_SIZE = 10;
+        private static final int STATUS_BYTE_IDX = 8;
+
+        protected DeviceType mDeviceType = DeviceType.DEVICE_TYPE_HX;
+        private UsbEndpoint mInterruptEndpoint;
+        private int mControlLinesValue = 0;
+        private int mBaudRate = -1, mDataBits = -1, mStopBits = -1, mParity = -1;
+
+        private int mStatus = 0;
+        private volatile Thread mReadStatusThread = null;
+        private final Object mReadStatusThreadLock = new Object();
+        private boolean mStopReadStatusThread = false;
+        private Exception mReadStatusException = null;
+
+
+        public ProlificSerialPort(UsbDevice device, int portNumber) {
+            super(device, portNumber);
+        }
+
+        @Override
+        public UsbSerialDriver getDriver() {
+            return ProlificSerialDriver.this;
+        }
+
+        private byte[] inControlTransfer(int requestType, int request, int value, int index, int length) throws IOException {
+            byte[] buffer = new byte[length];
+            int result = mConnection.controlTransfer(requestType, request, value, index, buffer, length, USB_READ_TIMEOUT_MILLIS);
+            if (result != length) {
+                throw new IOException(String.format("ControlTransfer %s 0x%x failed: %d",mDeviceType.name(), value, result));
+            }
+            return buffer;
+        }
+
+        private void outControlTransfer(int requestType, int request, int value, int index, byte[] data) throws IOException {
+            int length = (data == null) ? 0 : data.length;
+            int result = mConnection.controlTransfer(requestType, request, value, index, data, length, USB_WRITE_TIMEOUT_MILLIS);
+            if (result != length) {
+                throw new IOException( String.format("ControlTransfer %s 0x%x failed: %d", mDeviceType.name(), value, result));
+            }
+        }
+
+        private byte[] vendorIn(int value, int index, int length) throws IOException {
+            int request = (mDeviceType == DeviceType.DEVICE_TYPE_HXN) ? VENDOR_READ_HXN_REQUEST : VENDOR_READ_REQUEST;
+            return inControlTransfer(VENDOR_IN_REQTYPE, request, value, index, length);
+        }
+
+        private void vendorOut(int value, int index, byte[] data) throws IOException {
+            int request = (mDeviceType == DeviceType.DEVICE_TYPE_HXN) ? VENDOR_WRITE_HXN_REQUEST : VENDOR_WRITE_REQUEST;
+            outControlTransfer(VENDOR_OUT_REQTYPE, request, value, index, data);
+        }
+
+        private void resetDevice() throws IOException {
+            purgeHwBuffers(true, true);
+        }
+
+        private void ctrlOut(int request, int value, int index, byte[] data) throws IOException {
+            outControlTransfer(CTRL_OUT_REQTYPE, request, value, index, data);
+        }
+
+        private boolean testHxStatus() {
+            try {
+                inControlTransfer(VENDOR_IN_REQTYPE, VENDOR_READ_REQUEST, 0x8080, 0, 1);
+                return true;
+            } catch(IOException ignored) {
+                return false;
+            }
+        }
+
+        private void doBlackMagic() throws IOException {
+            if (mDeviceType == DeviceType.DEVICE_TYPE_HXN)
+                return;
+            vendorIn(0x8484, 0, 1);
+            vendorOut(0x0404, 0, null);
+            vendorIn(0x8484, 0, 1);
+            vendorIn(0x8383, 0, 1);
+            vendorIn(0x8484, 0, 1);
+            vendorOut(0x0404, 1, null);
+            vendorIn(0x8484, 0, 1);
+            vendorIn(0x8383, 0, 1);
+            vendorOut(0, 1, null);
+            vendorOut(1, 0, null);
+            vendorOut(2, (mDeviceType == DeviceType.DEVICE_TYPE_01) ? 0x24 : 0x44, null);
+        }
+
+        private void setControlLines(int newControlLinesValue) throws IOException {
+            ctrlOut(SET_CONTROL_REQUEST, newControlLinesValue, 0, null);
+            mControlLinesValue = newControlLinesValue;
+        }
+
+        private void readStatusThreadFunction() {
+            try {
+                byte[] buffer = new byte[STATUS_BUFFER_SIZE];
+                while (!mStopReadStatusThread) {
+                    long endTime = MonotonicClock.millis() + 500;
+                    int readBytesCount = mConnection.bulkTransfer(mInterruptEndpoint, buffer, STATUS_BUFFER_SIZE, 500);
+                    if(readBytesCount == -1)
+                        testConnection(MonotonicClock.millis() < endTime);
+                    if (readBytesCount > 0) {
+                        if (readBytesCount != STATUS_BUFFER_SIZE) {
+                            throw new IOException("Invalid status notification, expected " + STATUS_BUFFER_SIZE + " bytes, got " + readBytesCount);
+                        } else if(buffer[0] != (byte)STATUS_NOTIFICATION ) {
+                            throw new IOException("Invalid status notification, expected " + STATUS_NOTIFICATION + " request, got " + buffer[0]);
+                        } else {
+                            mStatus = buffer[STATUS_BYTE_IDX] & 0xff;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                mReadStatusException = e;
+            }
+            //Log.d(TAG, "end control line status thread " + mStopReadStatusThread + " " + (mReadStatusException == null ? "-" : mReadStatusException.getMessage()));
+        }
+
+        private int getStatus() throws IOException {
+            if (mReadStatusThread == null) {
+                synchronized (mReadStatusThreadLock) {
+                    if (mReadStatusThread == null) {
+                        mStatus = 0;
+                        if(mDeviceType == DeviceType.DEVICE_TYPE_HXN) {
+                            byte[] data = vendorIn(GET_CONTROL_HXN_REQUEST, 0, 1);
+                            if ((data[0] & GET_CONTROL_HXN_FLAG_CTS) == 0) mStatus |= STATUS_FLAG_CTS;
+                            if ((data[0] & GET_CONTROL_HXN_FLAG_DSR) == 0) mStatus |= STATUS_FLAG_DSR;
+                            if ((data[0] & GET_CONTROL_HXN_FLAG_CD) == 0) mStatus |= STATUS_FLAG_CD;
+                            if ((data[0] & GET_CONTROL_HXN_FLAG_RI) == 0) mStatus |= STATUS_FLAG_RI;
+                        } else {
+                            byte[] data = vendorIn(GET_CONTROL_REQUEST, 0, 1);
+                            if ((data[0] & GET_CONTROL_FLAG_CTS) == 0) mStatus |= STATUS_FLAG_CTS;
+                            if ((data[0] & GET_CONTROL_FLAG_DSR) == 0) mStatus |= STATUS_FLAG_DSR;
+                            if ((data[0] & GET_CONTROL_FLAG_CD) == 0) mStatus |= STATUS_FLAG_CD;
+                            if ((data[0] & GET_CONTROL_FLAG_RI) == 0) mStatus |= STATUS_FLAG_RI;
+                        }
+                        //Log.d(TAG, "start control line status thread " + mStatus);
+                        mReadStatusThread = new Thread(this::readStatusThreadFunction);
+                        mReadStatusThread.setDaemon(true);
+                        mReadStatusThread.start();
+                    }
+                }
+            }
+            if (mReadStatusException != null) {
+                throw new IOException(mReadStatusException);
+            }
+            return mStatus;
+        }
+
+        @Override
+        public void openInt() throws IOException {
+            UsbInterface usbInterface = mDevice.getInterface(0);
+
+            if (!mConnection.claimInterface(usbInterface, true)) {
+                throw new IOException("Error claiming Prolific interface 0");
+            }
+
+            for (int i = 0; i < usbInterface.getEndpointCount(); ++i) {
+                UsbEndpoint currentEndpoint = usbInterface.getEndpoint(i);
+
+                switch (currentEndpoint.getAddress()) {
+                case READ_ENDPOINT:
+                    mReadEndpoint = currentEndpoint;
+                    break;
+
+                case WRITE_ENDPOINT:
+                    mWriteEndpoint = currentEndpoint;
+                    break;
+
+                case INTERRUPT_ENDPOINT:
+                    mInterruptEndpoint = currentEndpoint;
+                    break;
+                }
+            }
+
+            byte[] rawDescriptors = mConnection.getRawDescriptors();
+            if(rawDescriptors == null || rawDescriptors.length < 14) {
+                throw new IOException("Could not get device descriptors");
+            }
+            int usbVersion = (rawDescriptors[3] << 8) + rawDescriptors[2];
+            int deviceVersion = (rawDescriptors[13] << 8) + rawDescriptors[12];
+            byte maxPacketSize0 = rawDescriptors[7];
+            if (mDevice.getDeviceClass() == 0x02 || maxPacketSize0 != 64) {
+                mDeviceType = DeviceType.DEVICE_TYPE_01;
+            } else if(usbVersion == 0x200) {
+                if(deviceVersion == 0x300 && testHxStatus()) {
+                    mDeviceType = DeviceType.DEVICE_TYPE_T; // TA
+                } else if(deviceVersion == 0x500 && testHxStatus()) {
+                    mDeviceType = DeviceType.DEVICE_TYPE_T; // TB
+                } else {
+                    mDeviceType = DeviceType.DEVICE_TYPE_HXN;
+                }
+            } else {
+                mDeviceType = DeviceType.DEVICE_TYPE_HX;
+            }
+            Log.d(TAG, String.format("usbVersion=%x, deviceVersion=%x, deviceClass=%d, packetSize=%d => deviceType=%s",
+                    usbVersion, deviceVersion, mDevice.getDeviceClass(), maxPacketSize0, mDeviceType.name()));
+            resetDevice();
+            doBlackMagic();
+            setControlLines(mControlLinesValue);
+            setFlowControl(mFlowControl);
+        }
+
+        @Override
+        public void closeInt() {
+            try {
+                synchronized (mReadStatusThreadLock) {
+                    if (mReadStatusThread != null) {
+                        try {
+                            mStopReadStatusThread = true;
+                            mReadStatusThread.join();
+                        } catch (Exception e) {
+                            Log.w(TAG, "An error occurred while waiting for status read thread", e);
+                        }
+                        mStopReadStatusThread = false;
+                        mReadStatusThread = null;
+                        mReadStatusException = null;
+                    }
+                }
+                resetDevice();
+            } catch(Exception ignored) {}
+            try {
+                mConnection.releaseInterface(mDevice.getInterface(0));
+            } catch(Exception ignored) {}
+        }
+
+        private int filterBaudRate(int baudRate) {
+            if (baudRate <= 0) {
+                throw new IllegalArgumentException("Invalid baud rate: " + baudRate);
+            }
+            if (mDeviceType == DeviceType.DEVICE_TYPE_HXN) {
+                return baudRate;
+            }
+            for(int br : standardBaudRates) {
+                if (br == baudRate) {
+                    return baudRate;
+                }
+            }
+            /*
+             * Formula taken from Linux + FreeBSD.
+             *
+             * For TA+TB devices
+             *   baudrate = baseline / (mantissa * 2^exponent)
+             * where
+             *   mantissa = buf[10:0]
+             *   exponent = buf[15:13 16]
+             *
+             * For other devices
+             *   baudrate = baseline / (mantissa * 4^exponent)
+             * where
+             *   mantissa = buf[8:0]
+             *   exponent = buf[11:9]
+             *
+             */
+            int baseline, mantissa, exponent, buf, effectiveBaudRate;
+            baseline = 12000000 * 32;
+            mantissa = baseline / baudRate;
+            if (mantissa == 0) { // > unrealistic 384 MBaud
+                throw new UnsupportedOperationException("Baud rate too high");
+            }
+            exponent = 0;
+            if (mDeviceType == DeviceType.DEVICE_TYPE_T) {
+                while (mantissa >= 2048) {
+                    if (exponent < 15) {
+                        mantissa >>= 1;    /* divide by 2 */
+                        exponent++;
+                    } else { // < 7 baud
+                        throw new UnsupportedOperationException("Baud rate too low");
+                    }
+                }
+                buf = mantissa + ((exponent & ~1) << 12) + ((exponent & 1) << 16) + (1 << 31);
+                effectiveBaudRate = (baseline / mantissa) >> exponent;
+            } else {
+                while (mantissa >= 512) {
+                    if (exponent < 7) {
+                        mantissa >>= 2;    /* divide by 4 */
+                        exponent++;
+                    } else { // < 45.8 baud
+                        throw new UnsupportedOperationException("Baud rate too low");
+                    }
+                }
+                buf = mantissa + (exponent << 9) + (1 << 31);
+                effectiveBaudRate = (baseline / mantissa) >> (exponent << 1);
+            }
+            double baudRateError = Math.abs(1.0 - (effectiveBaudRate / (double)baudRate));
+            if(baudRateError >= 0.031) // > unrealistic 11.6 Mbaud
+                throw new UnsupportedOperationException(String.format("Baud rate deviation %.1f%% is higher than allowed 3%%", baudRateError*100));
+
+            Log.d(TAG, String.format("baud rate=%d, effective=%d, error=%.1f%%, value=0x%08x, mantissa=%d, exponent=%d",
+                    baudRate, effectiveBaudRate, baudRateError*100, buf, mantissa, exponent));
+            return buf;
+        }
+
+        @Override
+        public void setParameters(int baudRate, int dataBits, int stopBits, @Parity int parity) throws IOException {
+            baudRate = filterBaudRate(baudRate);
+            if ((mBaudRate == baudRate) && (mDataBits == dataBits)
+                    && (mStopBits == stopBits) && (mParity == parity)) {
+                // Make sure no action is performed if there is nothing to change
+                return;
+            }
+
+            byte[] lineRequestData = new byte[7];
+            lineRequestData[0] = (byte) (baudRate & 0xff);
+            lineRequestData[1] = (byte) ((baudRate >> 8) & 0xff);
+            lineRequestData[2] = (byte) ((baudRate >> 16) & 0xff);
+            lineRequestData[3] = (byte) ((baudRate >> 24) & 0xff);
+
+            switch (stopBits) {
+            case STOPBITS_1:
+                lineRequestData[4] = 0;
+                break;
+            case STOPBITS_1_5:
+                lineRequestData[4] = 1;
+                break;
+            case STOPBITS_2:
+                lineRequestData[4] = 2;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid stop bits: " + stopBits);
+            }
+
+            switch (parity) {
+            case PARITY_NONE:
+                lineRequestData[5] = 0;
+                break;
+            case PARITY_ODD:
+                lineRequestData[5] = 1;
+                break;
+            case PARITY_EVEN:
+                lineRequestData[5] = 2;
+                break;
+            case PARITY_MARK:
+                lineRequestData[5] = 3;
+                break;
+            case PARITY_SPACE:
+                lineRequestData[5] = 4;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid parity: " + parity);
+            }
+
+            if(dataBits < DATABITS_5 || dataBits > DATABITS_8) {
+                throw new IllegalArgumentException("Invalid data bits: " + dataBits);
+            }
+            lineRequestData[6] = (byte) dataBits;
+
+            ctrlOut(SET_LINE_REQUEST, 0, 0, lineRequestData);
+
+            resetDevice();
+
+            mBaudRate = baudRate;
+            mDataBits = dataBits;
+            mStopBits = stopBits;
+            mParity = parity;
+        }
+
+        @Override
+        public boolean getCD() throws IOException {
+            return (getStatus() & STATUS_FLAG_CD) != 0;
+        }
+
+        @Override
+        public boolean getCTS() throws IOException {
+            return (getStatus() & STATUS_FLAG_CTS) != 0;
+        }
+
+        @Override
+        public boolean getDSR() throws IOException {
+            return (getStatus() & STATUS_FLAG_DSR) != 0;
+        }
+
+        @Override
+        public boolean getDTR() throws IOException {
+            return (mControlLinesValue & CONTROL_DTR) != 0;
+        }
+
+        @Override
+        public void setDTR(boolean value) throws IOException {
+            int newControlLinesValue;
+            if (value) {
+                newControlLinesValue = mControlLinesValue | CONTROL_DTR;
+            } else {
+                newControlLinesValue = mControlLinesValue & ~CONTROL_DTR;
+            }
+            setControlLines(newControlLinesValue);
+        }
+
+        @Override
+        public boolean getRI() throws IOException {
+            return (getStatus() & STATUS_FLAG_RI) != 0;
+        }
+
+        @Override
+        public boolean getRTS() throws IOException {
+            return (mControlLinesValue & CONTROL_RTS) != 0;
+        }
+
+        @Override
+        public void setRTS(boolean value) throws IOException {
+            int newControlLinesValue;
+            if (value) {
+                newControlLinesValue = mControlLinesValue | CONTROL_RTS;
+            } else {
+                newControlLinesValue = mControlLinesValue & ~CONTROL_RTS;
+            }
+            setControlLines(newControlLinesValue);
+        }
+
+        @Override
+        public EnumSet<ControlLine> getControlLines() throws IOException {
+            int status = getStatus();
+            EnumSet<ControlLine> set = EnumSet.noneOf(ControlLine.class);
+            if((mControlLinesValue & CONTROL_RTS) != 0) set.add(ControlLine.RTS);
+            if((status & STATUS_FLAG_CTS) != 0) set.add(ControlLine.CTS);
+            if((mControlLinesValue & CONTROL_DTR) != 0) set.add(ControlLine.DTR);
+            if((status & STATUS_FLAG_DSR) != 0) set.add(ControlLine.DSR);
+            if((status & STATUS_FLAG_CD) != 0) set.add(ControlLine.CD);
+            if((status & STATUS_FLAG_RI) != 0) set.add(ControlLine.RI);
+            return set;
+        }
+
+        @Override
+        public EnumSet<ControlLine> getSupportedControlLines() throws IOException {
+            return EnumSet.allOf(ControlLine.class);
+        }
+
+        @Override
+        public void setFlowControl(FlowControl flowControl) throws IOException {
+            // vendorOut values from https://www.mail-archive.com/linux-usb@vger.kernel.org/msg110968.html
+            switch (flowControl) {
+                case NONE:
+                    if (mDeviceType == DeviceType.DEVICE_TYPE_HXN)
+                        vendorOut(0x0a, 0xff, null);
+                    else
+                        vendorOut(0, 0, null);
+                    break;
+                case RTS_CTS:
+                    if (mDeviceType == DeviceType.DEVICE_TYPE_HXN)
+                        vendorOut(0x0a, 0xfa, null);
+                    else
+                        vendorOut(0, 0x61, null);
+                    break;
+                case XON_XOFF_INLINE:
+                    if (mDeviceType == DeviceType.DEVICE_TYPE_HXN)
+                        vendorOut(0x0a, 0xee, null);
+                    else
+                        vendorOut(0, 0xc1, null);
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+            mFlowControl = flowControl;
+        }
+
+        @Override
+        public EnumSet<FlowControl> getSupportedFlowControl() {
+            return EnumSet.of(FlowControl.NONE, FlowControl.RTS_CTS, FlowControl.XON_XOFF_INLINE);
+        }
+
+        @Override
+        public void purgeHwBuffers(boolean purgeWriteBuffers, boolean purgeReadBuffers) throws IOException {
+            if (mDeviceType == DeviceType.DEVICE_TYPE_HXN) {
+                int index = 0;
+                if(purgeWriteBuffers) index |= RESET_HXN_RX_PIPE;
+                if(purgeReadBuffers) index |= RESET_HXN_TX_PIPE;
+                if(index != 0)
+                    vendorOut(RESET_HXN_REQUEST, index, null);
+            } else {
+                if (purgeWriteBuffers)
+                    vendorOut(FLUSH_RX_REQUEST, 0, null);
+                if (purgeReadBuffers)
+                    vendorOut(FLUSH_TX_REQUEST, 0, null);
+            }
+        }
+
+        @Override
+        public void setBreak(boolean value) throws IOException {
+            ctrlOut(SEND_BREAK_REQUEST, value ? 0xffff : 0, 0, null);
+        }
+    }
+
+    @SuppressWarnings({"unused"})
+    public static Map<Integer, int[]> getSupportedDevices() {
+        final Map<Integer, int[]> supportedDevices = new LinkedHashMap<>();
+        supportedDevices.put(UsbId.VENDOR_PROLIFIC,
+                new int[] {
+                        UsbId.PROLIFIC_PL2303,
+                        UsbId.PROLIFIC_PL2303GC,
+                        UsbId.PROLIFIC_PL2303GB,
+                        UsbId.PROLIFIC_PL2303GT,
+                        UsbId.PROLIFIC_PL2303GL,
+                        UsbId.PROLIFIC_PL2303GE,
+                        UsbId.PROLIFIC_PL2303GS,
+                });
+        return supportedDevices;
+    }
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/SerialTimeoutException.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/SerialTimeoutException.java
@@ -1,0 +1,16 @@
+package com.hoho.android.usbserial.driver;
+
+import java.io.InterruptedIOException;
+
+/**
+ * Signals that a timeout has occurred on serial write.
+ * Similar to SocketTimeoutException.
+ *
+ * {@see InterruptedIOException#bytesTransferred} may contain bytes transferred
+ */
+public class SerialTimeoutException extends InterruptedIOException {
+    public SerialTimeoutException(String s, int bytesTransferred) {
+        super(s);
+        this.bytesTransferred = bytesTransferred;
+    }
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/UsbId.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/UsbId.java
@@ -1,0 +1,56 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.driver;
+
+/**
+ * Registry of USB vendor/product ID constants.
+ *
+ * Culled from various sources; see
+ * <a href="http://www.linux-usb.org/usb.ids">usb.ids</a> for one listing.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+public final class UsbId {
+
+    public static final int VENDOR_FTDI = 0x0403;
+    public static final int FTDI_FT232R = 0x6001;
+    public static final int FTDI_FT2232H = 0x6010;
+    public static final int FTDI_FT4232H = 0x6011;
+    public static final int FTDI_FT232H = 0x6014;
+    public static final int FTDI_FT231X = 0x6015; // same ID for FT230X, FT231X, FT234XD
+
+    public static final int VENDOR_SILABS = 0x10c4;
+    public static final int SILABS_CP2102 = 0xea60; // same ID for CP2101, CP2103, CP2104, CP2109
+    public static final int SILABS_CP2105 = 0xea70;
+    public static final int SILABS_CP2108 = 0xea71;
+
+    public static final int VENDOR_PROLIFIC = 0x067b;
+    public static final int PROLIFIC_PL2303 = 0x2303;   // device type 01, T, HX
+    public static final int PROLIFIC_PL2303GC = 0x23a3; // device type HXN
+    public static final int PROLIFIC_PL2303GB = 0x23b3; // "
+    public static final int PROLIFIC_PL2303GT = 0x23c3; // "
+    public static final int PROLIFIC_PL2303GL = 0x23d3; // "
+    public static final int PROLIFIC_PL2303GE = 0x23e3; // "
+    public static final int PROLIFIC_PL2303GS = 0x23f3; // "
+
+    public static final int VENDOR_GOOGLE = 0x18d1;
+    public static final int GOOGLE_CR50 = 0x5014;
+
+    public static final int VENDOR_QINHENG = 0x1a86;
+    public static final int QINHENG_CH340 = 0x7523;
+    public static final int QINHENG_CH341A = 0x5523;
+
+    public static final int VENDOR_UNISOC = 0x1782;
+    public static final int FIBOCOM_L610 = 0x4D10;
+    public static final int FIBOCOM_L612 = 0x4D12;
+
+
+    private UsbId() {
+        throw new IllegalAccessError("Non-instantiable class");
+    }
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/UsbSerialDriver.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/UsbSerialDriver.java
@@ -1,0 +1,38 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbDevice;
+
+import java.util.List;
+
+public interface UsbSerialDriver {
+
+    /*
+     * Additional interface properties. Invoked thru reflection.
+     *
+        UsbSerialDriver(UsbDevice device);                  // constructor with device
+        static Map<Integer, int[]> getSupportedDevices();
+        static boolean probe(UsbDevice device);             // optional
+     */
+
+
+    /**
+     * Returns the raw {@link UsbDevice} backing this port.
+     *
+     * @return the device
+     */
+    UsbDevice getDevice();
+
+    /**
+     * Returns all available ports for this device. This list must have at least
+     * one entry.
+     *
+     * @return the ports
+     */
+    List<UsbSerialPort> getPorts();
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/UsbSerialPort.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/UsbSerialPort.java
@@ -1,0 +1,341 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbManager;
+
+import androidx.annotation.IntDef;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.EnumSet;
+
+/**
+ * Interface for a single serial port.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+public interface UsbSerialPort extends Closeable {
+
+    /** 5 data bits. */
+    int DATABITS_5 = 5;
+    /** 6 data bits. */
+    int DATABITS_6 = 6;
+    /** 7 data bits. */
+    int DATABITS_7 = 7;
+    /** 8 data bits. */
+    int DATABITS_8 = 8;
+
+    /** Values for setParameters(..., parity) */
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({PARITY_NONE, PARITY_ODD, PARITY_EVEN, PARITY_MARK, PARITY_SPACE})
+    @interface Parity {}
+    /** No parity. */
+    int PARITY_NONE = 0;
+    /** Odd parity. */
+    int PARITY_ODD = 1;
+    /** Even parity. */
+    int PARITY_EVEN = 2;
+    /** Mark parity. */
+    int PARITY_MARK = 3;
+    /** Space parity. */
+    int PARITY_SPACE = 4;
+
+    /** 1 stop bit. */
+    int STOPBITS_1 = 1;
+    /** 1.5 stop bits. */
+    int STOPBITS_1_5 = 3;
+    /** 2 stop bits. */
+    int STOPBITS_2 = 2;
+
+    /** Values for get[Supported]ControlLines() */
+    enum ControlLine { RTS, CTS, DTR, DSR, CD, RI }
+
+    /** Values for (set|get|getSupported)FlowControl() */
+    enum FlowControl { NONE, RTS_CTS, DTR_DSR, XON_XOFF, XON_XOFF_INLINE }
+
+    /** XON character used with flow control XON/XOFF */
+    char CHAR_XON = 17;
+    /** XOFF character used with flow control XON/XOFF */
+    char CHAR_XOFF = 19;
+
+
+    /**
+     * Returns the driver used by this port.
+     */
+    UsbSerialDriver getDriver();
+
+    /**
+     * Returns the currently-bound USB device.
+     */
+    UsbDevice getDevice();
+
+    /**
+     * Port number within driver.
+     */
+    int getPortNumber();
+
+    /**
+     * Returns the write endpoint.
+     * @return write endpoint
+     */
+    UsbEndpoint getWriteEndpoint();
+
+    /**
+     * Returns the read endpoint.
+     * @return read endpoint
+     */
+    UsbEndpoint getReadEndpoint();
+
+    /**
+     * The serial number of the underlying UsbDeviceConnection, or {@code null}.
+     *
+     * @return value from {@link UsbDeviceConnection#getSerial()}
+     * @throws SecurityException starting with target SDK 29 (Android 10) if permission for USB device is not granted
+     */
+    String getSerial();
+
+    /**
+     * Applications doing permanent {@link #read} with timeout=0 can reduce data loss likelihood
+     * at high baud rate and continuous data transfer by using multiple buffers to copy next data
+     * from Linux kernel, while the current data is processed.
+     * When enabled, {@link #read} can not be called with timeout!=0 or different buffer size.
+     *
+     * @param bufferCount number of buffers to use for readQueue.
+     *                    Use 0 to disable.
+     * @param bufferSize size of each buffer.
+     *                   Use 0 for optimal size (= getReadEndpoint().getMaxPacketSize()).
+     * @throws IllegalStateException if port is open and buffer count should be lowered or
+     *                               buffer size should be changed.
+     */
+    void setReadQueue(int bufferCount, int bufferSize);
+    int getReadQueueBufferCount();
+    int getReadQueueBufferSize();
+
+    /**
+     * Opens and initializes the port. Upon success, caller must ensure that
+     * {@link #close()} is eventually called.
+     *
+     * @param connection an open device connection, acquired with
+     *                   {@link UsbManager#openDevice(android.hardware.usb.UsbDevice)}
+     * @throws IOException on error opening or initializing the port.
+     */
+    void open(UsbDeviceConnection connection) throws IOException;
+
+    /**
+     * Closes the port and {@link UsbDeviceConnection}
+     *
+     * @throws IOException on error closing the port.
+     */
+    void close() throws IOException;
+
+    /**
+     * Reads as many bytes as possible into the destination buffer.
+     *
+     * @param dest the destination byte buffer
+     * @param timeout the timeout for reading in milliseconds, 0 is infinite
+     * @return the actual number of bytes read
+     * @throws IOException if an error occurred during reading
+     */
+    int read(final byte[] dest, final int timeout) throws IOException;
+
+    /**
+     * Reads bytes with specified length into the destination buffer.
+     *
+     * @param dest the destination byte buffer
+     * @param length the maximum length of the data to read
+     * @param timeout the timeout for reading in milliseconds, 0 is infinite
+     * @return the actual number of bytes read
+     * @throws IOException if an error occurred during reading
+     */
+    int read(final byte[] dest, int length, final int timeout) throws IOException;
+
+    /**
+     * Writes as many bytes as possible from the source buffer.
+     *
+     * @param src the source byte buffer
+     * @param timeout the timeout for writing in milliseconds, 0 is infinite
+     * @throws SerialTimeoutException if timeout reached before sending all data.
+     *                                ex.bytesTransferred may contain bytes transferred
+     * @throws IOException if an error occurred during writing
+     */
+    void write(final byte[] src, final int timeout) throws IOException;
+
+    /**
+     * Writes bytes with specified length from the source buffer.
+     *
+     * @param src the source byte buffer
+     * @param length the length of the data to write
+     * @param timeout the timeout for writing in milliseconds, 0 is infinite
+     * @throws SerialTimeoutException if timeout reached before sending all data.
+     *                                ex.bytesTransferred may contain bytes transferred
+     * @throws IOException if an error occurred during writing
+     */
+    void write(final byte[] src, int length, final int timeout) throws IOException;
+
+    /**
+     * Sets various serial port parameters.
+     *
+     * @param baudRate baud rate as an integer, for example {@code 115200}.
+     * @param dataBits one of {@link #DATABITS_5}, {@link #DATABITS_6},
+     *                 {@link #DATABITS_7}, or {@link #DATABITS_8}.
+     * @param stopBits one of {@link #STOPBITS_1}, {@link #STOPBITS_1_5}, or {@link #STOPBITS_2}.
+     * @param parity one of {@link #PARITY_NONE}, {@link #PARITY_ODD},
+     *               {@link #PARITY_EVEN}, {@link #PARITY_MARK}, or {@link #PARITY_SPACE}.
+     * @throws IOException on error setting the port parameters
+     * @throws UnsupportedOperationException if not supported or values are not supported by a specific device
+     */
+    void setParameters(int baudRate, int dataBits, int stopBits, @Parity int parity) throws IOException;
+
+    /**
+     * Gets the CD (Carrier Detect) bit from the underlying UART.
+     *
+     * @return the current state
+     * @throws IOException if an error occurred during reading
+     * @throws UnsupportedOperationException if not supported
+     */
+    boolean getCD() throws IOException;
+
+    /**
+     * Gets the CTS (Clear To Send) bit from the underlying UART.
+     *
+     * @return the current state
+     * @throws IOException if an error occurred during reading
+     * @throws UnsupportedOperationException if not supported
+     */
+    boolean getCTS() throws IOException;
+
+    /**
+     * Gets the DSR (Data Set Ready) bit from the underlying UART.
+     *
+     * @return the current state
+     * @throws IOException if an error occurred during reading
+     * @throws UnsupportedOperationException if not supported
+     */
+    boolean getDSR() throws IOException;
+
+    /**
+     * Gets the DTR (Data Terminal Ready) bit from the underlying UART.
+     *
+     * @return the current state
+     * @throws IOException if an error occurred during reading
+     * @throws UnsupportedOperationException if not supported
+     */
+    boolean getDTR() throws IOException;
+
+    /**
+     * Sets the DTR (Data Terminal Ready) bit on the underlying UART, if supported.
+     *
+     * @param value the value to set
+     * @throws IOException if an error occurred during writing
+     * @throws UnsupportedOperationException if not supported
+     */
+    void setDTR(boolean value) throws IOException;
+
+    /**
+     * Gets the RI (Ring Indicator) bit from the underlying UART.
+     *
+     * @return the current state
+     * @throws IOException if an error occurred during reading
+     * @throws UnsupportedOperationException if not supported
+     */
+    boolean getRI() throws IOException;
+
+    /**
+     * Gets the RTS (Request To Send) bit from the underlying UART.
+     *
+     * @return the current state
+     * @throws IOException if an error occurred during reading
+     * @throws UnsupportedOperationException if not supported
+     */
+    boolean getRTS() throws IOException;
+
+    /**
+     * Sets the RTS (Request To Send) bit on the underlying UART, if supported.
+     *
+     * @param value the value to set
+     * @throws IOException if an error occurred during writing
+     * @throws UnsupportedOperationException if not supported
+     */
+    void setRTS(boolean value) throws IOException;
+
+    /**
+     * Gets all control line values from the underlying UART, if supported.
+     * Requires less USB calls than calling getRTS() + ... + getRI() individually.
+     *
+     * @return EnumSet.contains(...) is {@code true} if set, else {@code false}
+     * @throws IOException if an error occurred during reading
+     * @throws UnsupportedOperationException if not supported
+     */
+    EnumSet<ControlLine> getControlLines() throws IOException;
+
+    /**
+     * Gets all control line supported flags.
+     *
+     * @return EnumSet.contains(...) is {@code true} if supported, else {@code false}
+     * @throws IOException if an error occurred during reading
+     */
+    EnumSet<ControlLine> getSupportedControlLines() throws IOException;
+
+    /**
+     * Set flow control mode, if supported
+     * @param flowControl @FlowControl
+     * @throws IOException if an error occurred during writing
+     * @throws UnsupportedOperationException if not supported
+     */
+    void setFlowControl(FlowControl flowControl) throws IOException;
+
+    /**
+     * Get flow control mode.
+     * @return FlowControl
+     */
+    FlowControl getFlowControl();
+
+    /**
+     * Get supported flow control modes
+     * @return EnumSet.contains(...) is {@code true} if supported, else {@code false}
+     */
+    EnumSet<FlowControl> getSupportedFlowControl();
+
+    /**
+     * If flow control = XON_XOFF, indicates that send is enabled by XON.
+     * Devices supporting flow control = XON_XOFF_INLINE return CHAR_XON/CHAR_XOFF in read() data.
+     *
+     * @return the current state
+     * @throws IOException if an error occurred during reading
+     * @throws UnsupportedOperationException if not supported
+     */
+    boolean getXON() throws IOException;
+
+    /**
+     * Purge non-transmitted output data and / or non-read input data.
+     *
+     * @param purgeWriteBuffers {@code true} to discard non-transmitted output data
+     * @param purgeReadBuffers {@code true} to discard non-read input data
+     * @throws IOException if an error occurred during flush
+     * @throws UnsupportedOperationException if not supported
+     */
+    void purgeHwBuffers(boolean purgeWriteBuffers, boolean purgeReadBuffers) throws IOException;
+
+    /**
+     * send BREAK condition.
+     *
+     * @param value set/reset
+     */
+    void setBreak(boolean value) throws IOException;
+
+    /**
+     * Returns the current state of the connection.
+     */
+    boolean isOpen();
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/UsbSerialProber.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/UsbSerialProber.java
@@ -1,0 +1,90 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbManager;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+public class UsbSerialProber {
+
+    private final ProbeTable mProbeTable;
+
+    public UsbSerialProber(ProbeTable probeTable) {
+        mProbeTable = probeTable;
+    }
+
+    public static UsbSerialProber getDefaultProber() {
+        return new UsbSerialProber(getDefaultProbeTable());
+    }
+    
+    public static ProbeTable getDefaultProbeTable() {
+        final ProbeTable probeTable = new ProbeTable();
+        probeTable.addDriver(CdcAcmSerialDriver.class);
+        probeTable.addDriver(Cp21xxSerialDriver.class);
+        probeTable.addDriver(FtdiSerialDriver.class);
+        probeTable.addDriver(ProlificSerialDriver.class);
+        probeTable.addDriver(Ch34xSerialDriver.class);
+        probeTable.addDriver(GsmModemSerialDriver.class);
+        probeTable.addDriver(ChromeCcdSerialDriver.class);
+        return probeTable;
+    }
+
+    /**
+     * Finds and builds all possible {@link UsbSerialDriver UsbSerialDrivers}
+     * from the currently-attached {@link UsbDevice} hierarchy. This method does
+     * not require permission from the Android USB system, since it does not
+     * open any of the devices.
+     *
+     * @param usbManager usb manager
+     * @return a list, possibly empty, of all compatible drivers
+     */
+    public List<UsbSerialDriver> findAllDrivers(final UsbManager usbManager) {
+        final List<UsbSerialDriver> result = new ArrayList<>();
+
+        for (final UsbDevice usbDevice : usbManager.getDeviceList().values()) {
+            final UsbSerialDriver driver = probeDevice(usbDevice);
+            if (driver != null) {
+                result.add(driver);
+            }
+        }
+        return result;
+    }
+    
+    /**
+     * Probes a single device for a compatible driver.
+     * 
+     * @param usbDevice the usb device to probe
+     * @return a new {@link UsbSerialDriver} compatible with this device, or
+     *         {@code null} if none available.
+     */
+    public UsbSerialDriver probeDevice(final UsbDevice usbDevice) {
+        final Class<? extends UsbSerialDriver> driverClass = mProbeTable.findDriver(usbDevice);
+        if (driverClass != null) {
+            final UsbSerialDriver driver;
+            try {
+                final Constructor<? extends UsbSerialDriver> ctor =
+                        driverClass.getConstructor(UsbDevice.class);
+                driver = ctor.newInstance(usbDevice);
+            } catch (NoSuchMethodException | IllegalArgumentException | InstantiationException |
+                     IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+            return driver;
+        }
+        return null;
+    }
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/util/HexDump.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/util/HexDump.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hoho.android.usbserial.util;
+
+import java.security.InvalidParameterException;
+
+/**
+ * Clone of Android's /core/java/com/android/internal/util/HexDump class, for use in debugging.
+ * Changes: space separated hex strings
+ */
+public class HexDump {
+    private final static char[] HEX_DIGITS = {
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+    };
+
+    private HexDump() {
+    }
+
+    public static String dumpHexString(byte[] array) {
+        return dumpHexString(array, 0, array.length);
+    }
+
+    public static String dumpHexString(byte[] array, int offset, int length) {
+        StringBuilder result = new StringBuilder();
+
+        byte[] line = new byte[8];
+        int lineIndex = 0;
+
+        for (int i = offset; i < offset + length; i++) {
+            if (lineIndex == line.length) {
+                for (int j = 0; j < line.length; j++) {
+                    if (line[j] > ' ' && line[j] < '~') {
+                        result.append(new String(line, j, 1));
+                    } else {
+                        result.append(".");
+                    }
+                }
+
+                result.append("\n");
+                lineIndex = 0;
+            }
+
+            byte b = array[i];
+            result.append(HEX_DIGITS[(b >>> 4) & 0x0F]);
+            result.append(HEX_DIGITS[b & 0x0F]);
+            result.append(" ");
+
+            line[lineIndex++] = b;
+        }
+
+        for (int i = 0; i < (line.length - lineIndex); i++) {
+            result.append("   ");
+        }
+        for (int i = 0; i < lineIndex; i++) {
+            if (line[i] > ' ' && line[i] < '~') {
+                result.append(new String(line, i, 1));
+            } else {
+                result.append(".");
+            }
+        }
+
+        return result.toString();
+    }
+
+    public static String toHexString(byte b) {
+        return toHexString(toByteArray(b));
+    }
+
+    public static String toHexString(byte[] array) {
+        return toHexString(array, 0, array.length);
+    }
+
+    public static String toHexString(byte[] array, int offset, int length) {
+        char[] buf = new char[length > 0 ? length * 3 - 1 : 0];
+
+        int bufIndex = 0;
+        for (int i = offset; i < offset + length; i++) {
+            if (i > offset)
+                buf[bufIndex++] = ' ';
+            byte b = array[i];
+            buf[bufIndex++] = HEX_DIGITS[(b >>> 4) & 0x0F];
+            buf[bufIndex++] = HEX_DIGITS[b & 0x0F];
+        }
+
+        return new String(buf);
+    }
+
+    public static String toHexString(int i) {
+        return toHexString(toByteArray(i));
+    }
+
+    public static String toHexString(short i) {
+        return toHexString(toByteArray(i));
+    }
+
+    public static byte[] toByteArray(byte b) {
+        byte[] array = new byte[1];
+        array[0] = b;
+        return array;
+    }
+
+    public static byte[] toByteArray(int i) {
+        byte[] array = new byte[4];
+
+        array[3] = (byte) (i & 0xFF);
+        array[2] = (byte) ((i >> 8) & 0xFF);
+        array[1] = (byte) ((i >> 16) & 0xFF);
+        array[0] = (byte) ((i >> 24) & 0xFF);
+
+        return array;
+    }
+
+    public static byte[] toByteArray(short i) {
+        byte[] array = new byte[2];
+
+        array[1] = (byte) (i & 0xFF);
+        array[0] = (byte) ((i >> 8) & 0xFF);
+
+        return array;
+    }
+
+    private static int toByte(char c) {
+        if (c >= '0' && c <= '9')
+            return (c - '0');
+        if (c >= 'A' && c <= 'F')
+            return (c - 'A' + 10);
+        if (c >= 'a' && c <= 'f')
+            return (c - 'a' + 10);
+
+        throw new InvalidParameterException("Invalid hex char '" + c + "'");
+    }
+
+    /** accepts any separator, e.g. space or newline */
+    public static byte[] hexStringToByteArray(String hexString) {
+        int length = hexString.length();
+        byte[] buffer = new byte[(length + 1) / 3];
+
+        for (int i = 0; i < length; i += 3) {
+            buffer[i / 3] = (byte) ((toByte(hexString.charAt(i)) << 4) | toByte(hexString.charAt(i + 1)));
+        }
+
+        return buffer;
+    }
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/util/MonotonicClock.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/util/MonotonicClock.java
@@ -1,0 +1,14 @@
+package com.hoho.android.usbserial.util;
+
+public final class MonotonicClock {
+
+    private static final long NS_PER_MS = 1_000_000;
+
+    private MonotonicClock() {
+    }
+
+    public static long millis() {
+        return System.nanoTime() / NS_PER_MS;
+    }
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/util/SerialInputOutputManager.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/util/SerialInputOutputManager.java
@@ -1,0 +1,353 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.hoho.android.usbserial.util;
+
+import android.os.Process;
+import android.util.Log;
+
+import com.hoho.android.usbserial.driver.UsbSerialPort;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Utility class which services a {@link UsbSerialPort} in its {@link #runWrite()} ()} and {@link #runRead()} ()} ()} methods.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+public class SerialInputOutputManager {
+
+    public enum State {
+        STOPPED,
+        STARTING,
+        RUNNING,
+        STOPPING
+    }
+
+    public static boolean DEBUG = false;
+
+    private static final String TAG = SerialInputOutputManager.class.getSimpleName();
+    private static final int WRITE_BUFFER_SIZE = 4096;
+
+    private int mReadTimeout = 0;
+    private int mWriteTimeout = 0;
+    private int mReadQueueBufferCount = 0;
+    //       no mReadQueueBufferSize, using mReadBuffer.size instead
+
+    private final Object mReadBufferLock = new Object();
+    private final Object mWriteBufferLock = new Object();
+
+    private ByteBuffer mReadBuffer; // default size = getReadEndpoint().getMaxPacketSize()
+    private ByteBuffer mWriteBuffer = ByteBuffer.allocate(WRITE_BUFFER_SIZE);
+
+    private int mThreadPriority = Process.THREAD_PRIORITY_URGENT_AUDIO;
+    private final AtomicReference<State> mState = new AtomicReference<>(State.STOPPED);
+    private CountDownLatch mStartuplatch = new CountDownLatch(2);
+    private Listener mListener; // Synchronized by 'this'
+    private final UsbSerialPort mSerialPort;
+
+    public interface Listener {
+        /**
+         * Called when new incoming data is available.
+         */
+        void onNewData(byte[] data);
+
+        /**
+         * Called when {@link SerialInputOutputManager#runRead()} ()} or {@link SerialInputOutputManager#runWrite()} ()} ()} aborts due to an error.
+         */
+        void onRunError(Exception e);
+    }
+
+    public SerialInputOutputManager(UsbSerialPort serialPort) {
+        mSerialPort = serialPort;
+        mReadBuffer = ByteBuffer.allocate(serialPort.getReadEndpoint().getMaxPacketSize());
+    }
+
+    public SerialInputOutputManager(UsbSerialPort serialPort, Listener listener) {
+        this(serialPort);
+        mListener = listener;
+    }
+
+    public synchronized void setListener(Listener listener) {
+        mListener = listener;
+    }
+
+    public synchronized Listener getListener() {
+        return mListener;
+    }
+
+    /**
+     * setThreadPriority. By default a higher priority than UI thread is used to prevent data loss
+     *
+     * @param threadPriority  see {@link Process#setThreadPriority(int)}
+     * */
+    public void setThreadPriority(int threadPriority) {
+        if (!mState.compareAndSet(State.STOPPED, State.STOPPED)) {
+            throw new IllegalStateException("threadPriority only configurable before SerialInputOutputManager is started");
+        }
+        mThreadPriority = threadPriority;
+    }
+
+    /**
+     * read/write timeout
+     */
+    public void setReadTimeout(int timeout) {
+        // when set if already running, read already blocks and the new value will not become effective now
+        if(mReadTimeout == 0 && timeout != 0 && mState.get() != State.STOPPED)
+            throw new IllegalStateException("readTimeout only configurable before SerialInputOutputManager is started");
+        mReadTimeout = timeout;
+    }
+
+    public int getReadTimeout() {
+        return mReadTimeout;
+    }
+
+    public void setWriteTimeout(int timeout) {
+        mWriteTimeout = timeout;
+    }
+
+    public int getWriteTimeout() {
+        return mWriteTimeout;
+    }
+
+    /**
+     * read/write buffer size
+     */
+    public void setReadBufferSize(int bufferSize) {
+        if (getReadBufferSize() == bufferSize)
+            return;
+        synchronized (mReadBufferLock) {
+            mReadBuffer = ByteBuffer.allocate(bufferSize);
+        }
+    }
+
+    public int getReadBufferSize() {
+        return mReadBuffer.capacity();
+    }
+
+    public void setWriteBufferSize(int bufferSize) {
+        if(getWriteBufferSize() == bufferSize)
+            return;
+        synchronized (mWriteBufferLock) {
+            ByteBuffer newWriteBuffer = ByteBuffer.allocate(bufferSize);
+            if(mWriteBuffer.position() > 0)
+                newWriteBuffer.put(mWriteBuffer.array(), 0, mWriteBuffer.position());
+            mWriteBuffer = newWriteBuffer;
+        }
+    }
+
+    public int getWriteBufferSize() {
+        return mWriteBuffer.capacity();
+    }
+
+    /**
+     * Set read queue, similar to {@link UsbSerialPort#setReadQueue}
+     * except buffer size to be set before with {@link #setReadBufferSize}.
+     *
+     * @param bufferCount number of buffers to use for readQueue,
+     *                    disable with value 0
+     */
+    public void setReadQueue(int bufferCount) {
+        mSerialPort.setReadQueue(bufferCount, getReadBufferSize());
+        mReadQueueBufferCount = bufferCount; // only store if set ok
+    }
+
+    public int getReadQueueBufferCount() { return mReadQueueBufferCount; }
+
+    /**
+     * write data asynchronously
+     */
+    public void writeAsync(byte[] data) {
+        synchronized (mWriteBufferLock) {
+            mWriteBuffer.put(data);
+            mWriteBufferLock.notifyAll(); // Notify waiting threads
+        }
+    }
+
+    /**
+     * start SerialInputOutputManager in separate threads
+     */
+    public void start() {
+        mSerialPort.setReadQueue(mReadQueueBufferCount, getReadBufferSize());
+        if(mState.compareAndSet(State.STOPPED, State.STARTING)) {
+            mStartuplatch = new CountDownLatch(2);
+            new Thread(this::runRead, this.getClass().getSimpleName() + "_read").start();
+            new Thread(this::runWrite, this.getClass().getSimpleName() + "_write").start();
+            try {
+                mStartuplatch.await();
+                mState.set(State.RUNNING);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        } else {
+            throw new IllegalStateException("already started");
+        }
+    }
+
+    /**
+     * stop SerialInputOutputManager threads
+     *
+     * when using readTimeout == 0 (default), additionally use usbSerialPort.close() to
+     * interrupt blocking read
+     */
+    public void stop() {
+        if(mState.compareAndSet(State.RUNNING, State.STOPPING)) {
+            synchronized (mWriteBufferLock) {
+                mWriteBufferLock.notifyAll(); // wake up write thread to check the stop condition
+            }
+            Log.i(TAG, "Stop requested");
+        }
+    }
+
+    public State getState() {
+        return mState.get();
+    }
+
+    /**
+     * @return true if the thread is still running
+     */
+    private boolean isStillRunning() {
+        State state = mState.get();
+        return ((state == State.RUNNING) || (state == State.STARTING))
+            && !Thread.currentThread().isInterrupted();
+    }
+
+    /**
+     * Notify listener of an error
+     *
+     * @param e the exception
+     */
+    private void notifyErrorListener(Throwable e) {
+        Listener listener = getListener();
+        if (listener != null) {
+            try {
+                listener.onRunError(e instanceof Exception ? (Exception) e : new Exception(e));
+            } catch (Throwable t) {
+                Log.w(TAG, "Exception in onRunError: " + t.getMessage(), t);
+            }
+        }
+    }
+
+    /**
+     * Set the thread priority
+     */
+    private void setThreadPriority() {
+        if (mThreadPriority != Process.THREAD_PRIORITY_DEFAULT) {
+            Process.setThreadPriority(mThreadPriority);
+        }
+    }
+
+    /**
+     * Continuously services the read buffers until {@link #stop()} is called, or until a driver exception is
+     * raised.
+     */
+    void runRead() {
+        Log.i(TAG, "runRead running ...");
+        try {
+            setThreadPriority();
+            mStartuplatch.countDown();
+            do {
+                stepRead();
+            } while (isStillRunning());
+            Log.i(TAG, "runRead: Stopping mState=" + getState());
+        } catch (Throwable e) {
+            if (Thread.currentThread().isInterrupted()) {
+                Log.w(TAG, "runRead: interrupted");
+            } else if(mSerialPort.isOpen()) {
+                Log.w(TAG, "runRead ending due to exception: " + e.getMessage(), e);
+            } else {
+                Log.i(TAG, "runRead: Socket closed");
+            }
+            notifyErrorListener(e);
+        } finally {
+            if (mState.compareAndSet(State.RUNNING, State.STOPPING)) {
+                synchronized (mWriteBufferLock) {
+                    mWriteBufferLock.notifyAll(); // wake up write thread to check the stop condition
+                }
+            } else if (mState.compareAndSet(State.STOPPING, State.STOPPED)) {
+                Log.i(TAG, "runRead: Stopped mState=" + getState());
+            }
+        }
+    }
+
+    /**
+     * Continuously services the write buffers until {@link #stop()} is called, or until a driver exception is
+     * raised.
+     */
+    void runWrite() {
+        Log.i(TAG, "runWrite running ...");
+        try {
+            setThreadPriority();
+            mStartuplatch.countDown();
+            do {
+                stepWrite();
+            } while (isStillRunning());
+            Log.i(TAG, "runWrite: Stopping mState=" + getState());
+        } catch (Throwable e) {
+            if (Thread.currentThread().isInterrupted()) {
+                Log.w(TAG, "runWrite: interrupted");
+            } else if(mSerialPort.isOpen()) {
+                Log.w(TAG, "runWrite ending due to exception: " + e.getMessage(), e);
+            } else {
+                Log.i(TAG, "runWrite: Socket closed");
+            }
+            notifyErrorListener(e);
+        } finally {
+            if (!mState.compareAndSet(State.RUNNING, State.STOPPING)) {
+                if (mState.compareAndSet(State.STOPPING, State.STOPPED)) {
+                    Log.i(TAG, "runWrite: Stopped mState=" + getState());
+                }
+            }
+        }
+    }
+
+    private void stepRead() throws IOException {
+        // Handle incoming data.
+        byte[] buffer;
+        synchronized (mReadBufferLock) {
+            buffer = mReadBuffer.array();
+        }
+        int len = mSerialPort.read(buffer, mReadTimeout);
+        if (len > 0) {
+            if (DEBUG) {
+                Log.d(TAG, "Read data len=" + len);
+            }
+            final Listener listener = getListener();
+            if (listener != null) {
+                final byte[] data = new byte[len];
+                System.arraycopy(buffer, 0, data, 0, len);
+                listener.onNewData(data);
+            }
+        }
+    }
+
+    private void stepWrite() throws IOException, InterruptedException {
+        // Handle outgoing data.
+        byte[] buffer = null;
+        synchronized (mWriteBufferLock) {
+            int len = mWriteBuffer.position();
+            if (len > 0) {
+                buffer = new byte[len];
+                mWriteBuffer.rewind();
+                mWriteBuffer.get(buffer, 0, len);
+                mWriteBuffer.clear();
+                mWriteBufferLock.notifyAll(); // Notify writeAsync that there is space in the buffer
+            } else {
+                mWriteBufferLock.wait();
+            }
+        }
+        if (buffer != null) {
+            if (DEBUG) {
+                Log.d(TAG, "Writing data len=" + buffer.length);
+            }
+            mSerialPort.write(buffer, mWriteTimeout);
+        }
+    }
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/util/UsbUtils.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/util/UsbUtils.java
@@ -1,0 +1,37 @@
+package com.hoho.android.usbserial.util;
+
+import android.hardware.usb.UsbDeviceConnection;
+
+import java.util.ArrayList;
+
+public class UsbUtils {
+
+    // copied from java.util.function.Supplier which is not available < API 24
+    public interface Supplier<T> {
+        T get();
+    }
+
+    private UsbUtils() {
+    }
+
+    public static  ArrayList<byte[]> getDescriptors(UsbDeviceConnection connection) {
+        ArrayList<byte[]> descriptors = new ArrayList<>();
+        byte[] rawDescriptors = connection.getRawDescriptors();
+        if (rawDescriptors != null) {
+            int pos = 0;
+            while (pos < rawDescriptors.length) {
+                int len = rawDescriptors[pos] & 0xFF;
+                if (len == 0)
+                    break;
+                if (pos + len > rawDescriptors.length)
+                    len = rawDescriptors.length - pos;
+                byte[] descriptor = new byte[len];
+                System.arraycopy(rawDescriptors, pos, descriptor, 0, len);
+                descriptors.add(descriptor);
+                pos += len;
+            }
+        }
+        return descriptors;
+    }
+
+}

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/util/XonXoffFilter.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/util/XonXoffFilter.java
@@ -1,0 +1,47 @@
+package com.hoho.android.usbserial.util;
+
+import com.hoho.android.usbserial.driver.UsbSerialPort;
+
+import java.io.IOException;
+
+/**
+ * Some devices return XON and XOFF characters inline in read() data.
+ * Other devices return XON / XOFF condition thru getXOFF() method.
+ */
+
+public class XonXoffFilter {
+    private boolean xon = true;
+
+    public XonXoffFilter() {
+    }
+
+    public boolean getXON()  {
+        return xon;
+    }
+
+    /**
+     * Filter XON/XOFF from read() data and remember
+     *
+     * @param data unfiltered data
+     * @return filtered data
+     */
+    public byte[] filter(byte[] data) {
+        int found = 0;
+        for (int i=0; i<data.length; i++) {
+            if (data[i] == UsbSerialPort.CHAR_XON || data[i] == UsbSerialPort.CHAR_XOFF)
+                found++;
+        }
+        if(found == 0)
+            return data;
+        byte[] filtered = new byte[data.length - found];
+        for (int i=0, j=0; i<data.length; i++) {
+            if (data[i] == UsbSerialPort.CHAR_XON)
+                xon = true;
+            else if(data[i] == UsbSerialPort.CHAR_XOFF)
+                xon = false;
+            else
+                filtered[j++] = data[i];
+        }
+        return filtered;
+    }
+}

--- a/native/third_party/usb-serial-for-android/shim/com/hoho/android/usbserial/BuildConfig.java
+++ b/native/third_party/usb-serial-for-android/shim/com/hoho/android/usbserial/BuildConfig.java
@@ -1,0 +1,34 @@
+package com.hoho.android.usbserial;
+
+/**
+ * The one class the vendored library needs and Gradle does not generate for us.
+ *
+ * <p><b>Ours, not upstream's</b> — which is why it is in {@code shim/} and not
+ * in {@code java/}. That directory is a byte-for-byte drop of the release and
+ * has to stay that way, or updating it means diffing our edits back out.
+ *
+ * <p>Gradle synthesises a {@code BuildConfig} per Android <i>module</i>, in that
+ * module's own package. Consuming the library as an {@code .aar} you get
+ * {@code com.hoho.android.usbserial.BuildConfig} for free; compiling its sources
+ * into this app, Gradle generates one for {@code org.cleverdomain.sstvae} and
+ * nothing at all for the library's package, so two of its drivers fail to
+ * compile on an import.
+ *
+ * <p><b>{@code DEBUG} is false, and that is the correct value rather than a
+ * convenient one.</b> The single place upstream reads it
+ * ({@code Ch34xSerialDriver:206}) is a test-only escape hatch that strips a bit
+ * from the requested baud rate — its own comment says "for testing purpose
+ * bypass dedicated baud rate handling". False is what a release build of the
+ * library compiles to, and it is what a radio should be talking to.
+ * {@code ProlificSerialDriver} imports the class and never reads it.
+ *
+ * <p>Deliberately not wired to this app's own {@code BuildConfig}: AGP 8 does
+ * not generate one unless {@code android.buildFeatures.buildConfig} is turned
+ * on, so that would trade a compile error we understand for one we would have
+ * to rediscover.
+ */
+public final class BuildConfig {
+    public static final boolean DEBUG = false;
+
+    private BuildConfig() {}
+}

--- a/tools/check_layering.py
+++ b/tools/check_layering.py
@@ -16,11 +16,17 @@ The rules mirror the Python package's, for the same reasons:
   rendering has to work under QGuiApplication with an offscreen
   platform, so an overlay stays renderable from the command line. This
   is the C++ restatement of "nothing in sstvae/overlay/ may import Qt".
-* **Only `core/audio/android/` may include `<jni.h>`.** Same rule and
-  same reason as Qt Multimedia's below: the engines stay drivable with no
-  platform audio at all, which is what keeps the headless tests and the
-  CLI tools possible. A JNI include elsewhere under `core/` would quietly
-  make the core un-buildable off Android.
+* **Only `core/audio/android/` and `core/rig/android/` may include
+  `<jni.h>`.** Same rule and same reason as Qt Multimedia's below: the
+  engines stay drivable with no platform audio and no platform serial
+  port at all, which is what keeps the headless tests and the CLI tools
+  possible. A JNI include elsewhere under `core/` would quietly make the
+  core un-buildable off Android.
+
+  Both are `<subsystem>/android/` and both are separate libraries, which
+  is the convention -- but this is an allowlist rather than a pattern on
+  purpose. A third one should be a deliberate edit here, not something
+  that starts passing because of where a directory was put.
 * **Only `core/audio/qt/` may include Qt Multimedia.** Soundcard I/O is
   the one place in `core/` that needs a Qt module, and it is a separate
   library (`SSTVAE_BUILD_QTAUDIO`) so the modem, the codec and both
@@ -69,8 +75,9 @@ RULES = [
         re.compile(r'^\s*#\s*include\s*[<"](QtMultimedia|QAudio|QMediaDevices)', re.M),
     ),
     (
-        "only core/audio/android/ may depend on JNI",
-        lambda p: p.parts[0] == "core" and p.parts[:3] != ("core", "audio", "android"),
+        "only core/audio/android/ and core/rig/android/ may depend on JNI",
+        lambda p: p.parts[0] == "core"
+        and p.parts[:3] not in (("core", "audio", "android"), ("core", "rig", "android")),
         re.compile(r'^\s*#\s*include\s*[<"]jni\.h', re.M),
     ),
     (

--- a/tools/check_xml_comments.py
+++ b/tools/check_xml_comments.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Reject `--` inside an XML comment.
+
+XML forbids a double hyphen inside `<!-- -->`, which is a rule nobody
+remembers until they write an em-dash as two hyphens in a comment they
+were adding for someone else's benefit.
+
+**This exists for the same reason `check_includes.py` does**: it catches
+on Linux, in a second, something that otherwise only fails on the
+platform least likely to be in front of you. Here that platform is an
+Android Gradle build -- the slowest feedback loop in this project -- and
+aapt reports the failure against a *copy* of the file under
+`build/intermediates/packaged_res/`, so the path in the error is not a
+path you can edit.
+
+`native/android-app/android/AndroidManifest.xml` already carried a
+comment warning about this. That was not enough: the same mistake landed
+in `res/xml/device_filter.xml` two files away, written by the same
+person who had put the warning there. A note tells whoever reads that
+file; a check tells whoever does not.
+
+Comments only. A `--` *outside* a comment is perfectly legal and appears
+in this tree for real -- Qt's manifest template carries
+`android:versionCode="-- %%INSERT_VERSION_CODE%% --"` -- so scanning for
+the characters alone would report the placeholders forever and be
+switched off within a week.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def problems(text: str) -> list[tuple[int, int, str]]:
+    """(line, column, message) for each malformed comment."""
+    out: list[tuple[int, int, str]] = []
+    at = 0
+    while True:
+        start = text.find("<!--", at)
+        if start < 0:
+            return out
+        end = text.find("-->", start + 4)
+        if end < 0:
+            line = text.count("\n", 0, start) + 1
+            col = start - (text.rfind("\n", 0, start) + 1) + 1
+            out.append((line, col, "comment is never closed"))
+            return out
+
+        body = text[start + 4 : end]
+        # Report the first offending `--`, which is the one to fix.
+        bad = body.find("--")
+        if bad >= 0:
+            pos = start + 4 + bad
+            line = text.count("\n", 0, pos) + 1
+            col = pos - (text.rfind("\n", 0, pos) + 1) + 1
+            out.append((line, col, "'--' is not permitted inside a comment"))
+        at = end + 3
+
+
+def main() -> int:
+    files = [
+        p
+        for p in ROOT.rglob("*.xml")
+        if "third_party" not in p.parts
+        and "build" not in p.parts
+        and not any(part.startswith(".") for part in p.relative_to(ROOT).parts)
+    ]
+
+    failures = 0
+    for path in sorted(files):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"{path.relative_to(ROOT)}: could not read ({exc})")
+            failures += 1
+            continue
+        for line, col, message in problems(text):
+            print(f"{path.relative_to(ROOT)}:{line}:{col}: {message}")
+            failures += 1
+
+    if failures:
+        print(
+            f"\n{failures} malformed XML comment(s). "
+            "Use a colon, a single hyphen, or a real em-dash instead."
+        )
+        return 1
+    print(f"xml comments ok ({len(files)} file(s) checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements CAT and PTT control over USB and Bluetooth on Android, resolving the structural limitation that previously made rig control impossible on the platform.

## Summary

This change adds complete rig control support to the Android app by introducing a serial transport abstraction that allows Hamlib to operate over a loopback socket instead of requiring direct device paths. The implementation consists of:

1. **Core transport abstraction** (`core/rig/transport.hpp`, `core/rig/bridge.hpp`, `core/rig/bridged.hpp`): A `SerialTransport` interface that any backend can implement, a `LoopbackBridge` that presents a transport as a socket to Hamlib, and a `BridgedBackend` that composes them.

2. **Android serial implementation** (`core/rig/android/androidrig.hpp/cpp`): JNI bindings to Java's USB and Bluetooth APIs, implementing `SerialTransport` for both connection types.

3. **Java serial layer** (`SerialBridge.java`): Comprehensive USB (via `usb-serial-for-android`) and Bluetooth serial handling with permission management, device enumeration, and bidirectional I/O.

4. **Vendored USB library** (`native/third_party/usb-serial-for-android/`): Complete `usb-serial-for-android` 3.11.0 with drivers for CDC-ACM, FTDI, Prolific, CP210x, and CH34x adapters.

5. **QML UI** (`RigPane.qml`, `rigcontrol.hpp/cpp`): Settings screen for rig model selection, connection type (USB/Bluetooth/Network), device enumeration, and PTT method choice (CAT command or control line).

6. **Test coverage** (`test_rig_bridge.cpp`, `test_rig_bridged.cpp`, `test_rig_hamlib.cpp`): Comprehensive tests of the bridge mechanism, backend composition, and real Hamlib integration over a socket.

## Key Changes

- **`core/rig/bridge.cpp`**: Loopback socket server that pumps bytes between Hamlib and a `SerialTransport`, with proper shutdown semantics that don't block on read timeouts.

- **`core/rig/bridged.cpp`**: Factory that wraps any `RigBackend` with a bridge, transparently converting a transport into a Hamlib-compatible device.

- **`core/rig/android/androidrig.cpp`**: JNI layer managing Java VM attachment per thread, permission callbacks, and device enumeration through `SerialBridge`.

- **`SerialBridge.java`**: 640-line Java class handling USB device enumeration, permission requests, Bluetooth discovery, and serial I/O for both connection types. Uses `usb-serial-for-android` for USB and Android's native Bluetooth APIs.

- **`native/android-app/rigcontrol.cpp/hpp`**: QML bindings exposing rig model list, device enumeration, connection settings, and PTT control to the UI.

- **`RigPane.qml`**: Settings UI for selecting rig model, connection kind, device, and PTT method, with live device refresh on visibility.

- **`Session` integration**: Rig controller lifecycle management, keying state tracking, and proper teardown ordering.

- **CMake updates**: Conditional Android rig library build, Hamlib cross-compilation for Android with per-ABI install trees, and test additions.

## Notable Implementation Details

- **Device identification by vendor/product, not device path**: Android device paths change on every replug; the implementation uses `usb:vendor:product` identifiers that survive reconnection.

- **Loopback-only socket binding**: Security property ensuring only local Hamlib connections are possible.

- **Thread-local JNI environment**: Efficient attachment strategy for continuous pump thread operation without per-call overhead.

- **Dual PTT paths**: Supports both CAT command keying (via Hamlib) and direct control-line manipulation (DTR/RTS) for radios that require it.

- **Bluetooth and USB coexistence**: Both connection types fully supported with unified `SerialTransport` interface.

https://claude.ai/code/session_019YWM59wJ1LpbMkx9Jo6uQG