### PR TITLE
android: fix entering a network host for rig control

### DIFF
--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -942,6 +942,40 @@ which is what the process-wide singleton is for. Persisting the source
 path and framing in `QSettings` would fix it and is a few lines; it has
 not been done because nothing has asked for it yet.
 
+## Editable fields commit per keystroke
+
+Every view object here (`Listener`, `Transmitter`, `RigControl`) has a
+single `changed()` signal that a timer emits a few times a second, so
+live state redraws without anything having to push it. That is fine
+until an editable control is bound to one of those properties, and then
+it is a trap with a delay on it:
+
+**A QML binding is not broken by a C++ write.** Only a JavaScript
+assignment removes one. So `text: view.someProperty` stays live for the
+life of the field, and every tick re-evaluates it. Commit the value on
+`editingFinished` and the property sits at its old value while the
+operator types — until a tick puts that old value back into the field,
+about a second in. It looks exactly like the box deleting itself, which
+is how it was reported.
+
+So: **`onTextEdited`, `onValueModified`, `onMoved`, `onToggled`** — the
+per-change handlers, never the commit-at-the-end ones. Then the property
+tracks the control and the re-evaluation is a no-op. The Send screen's
+callsign field already carried this rule as a comment, for the *other*
+reason it matters: the back gesture dismisses the keyboard without ever
+firing `editingFinished`, so a field committed at the end silently loses
+what was typed.
+
+Splitting `changed()` into settings and live halves would also fix it,
+and was not done: all three view objects share this design, and one of
+them diverging is worse than a convention all of them follow.
+
+The same applies to anything hung off `changed()` that writes to a
+control — a `Connections { function onChanged() }` that re-syncs a
+`ComboBox` runs at the poll rate, including while the operator has its
+popup open. Watch the specific thing that can invalidate it
+(`onModelChanged`) instead.
+
 ## Rig control
 
 CAT and PTT, added 2026-08-22. `docs/android.md` has the design record

--- a/native/android-app/RigPane.qml
+++ b/native/android-app/RigPane.qml
@@ -203,7 +203,23 @@ ColumnLayout {
                 placeholderText: "192.168.1.10:4532"
                 text: pane.rig.host
                 inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
-                onEditingFinished: pane.rig.host = text
+                // **Per keystroke, not on editingFinished**, which is
+                // the convention the Send screen's callsign field
+                // already records — and there are now two reasons for
+                // it rather than one.
+                //
+                // The back gesture dismisses the keyboard without ever
+                // firing `editingFinished`, so a committed-at-the-end
+                // field silently loses what was typed. And `text:` here
+                // is a live binding: a C++ write does not break a QML
+                // binding the way a JS assignment does, so every
+                // `changed()` re-evaluates it. With the value committed
+                // only at the end, the 1 Hz poll tick put the *stored*
+                // host back into the field about a second after typing
+                // started — which looks like the box deleting itself.
+                // Committing per keystroke keeps the two in step, so
+                // the re-evaluation is a no-op.
+                onTextEdited: pane.rig.host = text
             }
             Label {
                 text: "With the radio set to \"Hamlib NET rigctl\" this is a "
@@ -293,10 +309,12 @@ ColumnLayout {
             }
             function sync() { currentIndex = Math.max(0, model.indexOf(pane.rig.pttMethod)) }
             Component.onCompleted: sync()
-            Connections {
-                target: pane.rig
-                function onChanged() { if (!pttBox.pressed) pttBox.sync() }
-            }
+            // The reason to re-sync is that the *list* narrows on
+            // Bluetooth, which can invalidate the current index — so
+            // watch the model, not the catch-all `changed()`. Hanging
+            // this off `changed()` re-ran it at the poll rate, for a
+            // control the operator might have open at the time.
+            onModelChanged: sync()
             onActivated: pane.rig.pttMethod = currentValue
         }
         Label {


### PR DESCRIPTION
Follow-up to #39, which merged before this landed.

Typing into the Network **Host** box put the text back to its stored value about a second in, which looks like the box deleting itself.

## Why

A QML binding is not broken by a C++ write — only a JavaScript assignment removes one. So `text: pane.rig.host` stays live for the life of the field and every `changed()` re-evaluates it. With the value committed on `editingFinished` the property sat empty while typing, and the 1 Hz poll tick put the empty value back.

`onTextEdited` fixes it, and it is the convention the Send screen's callsign field already carried — for a second reason worth having: the back gesture dismisses the keyboard without ever firing `editingFinished`, so a commit-at-the-end field loses what was typed even with no timer involved.

## Scope

Swept the rest of the app's QML rather than fixing only the reported box: all 13 other editable controls already used the per-change handler (`onTextEdited` / `onMoved` / `onToggled`). The Host field was the only one that did not.

One related thing found in that sweep: the PTT-method combo re-synced from a `Connections { onChanged }`, so it ran at the poll rate for a control the operator may have the popup open on. The reason to re-sync is that the list narrows on Bluetooth, so it watches `onModelChanged` instead.

## Not done

Splitting `changed()` into settings and live halves would fix the class outright. It was not done because all three view objects (`Listener`, `Transmitter`, `RigControl`) share this design, and one of them diverging seemed worse than a convention all of them follow. Happy to do the structural version instead if preferred.

## Notes

- The convention is written up in `native/android-app/README.md` now, rather than living as a comment in one file.
- QML only, plus the README — no C++ changes. `check_layering`, `check_includes`, `check_xml_comments` and `ctest` (20/20) all pass on the current `master` base.
- Verified on hardware only for the symptom's absence in code; the fix itself has not been run on a phone since rebasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YWM59wJ1LpbMkx9Jo6uQG

---
_Generated by [Claude Code](https://claude.ai/code/session_019YWM59wJ1LpbMkx9Jo6uQG)_