### PR TITLE
Do not build the rig bridge on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -996,6 +996,19 @@ the SPP UUID). Six things are settled and worth not re-deriving:
   unauthenticated path to a transmitter; the bind is `127.0.0.1` and the
   port is ephemeral. One thread per direction, so an idle link costs no
   wakeups.
+- **`bridge.cpp`/`bridged.cpp` are not built on Windows** (2026-08-23),
+  and the tests follow the source rather than being skipped. Windows has
+  COM ports, so nothing there constructs a bridge -- what a Windows
+  build compiled was a Winsock translation of a file only POSIX runs,
+  whose green test said nothing about the one Android runs. It was also
+  wrong: `stop()` depends on `shutdown()` waking a thread blocked in
+  `recv()`, which POSIX guarantees and **Winsock does not** -- a blocked
+  `recv` there simply does not return, and Microsoft warns against
+  `closesocket` concurrently with a blocking call, so a correct port
+  means making the data path non-blocking and polling it. `rig_bridge`
+  hung for the full 120 s of its own watchdog in CI before that was
+  understood. Linux and macOS still build and test it, on the same POSIX
+  calls Android uses.
 - **`Session` owns the `RigController`, and never destroys it.** An
   over is 32-95 s of committed airtime and the thing that brings PTT
   back down cannot be destroyed by a rotation -- nor by the operator

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -110,8 +110,6 @@ add_library(sstvae_core STATIC
   core/util/event.cpp
   core/rx/ringbuffer.cpp
   core/rig/controller.cpp
-  core/rig/bridge.cpp
-  core/rig/bridged.cpp
   core/rx/engine.cpp
   core/tx/engine.cpp
   core/settings/settings.cpp
@@ -134,12 +132,33 @@ target_include_directories(sstvae_core SYSTEM PUBLIC third_party/stb
 # pybind11 shared module.
 set_target_properties(sstvae_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+# --- the rig bridge, everywhere but Windows ---------------------------------
+#
 # `core/rig/bridge.cpp` presents a serial transport to Hamlib as a
 # loopback socket, which is what lets a phone -- where there is no
-# `/dev/ttyUSB0` to give Hamlib -- still drive every radio Hamlib knows.
-# POSIX puts the sockets API in libc; Windows needs Winsock named.
-if(WIN32)
-  target_link_libraries(sstvae_core PUBLIC ws2_32)
+# `/dev/ttyUSB0` to give Hamlib -- drive every radio Hamlib knows.
+#
+# **Not built on Windows, and that is not a workaround.** Windows has
+# COM ports, so nothing there ever constructs a bridge: `native/gui/`,
+# `native/apps/` and `native/bindings/` do not mention it, and the only
+# consumer is `native/android-app/`. What a Windows build would compile
+# is therefore a *Winsock translation* of a file that only ever runs on
+# POSIX -- a second implementation, exercised by nobody, whose green
+# test would say nothing about the one Android runs.
+#
+# It also does not work, which is how this was noticed: `stop()` relies
+# on `shutdown()` waking a thread blocked in `recv()`, guaranteed on
+# POSIX and not how Winsock behaves, so `rig_bridge` hung for the full
+# 120 s of its own watchdog in CI. Fixing that means making the data
+# path non-blocking and polling it, which is real work in service of
+# nothing.
+#
+# Linux and macOS keep building and testing it, and they use the same
+# POSIX calls Android does -- so the coverage that matters, including
+# `test_rig_hamlib`'s real Kenwood backend talking through a real
+# bridge, is intact.
+if(NOT WIN32)
+  target_sources(sstvae_core PRIVATE core/rig/bridge.cpp core/rig/bridged.cpp)
 endif()
 
 # --- codec ------------------------------------------------------------------

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1218,6 +1218,17 @@ also a settling period for an interface that wants audio flowing before
 the radio is properly in transmit, and `ptt_lead_s` is a different
 quantity doing a different job. Set it to zero if it is not wanted.
 
+**The bridge is not built on Windows, and the tests follow it.** Windows
+has COM ports and never constructs one, so a Windows build was compiling
+a Winsock translation of a file only POSIX runs — a second
+implementation exercised by nobody, whose green test would have said
+nothing about the one a phone runs. It was also broken: `stop()` relies
+on `shutdown()` waking a thread blocked in `recv()`, which POSIX
+guarantees and Winsock does not, so `rig_bridge` hung for the full 120 s
+of its watchdog in CI. Linux and macOS still build and test it, using
+the same POSIX calls Android does, so `test_rig_hamlib`'s
+real-Kenwood-through-a-real-bridge proof is untouched.
+
 **What is not tested on hardware.** Everything in this section. The
 composite-device question in particular is worth settling first with the
 actual radio: most rig USB interfaces present audio and CDC serial

--- a/native/core/rig/bridge.cpp
+++ b/native/core/rig/bridge.cpp
@@ -9,53 +9,31 @@
 #include <mutex>
 #include <utility>
 
-#ifdef _WIN32
-// Confined to this file on purpose. <winsock2.h> pulls in <windows.h>,
-// whose `min`/`max` macros turn every later `std::max` into a syntax
-// error -- the trap CLAUDE.md records from `check.hpp`. Nothing here is
-// exposed through bridge.hpp.
-#  ifndef WIN32_LEAN_AND_MEAN
-#    define WIN32_LEAN_AND_MEAN
-#  endif
-#  ifndef NOMINMAX
-#    define NOMINMAX
-#  endif
-#  include <winsock2.h>
-#  include <ws2tcpip.h>
-#else
-#  include <arpa/inet.h>
-#  include <netinet/in.h>
-#  include <netinet/tcp.h>
-#  include <poll.h>
-#  include <sys/socket.h>
-#  include <unistd.h>
-#endif
+// **POSIX sockets, and this file is not built on Windows.** See
+// `native/CMakeLists.txt` for the decision; the short version is that
+// the bridge exists because Android hands an app no serial device, and
+// Windows has COM ports, so nothing there ever constructs one.
+//
+// A Winsock port is not a matter of swapping the headers, which is why
+// the shim that used to be here was removed rather than left as a
+// starting point. `stop()` relies on `shutdown()` waking a thread
+// blocked in `recv()` -- guaranteed on POSIX, and **not** how Winsock
+// behaves: a blocked `recv` there does not return, and Microsoft warns
+// against `closesocket` concurrently with a blocking call. So a Windows
+// implementation has to make the data path non-blocking and poll it,
+// the way `pump_in`'s accept loop already does, rather than translating
+// call for call. It hung for two minutes in CI before that was
+// understood.
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 namespace sstvae::rig {
 namespace {
 
-#ifdef _WIN32
-using socket_t = SOCKET;
-using poll_fd = WSAPOLLFD;
-
-int poll_sockets(poll_fd* fds, unsigned n, int timeout_ms) {
-    return ::WSAPoll(fds, n, timeout_ms);
-}
-void close_socket(socket_t s) { ::closesocket(s); }
-int socket_errno() { return ::WSAGetLastError(); }
-constexpr int kShutBoth = SD_BOTH;
-
-// Winsock has to be started before any of it works, and nothing else in
-// this process does it -- Qt's networking is not linked here and the
-// Android build never reaches this branch.
-void init_sockets() {
-    static std::once_flag once;
-    std::call_once(once, [] {
-        WSADATA data;
-        ::WSAStartup(MAKEWORD(2, 2), &data);
-    });
-}
-#else
 using socket_t = int;
 using poll_fd = struct pollfd;
 
@@ -65,8 +43,6 @@ int poll_sockets(poll_fd* fds, unsigned n, int timeout_ms) {
 void close_socket(socket_t s) { ::close(s); }
 int socket_errno() { return errno; }
 constexpr int kShutBoth = SHUT_RDWR;
-void init_sockets() {}
-#endif
 
 constexpr std::intptr_t kNoFd = -1;
 
@@ -113,8 +89,6 @@ LoopbackBridge::LoopbackBridge(std::shared_ptr<SerialTransport> transport)
 LoopbackBridge::~LoopbackBridge() { stop(); }
 
 void LoopbackBridge::start() {
-    init_sockets();
-
     // The transport first: if the cable is gone there is no point
     // holding a port open, and this is the failure an operator most
     // needs named.
@@ -147,11 +121,7 @@ void LoopbackBridge::start() {
     if (::listen(listener, 1) != 0) give_up("bridge: listen");
 
     sockaddr_in bound{};
-#ifdef _WIN32
-    int len = static_cast<int>(sizeof(bound));
-#else
     socklen_t len = sizeof(bound);
-#endif
     if (::getsockname(listener, reinterpret_cast<sockaddr*>(&bound), &len) != 0) {
         give_up("bridge: getsockname");
     }

--- a/native/tests/CMakeLists.txt
+++ b/native/tests/CMakeLists.txt
@@ -116,15 +116,21 @@ add_test(NAME rig COMMAND test_rig)
 # sstvae_core only, so they run in a --no-rig build: the composition,
 # the PTT routing and the byte pumping are all covered with no
 # libhamlib present, exactly as the controller's threading already is.
-add_executable(test_rig_bridge test_rig_bridge.cpp)
-target_link_libraries(test_rig_bridge PRIVATE sstvae_core)
-target_include_directories(test_rig_bridge PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-add_test(NAME rig_bridge COMMAND test_rig_bridge)
+#
+# Not on Windows, because the code under test is not built there; see
+# the block in ../CMakeLists.txt for why. Following the source rather
+# than skipping a test on one platform -- there is nothing to test.
+if(NOT WIN32)
+  add_executable(test_rig_bridge test_rig_bridge.cpp)
+  target_link_libraries(test_rig_bridge PRIVATE sstvae_core)
+  target_include_directories(test_rig_bridge PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME rig_bridge COMMAND test_rig_bridge)
 
-add_executable(test_rig_bridged test_rig_bridged.cpp)
-target_link_libraries(test_rig_bridged PRIVATE sstvae_core)
-target_include_directories(test_rig_bridged PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-add_test(NAME rig_bridged COMMAND test_rig_bridged)
+  add_executable(test_rig_bridged test_rig_bridged.cpp)
+  target_link_libraries(test_rig_bridged PRIVATE sstvae_core)
+  target_include_directories(test_rig_bridged PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME rig_bridged COMMAND test_rig_bridged)
+endif()
 
 # The libhamlib backend itself, exercised against Hamlib's own dummy
 # rig (model 1) -- the same trick CLAUDE.md uses for the Python side,
@@ -181,7 +187,9 @@ set_tests_properties(golden npy modem_roundtrip ringbuffer audio rig
 # These two carry their own watchdogs, which name the wedged step. The
 # ctest bound is the backstop for a wedge before main or after it
 # returns, where an in-process watchdog cannot fire at all.
-set_tests_properties(rig_bridge rig_bridged PROPERTIES TIMEOUT 180)
+if(NOT WIN32)
+  set_tests_properties(rig_bridge rig_bridged PROPERTIES TIMEOUT 180)
+endif()
 if(TARGET sstvae_rig)
   # Shorter than the rest on purpose: this one carries its own 120 s
   # watchdog, so reaching the ctest bound at all already means the

--- a/native/tests/test_rig_hamlib.cpp
+++ b/native/tests/test_rig_hamlib.cpp
@@ -200,12 +200,48 @@ void test_the_controller_drives_a_real_backend() {
 
 }  // namespace
 
-// Announce each step on stderr, unbuffered, and publish it for the
-// watchdog.
-//
-// This test drives a real library that opens ports and starts threads,
-// so its plausible failure mode is not "wrong answer" but "never
 // --- a Kenwood on the end of a SerialTransport ------------------------------
+//
+// **Not on Windows**, because `core/rig/bridge.cpp` is not built there
+// -- Windows has COM ports and never constructs a bridge, so what a
+// Windows build would compile is a Winsock translation of a file only
+// POSIX runs. See the block in `native/CMakeLists.txt`. Linux and macOS
+// still run everything below, and they use the same POSIX calls Android
+// does, so the claim these tests exist to establish is unaffected.
+namespace {
+// Kenwood TS-2000: a real serial backend, used both by the caps
+// test here and by the bridged tests below.
+constexpr int MODEL_TS2000 = 2014;
+}  // namespace
+
+void test_serial_defaults_come_from_the_backend_caps() {
+    // The other half of the bridged path's line settings. `rig_init`
+    // takes a serial port's defaults from `struct rig_caps`, and its own
+    // comment on the rate says "fastest !" -- so this reads
+    // `serial_rate_max`, deliberately, rather than picking something
+    // more conservative. A different choice would make a bridged rig run
+    // at a different speed than the same rig on a desktop.
+    const rig::SerialDefaults ts2000 = rig::serial_defaults(MODEL_TS2000);
+    check::is_true(ts2000.baud > 0,
+                   "hamlib/defaults: a real backend reports a rate (" +
+                       std::to_string(ts2000.baud) + ")");
+    check::is_true(ts2000.data_bits == 7 || ts2000.data_bits == 8,
+                   "hamlib/defaults: and a plausible word length");
+    check::is_true(ts2000.stop_bits == 1 || ts2000.stop_bits == 2,
+                   "hamlib/defaults: and a plausible stop-bit count");
+
+    // A model Hamlib does not know is a configuration the operator has
+    // to fix anyway, and `rig_init` will refuse it a moment later with a
+    // better message. Falling back rather than throwing is what lets a
+    // settings screen still render while it is wrong.
+    const rig::SerialDefaults unknown = rig::serial_defaults(999999);
+    check::equal(unknown.baud, 9600,
+                 "hamlib/defaults: an unknown model falls back to 9600");
+    check::equal(unknown.data_bits, 8, "hamlib/defaults: ...8 data bits");
+    check::equal(unknown.stop_bits, 1, "hamlib/defaults: ...1 stop bit");
+}
+
+#ifndef _WIN32
 //
 // **This is the evidence the whole Android CAT design rests on**, and
 // it is why it is here rather than in `test_rig_bridge.cpp`: everything
@@ -229,8 +265,6 @@ void test_the_controller_drives_a_real_backend() {
 // could be satisfied by a cache, while `FA;` arriving at the far end
 // could not.
 namespace {
-
-constexpr int MODEL_TS2000 = 2014;
 
 // The radio's side of the link, kept alive independently of the
 // transport so the test can still read it after the backend has taken
@@ -418,33 +452,6 @@ void test_a_native_backend_works_over_a_socket() {
     check::is_true(radio->closed, "hamlib/bridge: closing releases the device");
 }
 
-void test_serial_defaults_come_from_the_backend_caps() {
-    // The other half of the bridged path's line settings. `rig_init`
-    // takes a serial port's defaults from `struct rig_caps`, and its own
-    // comment on the rate says "fastest !" -- so this reads
-    // `serial_rate_max`, deliberately, rather than picking something
-    // more conservative. A different choice would make a bridged rig run
-    // at a different speed than the same rig on a desktop.
-    const rig::SerialDefaults ts2000 = rig::serial_defaults(MODEL_TS2000);
-    check::is_true(ts2000.baud > 0,
-                   "hamlib/defaults: a real backend reports a rate (" +
-                       std::to_string(ts2000.baud) + ")");
-    check::is_true(ts2000.data_bits == 7 || ts2000.data_bits == 8,
-                   "hamlib/defaults: and a plausible word length");
-    check::is_true(ts2000.stop_bits == 1 || ts2000.stop_bits == 2,
-                   "hamlib/defaults: and a plausible stop-bit count");
-
-    // A model Hamlib does not know is a configuration the operator has
-    // to fix anyway, and `rig_init` will refuse it a moment later with a
-    // better message. Falling back rather than throwing is what lets a
-    // settings screen still render while it is wrong.
-    const rig::SerialDefaults unknown = rig::serial_defaults(999999);
-    check::equal(unknown.baud, 9600,
-                 "hamlib/defaults: an unknown model falls back to 9600");
-    check::equal(unknown.data_bits, 8, "hamlib/defaults: ...8 data bits");
-    check::equal(unknown.stop_bits, 1, "hamlib/defaults: ...1 stop bit");
-}
-
 void test_dtr_keying_never_reaches_hamlib() {
     // The one thing that cannot go over this transport. `ser_set_dtr`
     // is a TIOCMSET ioctl and Hamlib is holding a socket, so a DTR
@@ -517,6 +524,13 @@ void test_the_controller_drives_a_bridged_rig() {
 
 }  // namespace
 
+#endif  // !_WIN32
+
+// Announce each step on stderr, unbuffered, and publish it for the
+// watchdog.
+//
+// This test drives a real library that opens ports and starts threads,
+// so its plausible failure mode is not "wrong answer" but "never
 // returns" -- and a hang with no output tells you nothing at all except
 // on which platform it happened. Printing alone was not enough: ctest
 // holds a test's output until it finishes, so a live log shows nothing
@@ -557,10 +571,12 @@ int main() {
         STEP(test_an_unknown_model_is_refused_readably);
         STEP(test_using_a_closed_rig_reports_rather_than_crashes);
         STEP(test_the_controller_drives_a_real_backend);
-        STEP(test_a_native_backend_works_over_a_socket);
         STEP(test_serial_defaults_come_from_the_backend_caps);
+#ifndef _WIN32
+        STEP(test_a_native_backend_works_over_a_socket);
         STEP(test_dtr_keying_never_reaches_hamlib);
         STEP(test_the_controller_drives_a_bridged_rig);
+#endif
         check::current_step = "reporting";
         std::fprintf(stderr, "-- done\n");
         std::fflush(stderr);


### PR DESCRIPTION
Fixes the red `native / Native core (windows-x64)` job on `master`.

## What was actually wrong

`rig_bridge` failed at **120.02 s** — its own in-process watchdog, so a hang rather than a wrong answer.

The cause is real, not environmental. `LoopbackBridge::stop()` calls `shutdown()` and then joins the pump threads, relying on that waking the one blocked in `recv()`. POSIX guarantees it; **Winsock does not** — a blocked `recv` there does not return, and Microsoft warns against `closesocket` concurrently with a blocking call. A correct Windows port means making the data path non-blocking and polling it, the way the accept loop already does.

## Why that work would serve nobody

The bridge exists because Android hands an app no serial device. Windows has COM ports, and nothing there ever constructs one — `native/gui/`, `native/apps/` and `native/bindings/` do not mention it; the only consumer is `native/android-app/`.

So what Windows was compiling was a **second implementation** of the file, exercised by no user, whose green test would have said nothing about the one Android actually runs. Gating it is following the code, not hiding a failure.

## Changes

- `core/rig/bridge.cpp` and `bridged.cpp` are built only when `NOT WIN32`; `ws2_32` goes with them.
- The Winsock shim is **deleted** rather than left as a starting point — a broken one that looks finished is worse than none. `bridge.cpp` now records what a real port would have to do differently.
- Tests follow the source rather than being skipped on a platform: `rig_bridge` and `rig_bridged` are not registered, and the three bridged tests in `test_rig_hamlib.cpp` are gated.
- `test_serial_defaults_come_from_the_backend_caps` was lifted **out** of that gate — it reads `rig_caps` from `sstvae_rig` and never touches the bridge, so Windows keeps it.

## Coverage

Linux and macOS build and test everything as before, on the same POSIX calls Android uses — so `test_rig_hamlib`'s real-Kenwood-backend-through-a-real-bridge proof, which is the evidence the whole Android CAT design rests on, is untouched.

## Verification

- Linux: `ctest` 20/20, `check_layering`, `check_includes`, `check_xml_comments` clean.
- Simulated a Windows compile over the gated file: the `#ifndef`s balance, and no symbol defined inside the gate is referenced outside it (checked with comments and string literals stripped, since the words "Kenwood" and "bridged" appear in prose).
- Also repaired a splice from the original commit that had put the entire bridged-test block inside the `STEP` macro's comment. It compiled, so nobody noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YWM59wJ1LpbMkx9Jo6uQG

---
_Generated by [Claude Code](https://claude.ai/code/session_019YWM59wJ1LpbMkx9Jo6uQG)_