### PR TITLE
Android rig control: address a USB device, not a kind of USB device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,18 @@ jobs:
       # not a path anyone can edit.
       - name: XML comments
         run: python tools/check_xml_comments.py
+      # Third instance of the same pattern: a mistake only one
+      # expensive platform reports. `native/`'s C++ is checked six
+      # ways and its Java was checked by nobody until an APK was
+      # built on a machine with an NDK -- a multi-catch whose
+      # alternatives were related by subclassing is not a syntax
+      # error, so no parser would have found it either. Robolectric's
+      # `android-all` is a real Android API surface on Maven Central,
+      # pinned and checksummed; the script skips itself rather than
+      # failing if the fetch is unavailable, and a cache hit makes it
+      # free.
+      - name: Android Java types
+        run: tools/check_android_java.sh
       - name: Show the diff if anything is stale
         if: failure()
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1029,20 +1029,61 @@ the SPP UUID). Six things are settled and worth not re-deriving:
   which driver `UsbSerialProber` picked and which interface of how many
   it claimed. Off costs one relaxed atomic load, which is why the calls
   live in the byte pump unconditionally.
+- **`Default` line states mean *asserted*** (2026-08-23). **Hamlib
+  never raises DTR or RTS** -- `src/rig.c` says so outright: *"Needed on Linux
+  because the serial port driver sets RTS/DTR on open - only need to
+  address the PTT line as we offer config parameters to control the
+  other (dtr_state & rts_state)"* -- so it relies on the OS, drops only
+  the PTT line, and a desktop presents a radio with both lines high. A
+  bridged transport reaches no `serial_open`, and
+  `usb-serial-for-android` deasserts both in `openInt()`. So
+  `resolve_serial_params` now resolves them too (Default = high;
+  explicit `dtr_state`/`rts_state` honoured; the PTT line always low,
+  which is `rig_open`'s own single exception), and `openUsb` applies
+  them **before** `setFlowControl` -- the CP210x SET_FLOW structure
+  encodes each line's mode and the library builds it from the driver's
+  current fields, so setting the lines afterwards leaves the chip's
+  flow configuration describing the old state. RFCOMM is not offered
+  them at all, having no modem lines. This is desktop parity and
+  correct on its own terms; it is **not** thought to be the Icom fix
+  (Andrew): CI-V has no flow control and an Icom uses those lines only
+  for PTT, CW and RTTY keying.
 - **A K4 works over USB and two Icoms do not** (reported 2026-08-23,
-  open). What has been ruled out by reading, so it is not re-derived:
+  **open**). The trace narrowed it to one gap and no further: the app
+  writes a correct frame (`-> rig 6: fe fe a2 e0 03 fd`) to a
+  **CP2102N** at 19200 8N1 flow=none, one vendor-class interface, two
+  endpoints, `Cp21xxSerialDriver` port 0 of 1 -- and nothing ever comes
+  back, while `rigctl -m 3081 -r /dev/ttyUSB0 -s 19200` on the same
+  cable answers instantly. Every control transfer returns 0 and the
+  bulk write returns 6, so the chip is enumerated, configured and
+  accepting bytes. **What no software here can see is whether the UART
+  actually clocked them out**, which is where code reading stops and a
+  hardware A/B has to take over. What was ruled out along the way, so
+  it is not re-derived:
   the byte path is length-counted end to end and cannot truncate a
   binary CI-V frame; Hamlib's POSIX `port_read_generic`/`port_write`
   have no port-type branch (the ones that exist are Win32 serial);
   `network_flush` is a `FIONREAD`-guarded drain; `rigs/icom/` has no
   port-type conditional; and `serial_defaults` picks
   `rig_caps.serial_rate_max`, the same field `rig_init` uses, so a
-  bridged rig runs at the speed that rig runs at on a desktop; and it
-  is not the control lines, since **both** `FtdiSerialDriver` and
-  `Cp21xxSerialDriver` deassert DTR and RTS in `openInt()`, so the K4
-  works with them low (a difference from a desktop, where the OS raises
-  them, but not a fatal one), while every Icom declares
-  `RIG_HANDSHAKE_NONE` so no flow control is holding the chip off. The two
+  bridged rig runs at the speed that rig runs at on a desktop; and
+  every Icom declares `RIG_HANDSHAKE_NONE`, so no flow control is
+  holding the chip's transmitter off. **The one that looked ruled out
+  and was not** is the control lines: both `FtdiSerialDriver` and
+  `Cp21xxSerialDriver` deassert DTR and RTS, so the K4 demonstrably
+  CATs with them low -- but that only shows the *transport* works that
+  way, not that this *radio* does, and treating one radio's tolerance
+  as a general fact is what kept the real difference hidden for a
+  round. Two differences from the Linux `cp210x` driver survive and are
+  the shortlist if the A/B points at the chip: the vendored library
+  writes `SET_FLOW` as **16 blind zero bytes** where Linux does
+  `GET_FLOW`/modify/`SET_FLOW`, preserving `ulXonLimit`/`ulXoffLimit`;
+  and it writes the requested baud raw where Linux applies
+  `cp210x_get_actual_rate()` for a CP2102N (a no-op at 19200, which
+  divides 48 MHz exactly). Linux also carries erratum **CP2102N_E104**
+  -- firmware <= 0x10004 reads `ulXonLimit` as `ulFlowReplace`, so it
+  declares flow control unsupported on those parts. None of this is
+  confirmed to matter here. The two
   radio-side settings to check first are Icom-specific and invisible
   from here: the **CI-V USB baud rate** (a separate menu item,
   defaulting to an Auto that is not reliable on every model) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2040,7 +2040,15 @@ the same radio on the same phone. `SerialBridge.describeStatus` reads
 the chip's own `GET_COMM_STATUS` into the trace — transmit queue depth,
 receive queue depth and hold reasons — because a bulk write returning
 its length says the bytes reached the chip and nothing about whether
-the UART clocked them out. `rig::set_debug_sink` and the "Log
+the UART clocked them out. **It is printed from the write thread, and
+that is not arbitrary**: the first version printed it from the read
+loop and printed nothing, which was itself the finding —
+`bulkTransfer` on a CP2102N with nothing to say blocks indefinitely,
+where an FTDI returns every ~16 ms because the chip sends a status
+packet regardless, so the K4 never exercised it. A liveness probe on
+the thread whose liveness is in question cannot report. The read
+thread now only counts, in relaxed atomics, and the write thread
+prints. `rig::set_debug_sink` and the "Log
 rig traffic" switch landed for it, because until then Hamlib's trace on
 a phone went to stderr and therefore nowhere.
 Unplug/replug recovery and the "Connected with the cable out"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -750,6 +750,28 @@ refused, rather than that needing another CI round to find out. When the
 library owns the serial port, "quiet" and "unfalsifiable" are close
 together.
 
+**`tools/check_android_java.sh` is the same idea for the app's Java.**
+`native/`'s C++ is checked six ways -- ctest, the golden vectors,
+`pytest --native`, `check_includes.py`, `check_layering.py`, a mingw
+cross-compile -- and its Java was checked by nobody until an APK was
+built on a machine with an NDK. `catch (IOException |
+UnsupportedOperationException | RuntimeException e)` is not a syntax
+error, so no parser would have caught it either; javac catches it in
+two seconds and the only thing missing was an `android.jar`.
+Robolectric's `android-all` is one, on Maven Central, pinned with a
+sha256 like onnxruntime and Hamlib, and it is the **real API surface
+rather than a stub set**, so it cannot quietly drift from what the app
+compiles against. Three classes are stubbed because they are neither
+`android.*` nor ours -- `androidx.annotation.IntDef` (SOURCE
+retention, no runtime meaning), `FileProvider.getUriForFile` and Qt's
+`QtActivity`, whose jar is not on Maven Central at all -- and the trade
+is that a stub pins the signature *we use* but cannot notice upstream
+changing it. The script's own first run found two bugs in itself, one
+of them worth knowing: **piping javac into `grep` and testing that is
+wrong under `pipefail`**, which reports the pipeline's first failure,
+so a failing javac made the `if` false and the check passed while
+printing its own errors.
+
 **`tools/check_includes.py` catches on Linux what would otherwise only
 fail on MSVC**: a `std::` name used without its header. libstdc++ and
 libc++ pull in far more than they promise (`<vector>` happens to give

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -996,6 +996,39 @@ the SPP UUID). Six things are settled and worth not re-deriving:
   unauthenticated path to a transmitter; the bind is `127.0.0.1` and the
   port is ephemeral. One thread per direction, so an idle link costs no
   wakeups.
+- **Hamlib's trace needs a sink, and Android is why**
+  (`rig::set_debug_sink`, 2026-08-23). `SSTVAE_HAMLIB_DEBUG` raises the
+  level and the library writes to *stderr*, which a phone discards, so
+  the one artifact that answers "how far did `rig_open` get and what
+  did the radio refuse" was unreachable on the platform where rig
+  control is newest. A `vprintf_cb_t` trampoline formats and splits
+  into whole lines (a line is not a call -- `dump_hex` emits one line
+  in several); Settings > Rig control > Log rig traffic keeps 600 of
+  them and mirrors to logcat, off by default. **The callback is
+  registered only while a sink exists**: `rig_debug` writes to stderr
+  *or* to a callback, never both, so one left permanently registered
+  swallows the trace for every desktop run and every test -- silently,
+  a swallowed trace and a quiet library being the same output.
+  `test_rig_hamlib.cpp` captures stderr and requires it back, and that
+  is the assertion with teeth (mutation-tested; the other two survive
+  registering unconditionally). Hamlib's own `#ifdef ANDROID`
+  logcat branch is not an alternative: `configure.ac` uses `ANDROID`
+  only as an automake conditional, never as a define, and never links
+  `-llog`.
+- **A K4 works over USB and two Icoms do not** (reported 2026-08-23,
+  open). What has been ruled out by reading, so it is not re-derived:
+  the byte path is length-counted end to end and cannot truncate a
+  binary CI-V frame; Hamlib's POSIX `port_read_generic`/`port_write`
+  have no port-type branch (the ones that exist are Win32 serial);
+  `network_flush` is a `FIONREAD`-guarded drain; `rigs/icom/` has no
+  port-type conditional; and `serial_defaults` picks
+  `rig_caps.serial_rate_max`, the same field `rig_init` uses, so a
+  bridged rig runs at the speed that rig runs at on a desktop. The two
+  radio-side settings to check first are Icom-specific and invisible
+  from here: the **CI-V USB baud rate** (a separate menu item,
+  defaulting to an Auto that is not reliable on every model) and
+  **CI-V USB Echo Back**, which `icom_get_usb_echo_off` probes at open
+  and gets exactly one attempt at, `rig_open` having set `retry` to 0.
 - **`bridge.cpp`/`bridged.cpp` are not built on Windows** (2026-08-23),
   and the tests follow the source rather than being skipped. Windows has
   COM ports, so nothing there constructs a bridge -- what a Windows
@@ -1897,7 +1930,12 @@ interface — which settles the one question that could have sunk the
 whole approach, since the app needs the audio and the serial half of
 that device at the same time. **Bluetooth is untested for want of a
 device** and goes to beta on the strength of the shared code beneath
-it. Unplug/replug recovery and the "Connected with the cable out"
+it. **An IC-9700 and an IC-7100 do not work, and that is open** — see
+the rig-control bullets above for what has been ruled out and the two
+radio-side settings to check first. `rig::set_debug_sink` and the "Log
+rig traffic" switch landed for it, because until then Hamlib's trace on
+a phone went to stderr and therefore nowhere.
+Unplug/replug recovery and the "Connected with the cable out"
 reading were found the same day and fixed;
 `native/android-app/README.md` has the three separate mistakes behind
 that one symptom.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1048,8 +1048,8 @@ the SPP UUID). Six things are settled and worth not re-deriving:
   correct on its own terms; it is **not** thought to be the Icom fix
   (Andrew): CI-V has no flow control and an Icom uses those lines only
   for PTT, CW and RTTY keying.
-- **"No flow control" is not the same as writing zeros, and on a
-  CP2102N that difference cost an Icom entirely** (2026-08-23). An
+- **A K4 works over USB and two Icoms do not, and it is still open**
+  (2026-08-23). An
   IC-9700 would not answer a single CI-V frame from the app while
   `rigctl -m 3081 -r /dev/ttyUSB0 -s 19200` on the same cable answered
   instantly. The trace narrowed it to one gap: a correct frame reaching
@@ -1062,18 +1062,24 @@ the SPP UUID). Six things are settled and worth not re-deriving:
   `ulFlowReplace`, `ulXonLimit` and `ulXoffLimit` in one blind write.
   Two implementations that work with this chip do not do that:
   **FT8TW** (which drives the same radio on the same phone -- Andrew's
-  test) carries a fork of `Cp21xxSerialDriver` with no `SET_FLOW`
-  constant and no `setFlowControl` at all, and the **Linux `cp210x`
-  driver**, which is what the working `rigctl` goes through, does
-  `GET_FLOW`/modify/`SET_FLOW` and never zeroes the limits. The kernel
+  test) carries an older copy of `Cp21xxSerialDriver` with no
+  `SET_FLOW` constant and no `setFlowControl` at all, and the **Linux
+  `cp210x` driver**, which is what the working `rigctl` goes through,
+  does `GET_FLOW`/modify/`SET_FLOW` and never zeroes the limits.
+  **Skipping the write did not fix it**, and that is the useful part:
+  FT8TW's `setParameters` is behaviourally identical to ours, so with
+  the write gone the two program the chip the same way and the Icom
+  still fails -- which rules the chip's *configuration* out entirely
+  and leaves only what the chip does with the bytes. The kernel
   also carries erratum **CP2102N_E104** -- firmware <= 0x10004 reads
   `ulXonLimit` as `ulFlowReplace`, so a blind 16-byte write lands one
   word out of alignment and the chip's own `ulXoffLimit` comes from
   past the end of the buffer. So the write is skipped when there is no
   flow control to set, in `SerialBridge.applyFlowControl` **and** in
   `openInt` -- both, because `openInt` does it inside `port.open()`
-  before any of our code is asked. That is the **first patch carried
-  against the vendored library**; `third_party/usb-serial-for-android/PATCHES.md`
+  before any of our code is asked. The guard stays anyway -- both
+  reference implementations avoid the blind write and the erratum is
+  real -- as the **first patch carried against the vendored library**; `third_party/usb-serial-for-android/PATCHES.md`
   is the exhaustive list and every deviation is marked `// SSTVAE
   PATCH` in the source, because `java/` was a byte-for-byte drop of the
   release and is no longer. What was ruled out along the way, so it is
@@ -2004,11 +2010,15 @@ interface — which settles the one question that could have sunk the
 whole approach, since the app needs the audio and the serial half of
 that device at the same time. **Bluetooth is untested for want of a
 device** and goes to beta on the strength of the shared code beneath
-it. **An IC-9700 and an IC-7100 did not work**, and the cause was a
-16-byte `SET_FLOW` write of zeroes to their CP2102N — see the
-rig-control bullets above; it is the first patch carried against the
-vendored `usb-serial-for-android`. Awaiting Andrew's confirmation on
-hardware. `rig::set_debug_sink` and the "Log
+it. **An IC-9700 and an IC-7100 do not work and that is open** — see
+the rig-control bullets above for what is ruled out. The chip's
+*configuration* is eliminated: with the blind `SET_FLOW` write skipped,
+this app programs the CP2102N exactly as FT8TW does, and FT8TW drives
+the same radio on the same phone. `SerialBridge.describeStatus` reads
+the chip's own `GET_COMM_STATUS` into the trace — transmit queue depth,
+receive queue depth and hold reasons — because a bulk write returning
+its length says the bytes reached the chip and nothing about whether
+the UART clocked them out. `rig::set_debug_sink` and the "Log
 rig traffic" switch landed for it, because until then Hamlib's trace on
 a phone went to stderr and therefore nowhere.
 Unplug/replug recovery and the "Connected with the cable out"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1048,18 +1048,36 @@ the SPP UUID). Six things are settled and worth not re-deriving:
   correct on its own terms; it is **not** thought to be the Icom fix
   (Andrew): CI-V has no flow control and an Icom uses those lines only
   for PTT, CW and RTTY keying.
-- **A K4 works over USB and two Icoms do not** (reported 2026-08-23,
-  **open**). The trace narrowed it to one gap and no further: the app
-  writes a correct frame (`-> rig 6: fe fe a2 e0 03 fd`) to a
-  **CP2102N** at 19200 8N1 flow=none, one vendor-class interface, two
-  endpoints, `Cp21xxSerialDriver` port 0 of 1 -- and nothing ever comes
-  back, while `rigctl -m 3081 -r /dev/ttyUSB0 -s 19200` on the same
-  cable answers instantly. Every control transfer returns 0 and the
-  bulk write returns 6, so the chip is enumerated, configured and
-  accepting bytes. **What no software here can see is whether the UART
-  actually clocked them out**, which is where code reading stops and a
-  hardware A/B has to take over. What was ruled out along the way, so
-  it is not re-derived:
+- **"No flow control" is not the same as writing zeros, and on a
+  CP2102N that difference cost an Icom entirely** (2026-08-23). An
+  IC-9700 would not answer a single CI-V frame from the app while
+  `rigctl -m 3081 -r /dev/ttyUSB0 -s 19200` on the same cable answered
+  instantly. The trace narrowed it to one gap: a correct frame reaching
+  the transport (`-> rig 6: fe fe a2 e0 03 fd`) against a CP2102N at
+  19200 8N1 flow=none, one vendor-class interface, two endpoints,
+  `Cp21xxSerialDriver` port 0 of 1, every control transfer returning 0
+  and every bulk write returning its length -- and nothing ever coming
+  back. Setting a CP210x's flow control to *none* sends it a 16-byte
+  `SET_FLOW` structure of **zeroes**, clobbering `ulControlHandshake`,
+  `ulFlowReplace`, `ulXonLimit` and `ulXoffLimit` in one blind write.
+  Two implementations that work with this chip do not do that:
+  **FT8TW** (which drives the same radio on the same phone -- Andrew's
+  test) carries a fork of `Cp21xxSerialDriver` with no `SET_FLOW`
+  constant and no `setFlowControl` at all, and the **Linux `cp210x`
+  driver**, which is what the working `rigctl` goes through, does
+  `GET_FLOW`/modify/`SET_FLOW` and never zeroes the limits. The kernel
+  also carries erratum **CP2102N_E104** -- firmware <= 0x10004 reads
+  `ulXonLimit` as `ulFlowReplace`, so a blind 16-byte write lands one
+  word out of alignment and the chip's own `ulXoffLimit` comes from
+  past the end of the buffer. So the write is skipped when there is no
+  flow control to set, in `SerialBridge.applyFlowControl` **and** in
+  `openInt` -- both, because `openInt` does it inside `port.open()`
+  before any of our code is asked. That is the **first patch carried
+  against the vendored library**; `third_party/usb-serial-for-android/PATCHES.md`
+  is the exhaustive list and every deviation is marked `// SSTVAE
+  PATCH` in the source, because `java/` was a byte-for-byte drop of the
+  release and is no longer. What was ruled out along the way, so it is
+  not re-derived:
   the byte path is length-counted end to end and cannot truncate a
   binary CI-V frame; Hamlib's POSIX `port_read_generic`/`port_write`
   have no port-type branch (the ones that exist are Win32 serial);
@@ -1074,16 +1092,12 @@ the SPP UUID). Six things are settled and worth not re-deriving:
   CATs with them low -- but that only shows the *transport* works that
   way, not that this *radio* does, and treating one radio's tolerance
   as a general fact is what kept the real difference hidden for a
-  round. Two differences from the Linux `cp210x` driver survive and are
-  the shortlist if the A/B points at the chip: the vendored library
-  writes `SET_FLOW` as **16 blind zero bytes** where Linux does
-  `GET_FLOW`/modify/`SET_FLOW`, preserving `ulXonLimit`/`ulXoffLimit`;
-  and it writes the requested baud raw where Linux applies
-  `cp210x_get_actual_rate()` for a CP2102N (a no-op at 19200, which
-  divides 48 MHz exactly). Linux also carries erratum **CP2102N_E104**
-  -- firmware <= 0x10004 reads `ulXonLimit` as `ulFlowReplace`, so it
-  declares flow control unsupported on those parts. None of this is
-  confirmed to matter here. The two
+  round -- the blind `SET_FLOW` above was found by the same comparison
+  and was the real one. One further difference from the Linux driver
+  survives and is the next place to look if a CP210x still misbehaves:
+  the vendored library writes the requested baud raw where Linux
+  applies `cp210x_get_actual_rate()` for a CP2102N. That is a no-op at
+  19200, which divides 48 MHz exactly, and a 0.16% shift at 115200. The two
   radio-side settings to check first are Icom-specific and invisible
   from here: the **CI-V USB baud rate** (a separate menu item,
   defaulting to an Auto that is not reliable on every model) and
@@ -1990,9 +2004,11 @@ interface — which settles the one question that could have sunk the
 whole approach, since the app needs the audio and the serial half of
 that device at the same time. **Bluetooth is untested for want of a
 device** and goes to beta on the strength of the shared code beneath
-it. **An IC-9700 and an IC-7100 do not work, and that is open** — see
-the rig-control bullets above for what has been ruled out and the two
-radio-side settings to check first. `rig::set_debug_sink` and the "Log
+it. **An IC-9700 and an IC-7100 did not work**, and the cause was a
+16-byte `SET_FLOW` write of zeroes to their CP2102N — see the
+rig-control bullets above; it is the first patch carried against the
+vendored `usb-serial-for-android`. Awaiting Andrew's confirmation on
+hardware. `rig::set_debug_sink` and the "Log
 rig traffic" switch landed for it, because until then Hamlib's trace on
 a phone went to stderr and therefore nowhere.
 Unplug/replug recovery and the "Connected with the cable out"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1070,8 +1070,28 @@ the SPP UUID). Six things are settled and worth not re-deriving:
   correct on its own terms; it is **not** thought to be the Icom fix
   (Andrew): CI-V has no flow control and an Icom uses those lines only
   for PTT, CW and RTTY keying.
-- **A K4 works over USB and two Icoms do not, and it is still open**
-  (2026-08-23). An
+- **A device id of VID:PID names a *kind* of device, not a device, and
+  an IC-9700 has two of the same kind** (2026-08-23). That radio
+  presents its CI-V port and its USB serial function as **two separate
+  USB devices sharing `10c4:ea60`**, each with one interface and one
+  port -- so `usb:10c4:ea60` named both, the picker showed two
+  identical rows, and `findUsbDevice` returned whichever
+  `getDeviceList()` yielded first. Out of a `HashMap`, so not reliably
+  the same one twice. The app was writing to a real, healthy CP2102N
+  that is not wired to the radio's CI-V engine, which from above is
+  indistinguishable from a radio that ignores us -- and is why every
+  chip-level measurement came back clean. The id now carries `@unit`
+  beside the existing `#port`, and the two are **not the same axis**:
+  `#port` is one driver's several UARTs (a CP2105), `@unit` is several
+  devices with one VID:PID. Units are ordered by `getDeviceName()`, the
+  only ordering available before permission is granted; that is not
+  promised across a replug, so the *label* says "(1 of 2)" and the
+  operator picks, because nothing readable distinguishes an Icom's CI-V
+  port from its data port. Both suffixes are omitted at zero, so an id
+  saved before they existed still means the first port of the first
+  device.
+- **A K4 worked over USB and two Icoms did not** (2026-08-23; the unit
+  index above is the cause found, not yet confirmed on hardware). An
   IC-9700 would not answer a single CI-V frame from the app while
   `rigctl -m 3081 -r /dev/ttyUSB0 -s 19200` on the same cable answered
   instantly. The trace narrowed it to one gap: a correct frame reaching

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1015,6 +1015,20 @@ the SPP UUID). Six things are settled and worth not re-deriving:
   logcat branch is not an alternative: `configure.ac` uses `ANDROID`
   only as an automake conditional, never as a define, and never links
   `-llog`.
+- **`core/rig/trace.hpp` is the other half of that trace, and it is
+  the half that says whether the bytes left.** Hamlib's view of a
+  radio that never answers is "wrote six bytes, read nothing" --
+  identical to what a bug in our own bridge would produce. So the
+  loopback bridge and the Android transport write to a second,
+  Hamlib-free sink in `sstvae_core` (so a `--no-rig` build still tests
+  every line of it), and the app installs both into one ring. It logs
+  what reached the transport **after** the write and never before (on
+  the way in it would say "delivered" for a write that threw --
+  `test_rig_bridge.cpp` pins that placement), what came back, the
+  resolved line settings, and `SerialBridge.describeLink`'s account of
+  which driver `UsbSerialProber` picked and which interface of how many
+  it claimed. Off costs one relaxed atomic load, which is why the calls
+  live in the byte pump unconditionally.
 - **A K4 works over USB and two Icoms do not** (reported 2026-08-23,
   open). What has been ruled out by reading, so it is not re-derived:
   the byte path is length-counted end to end and cannot truncate a
@@ -1023,7 +1037,12 @@ the SPP UUID). Six things are settled and worth not re-deriving:
   `network_flush` is a `FIONREAD`-guarded drain; `rigs/icom/` has no
   port-type conditional; and `serial_defaults` picks
   `rig_caps.serial_rate_max`, the same field `rig_init` uses, so a
-  bridged rig runs at the speed that rig runs at on a desktop. The two
+  bridged rig runs at the speed that rig runs at on a desktop; and it
+  is not the control lines, since **both** `FtdiSerialDriver` and
+  `Cp21xxSerialDriver` deassert DTR and RTS in `openInt()`, so the K4
+  works with them low (a difference from a desktop, where the OS raises
+  them, but not a fatal one), while every Icom declares
+  `RIG_HANDSHAKE_NONE` so no flow control is holding the chip off. The two
   radio-side settings to check first are Icom-specific and invisible
   from here: the **CI-V USB baud rate** (a separate menu item,
   defaulting to an Auto that is not reliable on every model) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2040,15 +2040,18 @@ the same radio on the same phone. `SerialBridge.describeStatus` reads
 the chip's own `GET_COMM_STATUS` into the trace — transmit queue depth,
 receive queue depth and hold reasons — because a bulk write returning
 its length says the bytes reached the chip and nothing about whether
-the UART clocked them out. **It is printed from the write thread, and
-that is not arbitrary**: the first version printed it from the read
-loop and printed nothing, which was itself the finding —
-`bulkTransfer` on a CP2102N with nothing to say blocks indefinitely,
-where an FTDI returns every ~16 ms because the chip sends a status
-packet regardless, so the K4 never exercised it. A liveness probe on
-the thread whose liveness is in question cannot report. The read
-thread now only counts, in relaxed atomics, and the write thread
-prints. `rig::set_debug_sink` and the "Log
+the UART clocked them out. **It is printed from the write thread**, which is
+the one whose frames are in the log and therefore known to be running;
+the read thread only counts, in relaxed atomics. An earlier version
+printed from the read loop and printed nothing, which was read as a
+blocked `bulkTransfer` and was not — the counters show the loop
+cycling at the bridge's 500 ms timeout, and the heartbeat had simply
+wanted more consecutive empty reads than a short session produces. Two
+of the fields are weaker than they look, and the measurement is what
+taught it: `outQueue` is sampled a second after the write and reads
+zero whether the chip sent or dropped, and `inQueue` is drained
+continuously by the read thread. `errors` and `hold` are latched by the
+chip and are what carry information. `rig::set_debug_sink` and the "Log
 rig traffic" switch landed for it, because until then Hamlib's trace on
 a phone went to stderr and therefore nowhere.
 Unplug/replug recovery and the "Connected with the cable out"

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -118,7 +118,7 @@ static calibrated quantisation was tried and is *worse* — do not retry
 it without new information. The finding that outlived it — the model
 had never seen non-photographic content — became the item below.
 
-## Android rig control: two Icoms do not work
+## Android rig control: the CP2102N SET_FLOW write
 
 Landed 2026-08-22 (`docs/android.md`, "Rig control was said to be
 structurally impossible") and taken to hardware 2026-08-23. Most of what
@@ -152,7 +152,7 @@ OS raises them on open, but demonstrably not a fatal one -- and every
 Icom in Hamlib declares `RIG_HANDSHAKE_NONE`, so nothing is applying
 flow control that could hold the chip's transmitter off.
 
-**The trace answered its own question and stopped there (2026-08-23).** `fe fe a2 e0 03 fd` -- address A2, the
+**Cause found 2026-08-23: a 16-byte `SET_FLOW` write of zeroes.** `fe fe a2 e0 03 fd` -- address A2, the
 IC-9700's default -- written, `read_string_generic(): Timed out 1.001
 seconds after 0 chars`, every time, at 115200. `icom_get_usb_echo_off`
 therefore returns `-RIG_ETIMEOUT` and `icom_rig_open` gives up with
@@ -163,35 +163,34 @@ bridge now logs each direction's bytes (after the transport accepted
 them, never before) and the transport logs which driver and interface
 the Android USB layer chose. So the next run distinguishes:
 
-It is the first case: `-> rig 6: fe fe a2 e0 03 fd` to a **CP2102N**
-at 19200 8N1 flow=none, one vendor-class interface, two endpoints,
-`Cp21xxSerialDriver` port 0 of 1, and no `<- rig` line, ever. Every
-control transfer returns 0 and the bulk write returns 6, so the chip is
-enumerated, configured and accepting bytes. **Nothing in software can
-see whether the UART clocked them out.** That is where reading code
-stops.
-
-The next two moves are a hardware A/B, in this order because the first
-needs nothing but the phone already in hand:
-
-1. **Does FT8CN drive the same radio on the same phone?** It uses the
-   same `usb-serial-for-android`. A pass means the chip is drivable
-   from Android and our usage differs; a failure means this is not our
-   code at all.
-2. **Does a CP210x USB adapter into the K4's RS-232 port fail the same
-   way?** That separates the chip from the radio in one test, using a
-   radio already known to work over this transport.
-
-Two differences from the Linux `cp210x` driver survive as the shortlist
-if the A/B points at the chip: the vendored library writes `SET_FLOW`
-as 16 blind zero bytes where Linux does `GET_FLOW`/modify/`SET_FLOW`,
-preserving `ulXonLimit`/`ulXoffLimit`; and it writes the requested baud
-raw where Linux applies `cp210x_get_actual_rate()` for a CP2102N (a
-no-op at 19200, which divides 48 MHz exactly). Linux also carries
+The trace showed `-> rig 6: fe fe a2 e0 03 fd` to a **CP2102N** at
+19200 8N1 flow=none, one vendor-class interface, two endpoints,
+`Cp21xxSerialDriver` port 0 of 1, and no `<- rig` line, ever -- every
+control transfer returning 0 and every bulk write returning its length.
+Andrew's A/B settled it: **FT8TW drives the same radio on the same
+phone**, and its fork of `Cp21xxSerialDriver` has no
+`SILABSER_SET_FLOW_REQUEST_CODE` constant and no `setFlowControl`
+method at all. Setting a CP210x's flow control to *none* is not a
+no-op; it writes sixteen zero bytes over `ulControlHandshake`,
+`ulFlowReplace`, `ulXonLimit` and `ulXoffLimit`. The Linux `cp210x`
+driver, which the working `rigctl` goes through, does
+`GET_FLOW`/modify/`SET_FLOW` and never zeroes the limits, and carries
 erratum **CP2102N_E104** -- firmware <= 0x10004 reads `ulXonLimit` as
-`ulFlowReplace`, so it declares flow control unsupported there.
+`ulFlowReplace`, so a blind write lands one word out of alignment.
 
-Radio-side, still worth eliminating:
+Fixed by skipping the write when there is no flow control to set, in
+`SerialBridge.applyFlowControl` and in the vendored
+`Cp21xxSerialDriver.openInt` (both: `openInt` runs inside
+`port.open()`). First patch carried against the vendored library --
+`third_party/usb-serial-for-android/PATCHES.md`. **Not yet confirmed on
+hardware.**
+
+One further difference from the Linux driver survives, as the next
+place to look if a CP210x still misbehaves: the library writes the
+requested baud raw where Linux applies `cp210x_get_actual_rate()` for a
+CP2102N -- a no-op at 19200 and a 0.16% shift at 115200.
+
+Radio-side, still worth eliminating if it is not fixed:
 
 1. **The CI-V USB baud rate**, which on these radios is a menu item
    separate from the CI-V port's own and defaults to an "Auto" that is

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -194,14 +194,27 @@ which it will answer itself. `SerialBridge.describeStatus` issues
 `GET_COMM_STATUS` (AN571, 19 bytes) and the transport traces it every
 ten consecutive empty reads, with the modem control lines:
 
-* bytes sitting in `outQueue` -> the chip is holding our frame, and
-  `hold` says why;
-* `outQueue` empty and `inQueue` empty -> the frame went out on the
-  wire and the radio did not answer;
-* `errors` non-zero -> framing or overrun, i.e. a rate or line problem.
+**Measured 2026-08-23**: `errors=0x0 hold=0x0 inQueue=0 outQueue=0`,
+all six modem lines reading 1, and `reads started=3 returned=2
+last=512ms` against the bridge's 500 ms timeout. So the read loop
+cycles normally, the chip reports no framing or overrun error and
+nothing withholding transmission, and CTS is high so no handshake is
+holding the transmitter off. `bridge: <- rig` never appears, so the
+radio does not answer.
 
-The heartbeat also proves the bridge's read loop is running at all,
-which nothing in the log did before.
+Two of those fields carry less than they appear to, and it is worth not
+re-deriving: `outQueue` is sampled a second after the write and reads
+zero whether the chip sent the bytes or dropped them, and `inQueue` is
+drained continuously by the read thread. `errors`, `hold` and `CTS` are
+the informative ones.
+
+**That exhausts what code inspection can settle.** The chip is
+programmed identically to a working implementation, reports itself
+healthy, and no software here can see whether the UART put bits on the
+pin. The next step is a hardware A/B that separates the chip from the
+radio -- a CP210x USB adapter into the K4's RS-232 port, driven from
+the same phone and app. If that fails, the fault is in the CP210x path;
+if it works, it is the IC-9700 specifically.
 
 One further difference from the Linux driver survives, as the next
 place to look if a CP210x still misbehaves: the library writes the

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -118,7 +118,7 @@ static calibrated quantisation was tried and is *worse* — do not retry
 it without new information. The finding that outlived it — the model
 had never seen non-photographic content — became the item below.
 
-## Android rig control: the CP2102N SET_FLOW write
+## Android rig control: an Icom that will not answer a phone
 
 Landed 2026-08-22 (`docs/android.md`, "Rig control was said to be
 structurally impossible") and taken to hardware 2026-08-23. Most of what
@@ -152,7 +152,7 @@ OS raises them on open, but demonstrably not a fatal one -- and every
 Icom in Hamlib declares `RIG_HANDSHAKE_NONE`, so nothing is applying
 flow control that could hold the chip's transmitter off.
 
-**Cause found 2026-08-23: a 16-byte `SET_FLOW` write of zeroes.** `fe fe a2 e0 03 fd` -- address A2, the
+**Open. The chip's configuration is ruled out (2026-08-23).** `fe fe a2 e0 03 fd` -- address A2, the
 IC-9700's default -- written, `read_string_generic(): Timed out 1.001
 seconds after 0 chars`, every time, at 115200. `icom_get_usb_echo_off`
 therefore returns `-RIG_ETIMEOUT` and `icom_rig_open` gives up with
@@ -178,12 +178,30 @@ driver, which the working `rigctl` goes through, does
 erratum **CP2102N_E104** -- firmware <= 0x10004 reads `ulXonLimit` as
 `ulFlowReplace`, so a blind write lands one word out of alignment.
 
-Fixed by skipping the write when there is no flow control to set, in
+That write is now skipped when there is nothing to set, in
 `SerialBridge.applyFlowControl` and in the vendored
 `Cp21xxSerialDriver.openInt` (both: `openInt` runs inside
-`port.open()`). First patch carried against the vendored library --
-`third_party/usb-serial-for-android/PATCHES.md`. **Not yet confirmed on
-hardware.**
+`port.open()`) -- the first patch carried against the vendored library,
+`third_party/usb-serial-for-android/PATCHES.md`. **It did not fix it**,
+and that is the useful result: FT8TW's `setParameters` is behaviourally
+identical to ours, so with the write gone the two program the chip the
+same way and the Icom still fails. The register writes are not the
+difference. The guard stays because both reference implementations
+avoid the blind write and the erratum is real.
+
+So the next question is what the chip does with bytes it has accepted,
+which it will answer itself. `SerialBridge.describeStatus` issues
+`GET_COMM_STATUS` (AN571, 19 bytes) and the transport traces it every
+ten consecutive empty reads, with the modem control lines:
+
+* bytes sitting in `outQueue` -> the chip is holding our frame, and
+  `hold` says why;
+* `outQueue` empty and `inQueue` empty -> the frame went out on the
+  wire and the radio did not answer;
+* `errors` non-zero -> framing or overrun, i.e. a rate or line problem.
+
+The heartbeat also proves the bridge's read loop is running at all,
+which nothing in the log did before.
 
 One further difference from the Linux driver survives, as the next
 place to look if a CP210x still misbehaves: the library writes the

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -118,42 +118,63 @@ static calibrated quantisation was tried and is *worse* — do not retry
 it without new information. The finding that outlived it — the model
 had never seen non-photographic content — became the item below.
 
-## Android rig control: everything on hardware
+## Android rig control: two Icoms do not work
 
 Landed 2026-08-22 (`docs/android.md`, "Rig control was said to be
-structurally impossible"). The mechanism is covered by desktop tests --
-the loopback bridge, the composition, the PTT routing, the line-setting
-resolution, and a real Kenwood TS-2000 backend reading frequency and
-keying through the bridge. **None of it has been compiled for Android or
-run against a radio**, because the session that wrote it had no NDK and
-no reachable `dl.google.com`.
+structurally impossible") and taken to hardware 2026-08-23. Most of what
+this section used to list is answered:
 
-In the order that answers the most per attempt:
+- **A composite USB device gives the phone audio and serial at once.**
+  This was the question that could have sunk the approach, and on an
+  Elecraft K4 the answer is yes, with CAT and both control-line keying
+  methods working. mik3y/usb-serial-for-android#477 remains an open
+  report of a composite device where it does not, so it is a per-device
+  answer rather than a general one.
+- The Hamlib NDK cross-build, CAT against a real radio, and DTR/RTS
+  keying are all exercised. Bluetooth is not, for want of a device.
 
-1. **Does the phone hold USB audio and USB serial on one composite
-   device?** Most rig USB interfaces present both, and this app needs
-   both at once. It works for FT8CN on at least some devices, and
-   mik3y/usb-serial-for-android#477 is an open report of it failing on
-   others. If the answer is no for a given radio, that is the radio's
-   answer and not a bug to fix -- Bluetooth and the network kind are
-   unaffected. Settle it before anything else, because a bad answer
-   changes what the rest of the list is worth.
-2. **The Hamlib NDK cross-build.** Expect to fix something. The two
-   guards in `native/cmake/hamlib.cmake` (a named missing compiler
-   wrapper, and a refused versioned SONAME) exist so the first failure
-   is diagnosable in one round.
-3. **CAT against a real radio**, model 1 first -- Hamlib's dummy opens
-   and keys with nothing attached, so it separates "the bridge works"
-   from "this backend works".
-4. **PTT timing against a physical radio**, which is the *same*
-   outstanding item the desktop has and has never had: `ptt_lead_s` is
-   0.3 s of guess. A phone into a radio is now a way to measure it.
-5. **DTR/RTS keying**, which is the path Hamlib cannot take here and
-   ours is the only implementation of.
-6. **Battery over a multi-hour session with a rig session open.** The
-   poll is 10 s rather than the desktop's 5, and the bridge's idle cost
-   is meant to be two wakeups a second on one thread; both are claims,
-   not measurements.
+**What is open is that a K4 works and an IC-9700 and an IC-7100 do
+not.** Everything structural was ruled out by reading, and re-deriving
+it is the waste this paragraph exists to prevent: the byte path is
+length-counted end to end (`SerialBridge.read` → a `jbyteArray` region
+copy → `LoopbackBridge`'s `send`), so nothing truncates a binary CI-V
+frame at a `0x00`; Hamlib's POSIX `port_read_generic` and `port_write`
+have no port-type branch at all, the ones that exist being Win32 serial;
+`network_flush` is a `FIONREAD`-guarded drain that cannot block;
+`rigs/icom/` contains no port-type conditional; and `serial_defaults`
+takes `rig_caps.serial_rate_max`, the same field `rig_init` uses, so a
+bridged rig runs at the speed that rig runs at on a desktop.
+
+So the next move is evidence, not another hypothesis.
+`rig::set_debug_sink` and **Settings > Rig control > Log rig traffic**
+exist for this: Hamlib's own trace was going to stderr, which on a phone
+is nowhere, and it is the only thing that says how far `rig_open` got
+and what the radio answered. What to look for in it, in order:
+
+1. Does `icom_get_usb_echo_off` time out, or return an echo status? A
+   timeout at that point means nothing came back at all -- a wrong port,
+   a wrong baud, or a radio not answering on that address. An echo
+   status followed by a failed `rig_get_freq` means the link works and
+   the problem is above it.
+2. **The CI-V USB baud rate**, which on these radios is a menu item
+   separate from the CI-V port's own and defaults to an "Auto" that is
+   not reliable on every model. Set it to a fixed rate and set the same
+   rate in Settings rather than leaving Baud on Default, which resolves
+   to `serial_rate_max` (115200 for the IC-9700, 19200 for the IC-7100).
+3. **CI-V USB Echo Back**, which is what step 1 is probing, and which
+   `rig_open` gives exactly one attempt at -- it sets `retry` to 0 for
+   the duration.
+
+Still outstanding, unchanged and unrelated:
+
+- **PTT timing against a physical radio**, which is the *same*
+  outstanding item the desktop has and has never had: `ptt_lead_s` is
+  0.3 s of guess. A phone into a radio is now a way to measure it.
+- **Battery over a multi-hour session with a rig session open.** The
+  poll is 10 s rather than the desktop's 5, and the bridge's idle cost
+  is meant to be two wakeups a second on one thread; both are claims,
+  not measurements.
+- **Bluetooth RFCOMM against a real radio.**
 
 ## Non-photographic content: evaluate, then train on it
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -118,7 +118,7 @@ static calibrated quantisation was tried and is *worse* — do not retry
 it without new information. The finding that outlived it — the model
 had never seen non-photographic content — became the item below.
 
-## Android rig control: an Icom that will not answer a phone
+## Android rig control: two USB ports, one device id
 
 Landed 2026-08-22 (`docs/android.md`, "Rig control was said to be
 structurally impossible") and taken to hardware 2026-08-23. Most of what
@@ -152,7 +152,15 @@ OS raises them on open, but demonstrably not a fatal one -- and every
 Icom in Hamlib declares `RIG_HANDSHAKE_NONE`, so nothing is applying
 flow control that could hold the chip's transmitter off.
 
-**Open. The chip's configuration is ruled out (2026-08-23).** `fe fe a2 e0 03 fd` -- address A2, the
+**Cause found 2026-08-23, awaiting hardware confirmation: an IC-9700
+presents two USB serial devices sharing `10c4:ea60` -- CI-V and the USB
+serial function -- and `usb:VID:PID` named both.** The picker showed two
+identical rows and `findUsbDevice` returned whichever `getDeviceList()`
+yielded first, out of a `HashMap`. Ids now carry `@unit` beside
+`#port`, which is a different axis: `#port` is one driver's several
+UARTs, `@unit` is several devices with one VID:PID. What follows is the
+measurement record from before that was found, and it stands -- it is
+what ruled the chip's configuration out. `fe fe a2 e0 03 fd` -- address A2, the
 IC-9700's default -- written, `read_string_generic(): Timed out 1.001
 seconds after 0 chars`, every time, at 115200. `icom_get_usb_echo_off`
 therefore returns `-RIG_ETIMEOUT` and `icom_rig_open` gives up with

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -152,8 +152,7 @@ OS raises them on open, but demonstrably not a fatal one -- and every
 Icom in Hamlib declares `RIG_HANDSHAKE_NONE`, so nothing is applying
 flow control that could hold the chip's transmitter off.
 
-**The first trace (2026-08-23) shows correct frames going out and zero
-bytes ever coming back.** `fe fe a2 e0 03 fd` -- address A2, the
+**The trace answered its own question and stopped there (2026-08-23).** `fe fe a2 e0 03 fd` -- address A2, the
 IC-9700's default -- written, `read_string_generic(): Timed out 1.001
 seconds after 0 chars`, every time, at 115200. `icom_get_usb_echo_off`
 therefore returns `-RIG_ETIMEOUT` and `icom_rig_open` gives up with
@@ -164,13 +163,35 @@ bridge now logs each direction's bytes (after the transport accepted
 them, never before) and the transport logs which driver and interface
 the Android USB layer chose. So the next run distinguishes:
 
-* `-> rig 6: fe fe a2 e0 03 fd` with no `<- rig` line -- the bytes left
-  and the radio said nothing. Radio-side; see below.
-* no `-> rig` line at all -- our write never reached the chip, which
-  would be the first evidence of a bug on this side.
-* a `<- rig` line that Hamlib did not see -- a fault in the socket half.
+It is the first case: `-> rig 6: fe fe a2 e0 03 fd` to a **CP2102N**
+at 19200 8N1 flow=none, one vendor-class interface, two endpoints,
+`Cp21xxSerialDriver` port 0 of 1, and no `<- rig` line, ever. Every
+control transfer returns 0 and the bulk write returns 6, so the chip is
+enumerated, configured and accepting bytes. **Nothing in software can
+see whether the UART clocked them out.** That is where reading code
+stops.
 
-Assuming the first, what to check, in order:
+The next two moves are a hardware A/B, in this order because the first
+needs nothing but the phone already in hand:
+
+1. **Does FT8CN drive the same radio on the same phone?** It uses the
+   same `usb-serial-for-android`. A pass means the chip is drivable
+   from Android and our usage differs; a failure means this is not our
+   code at all.
+2. **Does a CP210x USB adapter into the K4's RS-232 port fail the same
+   way?** That separates the chip from the radio in one test, using a
+   radio already known to work over this transport.
+
+Two differences from the Linux `cp210x` driver survive as the shortlist
+if the A/B points at the chip: the vendored library writes `SET_FLOW`
+as 16 blind zero bytes where Linux does `GET_FLOW`/modify/`SET_FLOW`,
+preserving `ulXonLimit`/`ulXoffLimit`; and it writes the requested baud
+raw where Linux applies `cp210x_get_actual_rate()` for a CP2102N (a
+no-op at 19200, which divides 48 MHz exactly). Linux also carries
+erratum **CP2102N_E104** -- firmware <= 0x10004 reads `ulXonLimit` as
+`ulFlowReplace`, so it declares flow control unsupported there.
+
+Radio-side, still worth eliminating:
 
 1. **The CI-V USB baud rate**, which on these radios is a menu item
    separate from the CI-V port's own and defaults to an "Auto" that is

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -145,25 +145,48 @@ have no port-type branch at all, the ones that exist being Win32 serial;
 takes `rig_caps.serial_rate_max`, the same field `rig_init` uses, so a
 bridged rig runs at the speed that rig runs at on a desktop.
 
-So the next move is evidence, not another hypothesis.
-`rig::set_debug_sink` and **Settings > Rig control > Log rig traffic**
-exist for this: Hamlib's own trace was going to stderr, which on a phone
-is nowhere, and it is the only thing that says how far `rig_open` got
-and what the radio answered. What to look for in it, in order:
+Nor is it the control lines: **both** `FtdiSerialDriver` and
+`Cp21xxSerialDriver` deassert DTR and RTS in `openInt()`, so the K4 is
+CAT-ing with them low. That is a difference from a desktop, where the
+OS raises them on open, but demonstrably not a fatal one -- and every
+Icom in Hamlib declares `RIG_HANDSHAKE_NONE`, so nothing is applying
+flow control that could hold the chip's transmitter off.
 
-1. Does `icom_get_usb_echo_off` time out, or return an echo status? A
-   timeout at that point means nothing came back at all -- a wrong port,
-   a wrong baud, or a radio not answering on that address. An echo
-   status followed by a failed `rig_get_freq` means the link works and
-   the problem is above it.
-2. **The CI-V USB baud rate**, which on these radios is a menu item
+**The first trace (2026-08-23) shows correct frames going out and zero
+bytes ever coming back.** `fe fe a2 e0 03 fd` -- address A2, the
+IC-9700's default -- written, `read_string_generic(): Timed out 1.001
+seconds after 0 chars`, every time, at 115200. `icom_get_usb_echo_off`
+therefore returns `-RIG_ETIMEOUT` and `icom_rig_open` gives up with
+"is rig on and connected?". What that trace *cannot* say is whether
+those six bytes reached the USB endpoint, because Hamlib only ever saw
+a successful socket write. `core/rig/trace.hpp` closes that gap: the
+bridge now logs each direction's bytes (after the transport accepted
+them, never before) and the transport logs which driver and interface
+the Android USB layer chose. So the next run distinguishes:
+
+* `-> rig 6: fe fe a2 e0 03 fd` with no `<- rig` line -- the bytes left
+  and the radio said nothing. Radio-side; see below.
+* no `-> rig` line at all -- our write never reached the chip, which
+  would be the first evidence of a bug on this side.
+* a `<- rig` line that Hamlib did not see -- a fault in the socket half.
+
+Assuming the first, what to check, in order:
+
+1. **The CI-V USB baud rate**, which on these radios is a menu item
    separate from the CI-V port's own and defaults to an "Auto" that is
    not reliable on every model. Set it to a fixed rate and set the same
-   rate in Settings rather than leaving Baud on Default, which resolves
-   to `serial_rate_max` (115200 for the IC-9700, 19200 for the IC-7100).
-3. **CI-V USB Echo Back**, which is what step 1 is probing, and which
-   `rig_open` gives exactly one attempt at -- it sets `retry` to 0 for
-   the duration.
+   rate in Settings. Note that the trace shows **115200**, which is not
+   this app's default: `serial_defaults` returns `serial_rate_max`,
+   which Hamlib gives as 38400 for the IC-9700 and 19200 for the
+   IC-7100. Worth trying Default (or 19200) as well as whatever the
+   radio's menu says, since Auto has an easier time at the lower rates.
+2. **CI-V USB Echo Back**, which is what `icom_get_usb_echo_off` is
+   probing, and which `rig_open` gives exactly one attempt at -- it
+   sets `retry` to 0 for the duration.
+3. **The CI-V address**, which on these radios is a *separate* setting
+   for the USB port when "CI-V USB Port" is "Unlink from [REMOTE]".
+   The app sends to A2, the IC-9700's factory default; a changed
+   address produces exactly this silence.
 
 Still outstanding, unchanged and unrelated:
 

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(sstvae_core STATIC
   core/util/event.cpp
   core/rx/ringbuffer.cpp
   core/rig/controller.cpp
+  core/rig/trace.cpp
   core/rx/engine.cpp
   core/tx/engine.cpp
   core/settings/settings.cpp

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1262,8 +1262,19 @@ lines only for PTT, CW and RTTY keying. And every Icom in Hamlib declares
 `RIG_HANDSHAKE_NONE`, so no flow control is being applied that could
 hold the chip's transmitter off.
 
-**Still open, and the chip's configuration is now ruled out
-(2026-08-23).** With the blind `SET_FLOW` write below skipped, this app
+**Cause found 2026-08-23: the device id could not tell two ports
+apart.** An IC-9700 presents its CI-V port and its USB serial function
+as two separate USB devices sharing `10c4:ea60`, each with one
+interface and one port. `usb:VID:PID` named both, so the picker showed
+two identical rows and the lookup returned whichever `getDeviceList()`
+— a `HashMap` — yielded first. The app was talking to a real, healthy
+CP2102N that is not wired to the radio's CI-V engine, which explains
+why every chip-level measurement below came back clean. Ids now carry
+`@unit` alongside `#port`; the two are different axes and conflating
+them was the bug. **Not yet confirmed on hardware.**
+
+**What the measurements said while that was still hidden
+(2026-08-23), and the chip configuration they ruled out.** With the blind `SET_FLOW` write below skipped, this app
 programs the CP2102N exactly as FT8TW does — its `setParameters` is
 behaviourally identical and its older copy of the driver has no flow
 control code at all — and FT8TW drives the same radio on the same

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1284,6 +1284,15 @@ whole row on a phone. `Label` rather than `Text`: it takes its colour
 from the active style, and hardcoding a colour is how a control ends up
 unreadable in the other theme.
 
+**And both device lists are sorted before they are handed up.**
+`UsbSerialProber.findAllDrivers` walks `getDeviceList().values()` — the
+same `HashMap` — and `getBondedDevices()` returns a `Set`, so the rows
+arrived in whatever order those felt like: "(2 of 2)" could sit above
+"(1 of 2)", and a Bluetooth list could reshuffle between refreshes.
+Sorting the *unit index* was not enough, because that fixed the
+numbering and not the order the numbered rows came out in — the same
+`HashMap` leaking through one layer further up.
+
 **What the measurements said while that was still hidden
 (2026-08-23), and the chip configuration they ruled out.** With the blind `SET_FLOW` write below skipped, this app
 programs the CP2102N exactly as FT8TW does — its `setParameters` is

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1254,14 +1254,40 @@ CI-V frame at a `0x00` the way a string would; Hamlib's POSIX
 a bridged rig runs at the speed the same rig runs at on a desktop. Nor
 is it the control lines: **both** `FtdiSerialDriver` and
 `Cp21xxSerialDriver` explicitly deassert DTR and RTS in `openInt()`, so
-the K4 is CAT-ing over this transport with them low — which is a
-difference from a desktop, where the OS raises them on open, but
-demonstrably not a fatal one. And every Icom in Hamlib declares
+the K4 is CAT-ing over this transport with them low. That is a
+difference from a desktop, where the OS raises them on open, and the
+transport now matches the desktop — but it is **not** thought to be the
+Icom fix (Andrew): CI-V has no flow control and an Icom uses those
+lines only for PTT, CW and RTTY keying. And every Icom in Hamlib declares
 `RIG_HANDSHAKE_NONE`, so no flow control is being applied that could
 hold the chip's transmitter off.
 
-**The first trace (2026-08-23) shows correct frames going out and zero
-bytes coming back.** `fe fe a2 e0 03 fd` — address A2, the IC-9700's
+**The trace narrowed it to one gap and no further (2026-08-23).** The
+app writes a correct frame — `-> rig 6: fe fe a2 e0 03 fd` — to a
+**CP2102N** at 19200 8N1 flow=none, one vendor-class interface, two
+endpoints, `Cp21xxSerialDriver` port 0 of 1, and nothing ever comes
+back; `rigctl -m 3081 -r /dev/ttyUSB0 -s 19200` on the same cable
+answers instantly. Every control transfer the driver makes returns 0
+and the bulk write returns 6, so the chip is enumerated, configured and
+accepting bytes. **What no software here can see is whether the UART
+clocked them out**, which is where reading code stops and a hardware
+A/B has to take over — the two worth running are whether FT8CN drives
+the same radio on the same phone (it uses the same USB library, so a
+pass there means our usage differs and a failure means it is not our
+code), and whether a CP210x adapter into the K4's RS-232 port fails the
+same way (which would separate the chip from the radio).
+
+Two differences from the Linux `cp210x` driver survive as the shortlist
+if the A/B points at the chip: the vendored library writes `SET_FLOW`
+as 16 blind zero bytes where Linux does `GET_FLOW`/modify/`SET_FLOW`,
+preserving `ulXonLimit`/`ulXoffLimit`; and it writes the requested baud
+raw where Linux applies `cp210x_get_actual_rate()` for a CP2102N (a
+no-op at 19200, which divides 48 MHz exactly). Linux also carries
+erratum **CP2102N_E104** — firmware ≤ 0x10004 reads `ulXonLimit` as
+`ulFlowReplace`, so it declares flow control unsupported on those
+parts. None of it is confirmed to matter.
+
+**The earlier reading of that trace was:** `fe fe a2 e0 03 fd` — address A2, the IC-9700's
 default — written, then `read_string_generic(): Timed out 1.001 seconds
 after 0 chars`, every time, at 115200. So `icom_get_usb_echo_off`
 returns `-RIG_ETIMEOUT` and `icom_rig_open` gives up with "is rig on and

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1262,7 +1262,24 @@ lines only for PTT, CW and RTTY keying. And every Icom in Hamlib declares
 `RIG_HANDSHAKE_NONE`, so no flow control is being applied that could
 hold the chip's transmitter off.
 
-**The trace narrowed it to one gap and no further (2026-08-23).** The
+**It was a 16-byte `SET_FLOW` write of zeroes (2026-08-23).** Setting a
+CP210x's flow control to *none* is not a no-op: the library sends the
+chip sixteen zero bytes, clobbering `ulControlHandshake`,
+`ulFlowReplace`, `ulXonLimit` and `ulXoffLimit` at once. FT8TW drives
+the same radio on the same phone with a fork of `Cp21xxSerialDriver`
+that has no `SET_FLOW` code in it at all, and the Linux `cp210x`
+driver — which is what the working `rigctl` goes through — does
+`GET_FLOW`/modify/`SET_FLOW` and never zeroes the limits. The kernel
+additionally carries erratum **CP2102N_E104**: firmware ≤ 0x10004 reads
+`ulXonLimit` as `ulFlowReplace`, so a blind write lands one word out of
+alignment and the chip's own `ulXoffLimit` comes from past the end of
+the buffer. The write is now skipped when there is nothing to set —
+in `SerialBridge.applyFlowControl` **and** in the vendored
+`Cp21xxSerialDriver.openInt`, which does it inside `port.open()` before
+any of our code is asked. That is the first patch carried against the
+vendored library; see `third_party/usb-serial-for-android/PATCHES.md`.
+
+**How the trace got there:** The
 app writes a correct frame — `-> rig 6: fe fe a2 e0 03 fd` — to a
 **CP2102N** at 19200 8N1 flow=none, one vendor-class interface, two
 endpoints, `Cp21xxSerialDriver` port 0 of 1, and nothing ever comes

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1229,14 +1229,74 @@ of its watchdog in CI. Linux and macOS still build and test it, using
 the same POSIX calls Android does, so `test_rig_hamlib`'s
 real-Kenwood-through-a-real-bridge proof is untouched.
 
-**What is not tested on hardware.** Everything in this section. The
-composite-device question in particular is worth settling first with the
-actual radio: most rig USB interfaces present audio and CDC serial
-together, and this app needs both at once. FT8CN does it successfully on
-at least some devices, and mik3y/usb-serial-for-android#477 is an open
-report of a composite device where claiming the CDC interface fails
-while the platform holds the audio interfaces. If that turns out badly
-for a given radio, Bluetooth and the network kind are unaffected.
+**The composite-device question is settled, and it was the one that
+could have sunk the approach.** Most rig USB interfaces present audio
+and CDC serial together and this app needs both at once;
+mik3y/usb-serial-for-android#477 is an open report of a composite device
+where claiming the serial interface fails while the platform holds the
+audio ones. On an Elecraft K4 over one composite interface it works:
+CAT, DTR keying and RTS keying, with the audio path live (Andrew,
+2026-08-23). **Bluetooth is still untested for want of a device** and
+goes to beta on the strength of the shared code beneath it.
+
+**Not every radio works, and the trace is how to find out why.** A K4
+works over USB; an IC-9700 and an IC-7100 do not (reported 2026-08-23,
+unresolved). Everything structural was ruled out by reading before the
+logging below was written, and it is worth not re-deriving: the byte
+path is length-counted end to end (`SerialBridge.read` → a `jbyteArray`
+region copy → `LoopbackBridge`'s `send`), so nothing truncates a binary
+CI-V frame at a `0x00` the way a string would; Hamlib's POSIX
+`port_read_generic` and `port_write` have no port-type branch at all
+(the ones that exist are Win32 serial); `network_flush` is a
+`FIONREAD`-guarded drain and cannot block; the port-type conditionals in
+`rigs/icom/` are none; and the baud our `serial_defaults` picks is
+`rig_caps.serial_rate_max`, which is the same field `rig_init` uses, so
+a bridged rig runs at the speed the same rig runs at on a desktop.
+
+Two things worth trying on the radio before suspecting this app, since
+both are Icom-specific and neither is visible from here: **the CI-V USB
+baud rate** (a menu item separate from the CI-V port's own, defaulting
+to Auto, which is not reliable on every model — set it to a fixed rate
+and set the same rate in Settings rather than leaving Baud on Default),
+and **CI-V USB Echo Back**, which is what `icom_get_usb_echo_off`
+probes for at open and gets exactly one attempt at, `rig_open` having
+set `retry` to 0 for the duration.
+
+## Reading Hamlib's trace on a phone
+
+`SSTVAE_HAMLIB_DEBUG` raises Hamlib's level and Hamlib writes to
+**stderr**, which a desktop operator can capture and a phone discards.
+So on the one platform where rig control is newest, the single artifact
+that answers "how far did `rig_open` get, and what did the radio say"
+was unreachable. (Hamlib's own `debug.c` has an `#ifdef ANDROID` branch
+that would log to logcat — it is dead in any build of ours and probably
+in most: `configure.ac` uses `ANDROID` only as an automake conditional,
+never as a preprocessor define, and never links `-llog`.)
+
+`rig::set_debug_sink` (`core/rig/hamlib.hpp`) registers a
+`vprintf_cb_t` and turns the trace into a stream of whole lines.
+**Settings → Rig control → Log rig traffic** installs a sink that keeps
+the last 600 lines and mirrors each to logcat; Refresh, Copy and Clear
+are under the switch. Off by default — at `RIG_DEBUG_TRACE` it is a line
+per CAT frame.
+
+Three things about it are load-bearing rather than incidental:
+
+- **The callback is registered only while a sink exists.** `rig_debug`
+  writes to stderr *or* to the callback, never both, so one left
+  registered swallows the trace for every later run — silently, since a
+  swallowed trace and a quiet library are the same output.
+  `test_rig_hamlib.cpp` captures stderr and requires it back, and that
+  assertion was mutation-tested: registering unconditionally fails it
+  and nothing else.
+- **The ring is a process-wide singleton, not a member of `RigControl`.**
+  QML destroys and rebuilds that view on every rotation while the rig
+  session outlives both, so a per-view buffer would discard the trace of
+  the open being diagnosed. It also keeps the sink's captures free of
+  `this`, which matters because it is called from the rig worker thread.
+- **The text area is refreshed by hand.** The rig screen republishes at
+  1 Hz and a bound `text:` would reset the scroll position every second,
+  which is unreadable in exactly the situation it is for.
 
 ## `core/audio/android/`
 

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1262,7 +1262,25 @@ lines only for PTT, CW and RTTY keying. And every Icom in Hamlib declares
 `RIG_HANDSHAKE_NONE`, so no flow control is being applied that could
 hold the chip's transmitter off.
 
-**It was a 16-byte `SET_FLOW` write of zeroes (2026-08-23).** Setting a
+**Still open, and the chip's configuration is now ruled out
+(2026-08-23).** With the blind `SET_FLOW` write below skipped, this app
+programs the CP2102N exactly as FT8TW does — its `setParameters` is
+behaviourally identical and its older copy of the driver has no flow
+control code at all — and FT8TW drives the same radio on the same
+phone. So the register writes are not the difference.
+
+What no software above the chip can see is whether the UART clocked the
+bytes out: a bulk write returning its length means they reached the
+chip. A CP210x will say. `SerialBridge.describeStatus` issues
+`GET_COMM_STATUS` (Silicon Labs AN571, 19 bytes) and puts the transmit
+queue depth, the receive queue depth, the error mask and the hold
+reasons into the trace, alongside the modem control lines, every ten
+consecutive empty reads — which also proves the read loop is running,
+something nothing else in the log did. Bytes stuck in `outQueue` mean
+the chip is holding them and `hold` says why; an empty `outQueue` with
+an empty `inQueue` means they went out and the radio said nothing.
+
+**The write that was skipped, and why it stays (2026-08-23).** Setting a
 CP210x's flow control to *none* is not a no-op: the library sends the
 chip sixteen zero bytes, clobbering `ulControlHandshake`,
 `ulFlowReplace`, `ulXonLimit` and `ulXoffLimit` at once. FT8TW drives

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1273,6 +1273,17 @@ why every chip-level measurement below came back clean. Ids now carry
 `@unit` alongside `#port`; the two are different axes and conflating
 them was the bug. **Not yet confirmed on hardware.**
 
+Two presentation details go with it, and both are about the one piece
+of text that matters. The unit marker is a **prefix** — `(1 of 2)
+Silicon Labs CP2102N…` — because put after the name it is the first
+thing a narrow combo elides, which leaves two rows reading identically.
+And the device picker and the radio picker both use a **wrapping
+delegate** (`contentItem: Label { wrapMode: Text.Wrap }`, not the
+default `ItemDelegate` text, which elides), so the open list shows the
+whole row on a phone. `Label` rather than `Text`: it takes its colour
+from the active style, and hardcoding a colour is how a control ends up
+unreadable in the other theme.
+
 **What the measurements said while that was still hidden
 (2026-08-23), and the chip configuration they ruled out.** With the blind `SET_FLOW` write below skipped, this app
 programs the CP2102N exactly as FT8TW does — its `setParameters` is

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1274,11 +1274,31 @@ bytes out: a bulk write returning its length means they reached the
 chip. A CP210x will say. `SerialBridge.describeStatus` issues
 `GET_COMM_STATUS` (Silicon Labs AN571, 19 bytes) and puts the transmit
 queue depth, the receive queue depth, the error mask and the hold
-reasons into the trace, alongside the modem control lines, every ten
-consecutive empty reads — which also proves the read loop is running,
-something nothing else in the log did. Bytes stuck in `outQueue` mean
-the chip is holding them and `hold` says why; an empty `outQueue` with
-an empty `inQueue` means they went out and the radio said nothing.
+reasons into the trace alongside the modem control lines. Bytes stuck
+in `outQueue` mean the chip is holding them and `hold` says why; an
+empty `outQueue` with an empty `inQueue` means they went out and the
+radio said nothing.
+
+**It is reported from the write path, and where it is reported was a
+mistake worth recording.** The first version logged it from the read
+loop, every ten consecutive empty reads — and printed nothing at all,
+which turned out to be the finding: the read loop was not cycling. A
+liveness probe on the thread whose liveness is in question cannot
+report. `bulkTransfer` on a CP2102N that has nothing to say blocks for
+as long as it likes, where an FTDI returns every ~16 ms because the
+chip sends a status packet whether or not there is data — so the K4
+never exercised this and the Icom never got past the first read. That
+is not itself a fault (a blocked read still delivers data the moment
+any arrives) but it is why the instrument was silent.
+
+So the read thread now only *counts* — reads started, reads returned,
+and how long the last one took, in relaxed atomics that nothing
+synchronises through — and the **write** thread prints them, because
+its frames are in the log and it is therefore known to be running. The
+probe fires *before* each frame rather than after, so what it describes
+is the state the previous frame left behind after Hamlib's full
+timeout; probed immediately after a write it would only ever catch a
+UART mid-transmission and prove nothing.
 
 **The write that was skipped, and why it stays (2026-08-23).** Setting a
 CP210x's flow control to *none* is not a no-op: the library sends the

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -1251,18 +1251,37 @@ CI-V frame at a `0x00` the way a string would; Hamlib's POSIX
 `FIONREAD`-guarded drain and cannot block; the port-type conditionals in
 `rigs/icom/` are none; and the baud our `serial_defaults` picks is
 `rig_caps.serial_rate_max`, which is the same field `rig_init` uses, so
-a bridged rig runs at the speed the same rig runs at on a desktop.
+a bridged rig runs at the speed the same rig runs at on a desktop. Nor
+is it the control lines: **both** `FtdiSerialDriver` and
+`Cp21xxSerialDriver` explicitly deassert DTR and RTS in `openInt()`, so
+the K4 is CAT-ing over this transport with them low — which is a
+difference from a desktop, where the OS raises them on open, but
+demonstrably not a fatal one. And every Icom in Hamlib declares
+`RIG_HANDSHAKE_NONE`, so no flow control is being applied that could
+hold the chip's transmitter off.
 
-Two things worth trying on the radio before suspecting this app, since
-both are Icom-specific and neither is visible from here: **the CI-V USB
-baud rate** (a menu item separate from the CI-V port's own, defaulting
-to Auto, which is not reliable on every model — set it to a fixed rate
-and set the same rate in Settings rather than leaving Baud on Default),
-and **CI-V USB Echo Back**, which is what `icom_get_usb_echo_off`
-probes for at open and gets exactly one attempt at, `rig_open` having
-set `retry` to 0 for the duration.
+**The first trace (2026-08-23) shows correct frames going out and zero
+bytes coming back.** `fe fe a2 e0 03 fd` — address A2, the IC-9700's
+default — written, then `read_string_generic(): Timed out 1.001 seconds
+after 0 chars`, every time, at 115200. So `icom_get_usb_echo_off`
+returns `-RIG_ETIMEOUT` and `icom_rig_open` gives up with "is rig on and
+connected?". What that trace cannot say is whether the six bytes reached
+the USB endpoint — Hamlib only ever saw a successful *socket* write —
+which is what the second sink below was added to answer.
 
-## Reading Hamlib's trace on a phone
+Three things to check on the radio, all Icom-specific and none visible
+from here: **the CI-V USB baud rate** (a menu item separate from the
+CI-V port's own, defaulting to an Auto that is not reliable on every
+model — note 115200 is not this app's default either, since
+`serial_defaults` gives 38400 for an IC-9700 and 19200 for an IC-7100);
+**CI-V USB Echo Back**, which is exactly what `icom_get_usb_echo_off`
+probes at open and gets one attempt at, `rig_open` having set `retry` to
+0 for the duration; and **the CI-V address**, which is a separate
+setting for the USB port when "CI-V USB Port" is "Unlink from
+[REMOTE]" — the app sends to the factory-default A2, and a changed
+address produces exactly this silence.
+
+## Reading the rig trace on a phone
 
 `SSTVAE_HAMLIB_DEBUG` raises Hamlib's level and Hamlib writes to
 **stderr**, which a desktop operator can capture and a phone discards.
@@ -1279,6 +1298,23 @@ never as a preprocessor define, and never links `-llog`.)
 the last 600 lines and mirrors each to logcat; Refresh, Copy and Clear
 are under the switch. Off by default — at `RIG_DEBUG_TRACE` it is a line
 per CAT frame.
+
+**Hamlib's trace is only half of it, and the missing half is ours.**
+For a radio that never answers, Hamlib's view is "I wrote six bytes and
+read nothing", repeated — which is byte for byte what a bug in our own
+bridge would produce. So `core/rig/trace.hpp` is a second sink, Qt-free
+and Hamlib-free in `sstvae_core`, that the loopback bridge and the
+Android transport write to; the switch installs both, into one ring, so
+the two interleave. It reports what actually reached the transport
+(after the write, never before — a line logged on the way in would say
+"delivered" for a write that threw), what came back from it, the
+resolved line settings, and — from `SerialBridge.describeLink` — the
+device's ids, its interface count and classes, which driver
+`UsbSerialProber` chose and which of its ports was opened. That last
+part is the one nothing else can supply, and it is where an FTDI on its
+own and a vendor bridge inside a composite device stop looking alike.
+Tracing off costs one relaxed atomic load, which is why the calls sit
+in the byte pump unconditionally.
 
 Three things about it are load-bearing rather than incidental:
 

--- a/native/android-app/RigPane.qml
+++ b/native/android-app/RigPane.qml
@@ -373,6 +373,80 @@ ColumnLayout {
             Layout.leftMargin: 12
             Layout.rightMargin: 12
         }
+
+        // ---- diagnostics ----------------------------------------------
+        //
+        // Hamlib's own trace, which is the only thing that answers "how
+        // far did open get, and what did the radio say" -- the library
+        // writes it to stderr, which on a phone is nowhere.
+        Switch {
+            text: "Log rig traffic"
+            Layout.leftMargin: 4
+            checked: pane.rig.debugLog
+            onToggled: pane.rig.debugLog = checked
+        }
+        Label {
+            text: "For bug reports. Records every CAT command and reply, "
+                  + "which slows things down and fills the log quickly — "
+                  + "leave it off unless a radio will not work."
+            font.pixelSize: 11
+            color: "#666"
+            Layout.fillWidth: true
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+            wrapMode: Text.Wrap
+        }
+        ColumnLayout {
+            visible: pane.rig.debugLog
+            spacing: 4
+            Layout.fillWidth: true
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+
+            RowLayout {
+                // **Refreshed by hand, not bound to the property.** The
+                // rig screen republishes at 1 Hz, and a bound text
+                // property would reset this view's scroll position
+                // every second — unreadable in exactly the situation it
+                // is for. A trace is read after the failure anyway.
+                Button {
+                    text: "Refresh"
+                    onClicked: logArea.text = pane.rig.logText
+                }
+                Button {
+                    text: "Copy"
+                    onClicked: {
+                        logArea.selectAll();
+                        logArea.copy();
+                        logArea.deselect();
+                    }
+                }
+                Button {
+                    text: "Clear"
+                    onClicked: {
+                        pane.rig.clearLog();
+                        logArea.text = "";
+                    }
+                }
+            }
+
+            ScrollView {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 260
+                clip: true
+
+                TextArea {
+                    id: logArea
+                    readOnly: true
+                    // No wrapping: a CI-V frame dump read across
+                    // wrapped lines is worse than one read sideways.
+                    wrapMode: Text.NoWrap
+                    font.family: "monospace"
+                    font.pixelSize: 10
+                    placeholderText: "Press Refresh after the radio fails to connect."
+                }
+            }
+        }
     }
 
     // ---- the radio picker ---------------------------------------------

--- a/native/android-app/RigPane.qml
+++ b/native/android-app/RigPane.qml
@@ -134,6 +134,32 @@ ColumnLayout {
                     function onDevicesChanged() { deviceCombo.sync() }
                 }
                 onActivated: pane.rig.device = currentValue
+
+                // **A wrapping delegate, because these labels are long
+                // and the phone is narrow.** A device row can carry a
+                // manufacturer, a product name and a "(1 of 2)" unit
+                // marker, and the default `ItemDelegate` elides — which
+                // on an Icom hides exactly the part that says which of
+                // its two ports this is. The closed combo still shows
+                // one elided line, as it must; the open list wraps.
+                delegate: ItemDelegate {
+                    id: deviceItem
+                    required property var modelData
+                    required property int index
+
+                    width: deviceCombo.width
+                    highlighted: deviceCombo.highlightedIndex === deviceItem.index
+
+                    // `Label` rather than `Text`: it takes its colour
+                    // from the active style, which a bare `Text` would
+                    // have to hardcode — and hardcoding it is how a
+                    // control ends up unreadable in the other theme.
+                    contentItem: Label {
+                        text: deviceItem.modelData.label
+                        wrapMode: Text.Wrap
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
             }
             RowLayout {
                 Layout.fillWidth: true
@@ -488,11 +514,20 @@ ColumnLayout {
                 clip: true
                 ScrollBar.vertical: ScrollBar {}
                 delegate: ItemDelegate {
+                    id: modelItem
                     required property var modelData
                     width: results.width
-                    text: modelData.label
+                    // Wrapped for the same reason as the device list:
+                    // "Manufacturer Model (Status)" does not fit a phone
+                    // in one line, and the status is the part that gets
+                    // cut off.
+                    contentItem: Label {
+                        text: modelItem.modelData.label
+                        wrapMode: Text.Wrap
+                        verticalAlignment: Text.AlignVCenter
+                    }
                     onClicked: {
-                        pane.rig.model = modelData.number
+                        pane.rig.model = modelItem.modelData.number
                         modelDialog.close()
                     }
                 }

--- a/native/android-app/rigcontrol.cpp
+++ b/native/android-app/rigcontrol.cpp
@@ -1,5 +1,6 @@
 #include "rigcontrol.hpp"
 
+#include <QDebug>
 #include <QJniEnvironment>
 #include <QJniObject>
 #include <QLatin1String>
@@ -10,8 +11,11 @@
 #include <QtCore/qcoreapplication_platform.h>
 
 #include <algorithm>
+#include <deque>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <string>
 
 #include "rig/android/androidrig.hpp"
 #include "rig/bridged.hpp"
@@ -77,6 +81,54 @@ constexpr auto kDeviceKey = "rig/device";
 constexpr auto kHostKey = "rig/host";
 constexpr auto kBaudKey = "rig/baud";
 constexpr auto kPttKey = "rig/ptt";
+constexpr auto kDebugLogKey = "rig/debuglog";
+
+// Hamlib's trace, ring-buffered for the settings screen.
+//
+// **A process-wide singleton, not a member.** `RigControl` is created
+// and destroyed by QML on every rotation while the rig session outlives
+// both, so a per-view buffer would throw away the trace of the open
+// that is being diagnosed. It also keeps the sink's captures free of
+// `this`, which matters because the sink is called from the rig worker
+// thread and a view can go away underneath it.
+//
+// 600 lines is a few opens' worth at `RIG_DEBUG_TRACE` -- enough to
+// carry the whole of a failing `rig_open` and its retry, which is the
+// span that answers the question.
+constexpr std::size_t kMaxTraceLines = 600;
+
+class RigTrace {
+public:
+    void add(std::string line) {
+        std::lock_guard<std::mutex> lock(mu_);
+        lines_.push_back(std::move(line));
+        while (lines_.size() > kMaxTraceLines) lines_.pop_front();
+    }
+
+    QString text() const {
+        std::lock_guard<std::mutex> lock(mu_);
+        QString out;
+        for (const std::string& line : lines_) {
+            out += QString::fromStdString(line);
+            out += QLatin1Char('\n');
+        }
+        return out;
+    }
+
+    void clear() {
+        std::lock_guard<std::mutex> lock(mu_);
+        lines_.clear();
+    }
+
+private:
+    mutable std::mutex mu_;
+    std::deque<std::string> lines_;
+};
+
+RigTrace& rig_trace() {
+    static RigTrace trace;
+    return trace;
+}
 
 // How many rows a model search returns. Hamlib knows several hundred
 // rigs; a phone list view of all of them is a scroll, not a picker.
@@ -133,6 +185,11 @@ RigControl::RigControl(QObject* parent) : QObject(parent) {
         enabled_ = false;
     }
 
+    // Before `connectRig()` below, so that a station whose radio fails
+    // to open at launch has that open in the log rather than only the
+    // reconnection attempts that follow it.
+    apply_debug_log();
+
     // A guarded pointer, not a raw capture: the callback is queued, so
     // an event can still be in flight when a rotation destroys this
     // view. Clearing the callback in the destructor closes the window
@@ -186,6 +243,7 @@ void RigControl::load() {
     host_ = s.value(QLatin1String(kHostKey), QString()).toString();
     baud_ = s.value(QLatin1String(kBaudKey), 0).toInt();
     ptt_ = s.value(QLatin1String(kPttKey), ptt_).toString();
+    debug_log_ = s.value(QLatin1String(kDebugLogKey), false).toBool();
 }
 
 void RigControl::save() {
@@ -197,6 +255,7 @@ void RigControl::save() {
     s.setValue(QLatin1String(kHostKey), host_);
     s.setValue(QLatin1String(kBaudKey), baud_);
     s.setValue(QLatin1String(kPttKey), ptt_);
+    s.setValue(QLatin1String(kDebugLogKey), debug_log_);
 }
 
 void RigControl::setEnabled(bool on) {
@@ -474,6 +533,43 @@ void RigControl::disconnectRig() {
 }
 
 // --- staying connected ------------------------------------------------------
+
+void RigControl::setDebugLog(bool on) {
+    if (on == debug_log_) return;
+    debug_log_ = on;
+    save();
+    apply_debug_log();
+    emit changed();
+}
+
+QString RigControl::logText() const { return rig_trace().text(); }
+
+void RigControl::clearLog() {
+    rig_trace().clear();
+    emit changed();
+}
+
+void RigControl::apply_debug_log() {
+#ifdef SSTVAE_ANDROID_HAVE_RIG
+    if (!debug_log_) {
+        rig::set_debug_sink({});
+        return;
+    }
+    // Captures nothing but a reference to the singleton, deliberately:
+    // this is called from the rig worker thread, and the view that
+    // installed it can be destroyed by a rotation at any point.
+    //
+    // Also to logcat, because the two audiences are different. The ring
+    // is what an operator in the field can read and send; `adb logcat`
+    // is what whoever is reading the report wants when they can plug
+    // the phone in, and it carries lines from before the screen was
+    // opened.
+    rig::set_debug_sink([](const std::string& line) {
+        rig_trace().add(line);
+        qInfo("hamlib: %s", line.c_str());
+    });
+#endif
+}
 
 void RigControl::maybe_reconnect() {
     if (!enabled_ || !layer_ok_) return;

--- a/native/android-app/rigcontrol.cpp
+++ b/native/android-app/rigcontrol.cpp
@@ -20,6 +20,7 @@
 #include "rig/android/androidrig.hpp"
 #include "rig/bridged.hpp"
 #include "rig/hamlib.hpp"
+#include "rig/trace.hpp"
 #include "session.hpp"
 
 // `SSTVAE_ANDROID_RIG=OFF` is a supported configuration -- the one
@@ -550,20 +551,36 @@ void RigControl::clearLog() {
 }
 
 void RigControl::apply_debug_log() {
-#ifdef SSTVAE_ANDROID_HAVE_RIG
     if (!debug_log_) {
+        rig::set_trace_sink({});
+#ifdef SSTVAE_ANDROID_HAVE_RIG
         rig::set_debug_sink({});
+#endif
         return;
     }
-    // Captures nothing but a reference to the singleton, deliberately:
-    // this is called from the rig worker thread, and the view that
-    // installed it can be destroyed by a rotation at any point.
+
+    // **Two sinks, one log, and that is the point.** Hamlib's trace
+    // ends at "I wrote six bytes and read nothing"; ours says whether
+    // those bytes reached the USB endpoint, whether anything came back
+    // from it, and which driver and interface the Android USB layer
+    // chose. Interleaved in one buffer they answer together the
+    // question neither answers alone -- is the radio ignoring us, or
+    // are we not reaching the radio.
     //
-    // Also to logcat, because the two audiences are different. The ring
-    // is what an operator in the field can read and send; `adb logcat`
-    // is what whoever is reading the report wants when they can plug
-    // the phone in, and it carries lines from before the screen was
-    // opened.
+    // Both capture nothing but a reference to the singleton,
+    // deliberately: they are called from the rig worker and the
+    // bridge's two pump threads, and the view that installed them can
+    // be destroyed by a rotation at any point.
+    //
+    // Also to logcat, because the two audiences differ. The ring is
+    // what an operator in the field can read and send; `adb logcat` is
+    // what whoever reads the report wants when they can plug the phone
+    // in, and it carries lines from before the screen was opened.
+    rig::set_trace_sink([](const std::string& line) {
+        rig_trace().add(line);
+        qInfo("rig: %s", line.c_str());
+    });
+#ifdef SSTVAE_ANDROID_HAVE_RIG
     rig::set_debug_sink([](const std::string& line) {
         rig_trace().add(line);
         qInfo("hamlib: %s", line.c_str());

--- a/native/android-app/rigcontrol.hpp
+++ b/native/android-app/rigcontrol.hpp
@@ -109,6 +109,18 @@ class RigControl : public QObject {
     // screen, which says so rather than leaving the operator to work out
     // whether the VOX leader is still doing the job.
     Q_PROPERTY(bool canKey READ canKey NOTIFY changed)
+    // Hamlib's own trace, kept where an operator can read and send it.
+    //
+    // **This is a diagnostic, and it exists because of a bug this
+    // screen could not explain.** A Kenwood worked over USB and two
+    // Icoms did not, and the artifact that answers "how far did open
+    // get, and which CAT command did the radio refuse" is Hamlib's
+    // trace -- which the library writes to stderr, i.e. nowhere on a
+    // phone. Off by default: at `RIG_DEBUG_TRACE` it is a line per
+    // frame and there is nothing here a working station needs.
+    Q_PROPERTY(bool debugLog READ debugLog WRITE setDebugLog NOTIFY changed)
+    Q_PROPERTY(QString logText READ logText NOTIFY changed)
+
     // Whether Bluetooth can be listed at all. Distinct from "no paired
     // radios", which is what an empty list looks like either way -- and
     // telling an operator to go and pair a radio they already paired is
@@ -155,6 +167,11 @@ public:
     bool canKey() const;
     bool bluetoothReady() const;
 
+    bool debugLog() const { return debug_log_; }
+    void setDebugLog(bool on);
+    QString logText() const;
+    Q_INVOKABLE void clearLog();
+
     // Rows matching `query`, capped -- Hamlib knows several hundred
     // rigs and a phone list view of all of them is not a picker. An
     // empty query returns the most useful few rather than nothing, so
@@ -188,6 +205,9 @@ private:
     // has stopped answering and the device is reachable again.
     void maybe_reconnect();
 
+    // Install or remove the Hamlib debug sink to match `debug_log_`.
+    void apply_debug_log();
+
     bool enabled_ = false;
     QString connection_ = QStringLiteral("usb");
     int model_ = 1;  // Hamlib's dummy: connects with no radio attached
@@ -195,6 +215,7 @@ private:
     QString host_;
     int baud_ = 0;  // 0 = whatever the chosen backend would have used
     QString ptt_ = QStringLiteral("cat");
+    bool debug_log_ = false;
 
     // False when `init_rig_bridge` could not hand the layer a VM and a
     // Context. Distinct from the compile-time `SSTVAE_ANDROID_HAVE_RIG`:

--- a/native/core/rig/android/androidrig.cpp
+++ b/native/core/rig/android/androidrig.cpp
@@ -1,10 +1,13 @@
 #include "rig/android/androidrig.hpp"
 
+#include "rig/trace.hpp"
+
 #include <jni.h>
 
 #include <atomic>
 #include <mutex>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -158,6 +161,50 @@ std::vector<SerialDevice> device_list(const char* method) {
 
 // --- the transport ----------------------------------------------------------
 
+// --- trace helpers ----------------------------------------------------
+//
+// Deliberately spelled the way a settings screen spells it (`8N1`,
+// `flow=none`), because the first thing to do with this line is compare
+// it against what the operator set and what the radio's menu says.
+const char* parity_letter(int parity) {
+    switch (parity) {
+        case SerialParams::kOdd: return "O";
+        case SerialParams::kEven: return "E";
+        default: return "N";
+    }
+}
+
+const char* flow_name(int flow) {
+    switch (flow) {
+        case SerialParams::kRtsCts: return "rts/cts";
+        case SerialParams::kXonXoff: return "xon/xoff";
+        default: return "none";
+    }
+}
+
+// Never throws and never leaves an exception pending: this runs inside
+// an open that has already succeeded, and a diagnostic that fails the
+// operation it is diagnosing is worse than no diagnostic.
+std::string describe_link(const Env& env, jclass cls, const std::string& id) {
+    jmethodID m = env->GetStaticMethodID(cls, "describeLink",
+                                         "(Ljava/lang/String;)Ljava/lang/String;");
+    if (m == nullptr) {
+        env->ExceptionClear();
+        return id + " (no describeLink)";
+    }
+    jstring jid = env->NewStringUTF(id.c_str());
+    auto out = static_cast<jstring>(env->CallStaticObjectMethod(cls, m, jid));
+    if (jid != nullptr) env->DeleteLocalRef(jid);
+    if (env->ExceptionCheck() != JNI_FALSE) {
+        env->ExceptionClear();
+        return id + " (describeLink threw)";
+    }
+    if (out == nullptr) return id;
+    std::string text = to_std(env.e, out);
+    env->DeleteLocalRef(out);
+    return text;
+}
+
 class AndroidTransport : public SerialTransport {
 public:
     explicit AndroidTransport(SerialParams params) : params_(std::move(params)) {}
@@ -192,6 +239,21 @@ public:
         }
         buffer_ = static_cast<jbyteArray>(env->NewGlobalRef(local));
         env->DeleteLocalRef(local);
+
+        // What was opened, and how. This is the half of the picture
+        // that neither Hamlib's trace nor the bridge's byte counts can
+        // supply -- which driver the prober chose and which interface
+        // of how many it claimed. Guarded, because building it is a
+        // handful of JNI calls and the answer is only wanted when
+        // somebody is looking.
+        if (tracing()) {
+            trace("transport: opened " + params_.device_id + " at " +
+                  std::to_string(params_.baud) + " " +
+                  std::to_string(params_.data_bits) + parity_letter(params_.parity) +
+                  std::to_string(params_.stop_bits) + ", flow=" +
+                  flow_name(params_.flow));
+            trace("transport: " + describe_link(env, cls, params_.device_id));
+        }
     }
 
     void close() noexcept override {

--- a/native/core/rig/android/androidrig.cpp
+++ b/native/core/rig/android/androidrig.cpp
@@ -342,17 +342,27 @@ public:
         Env env;
         jclass cls = env.bridge();
 
-        // **Before this frame, not after it, and that is the whole
-        // point.** Reported here it describes the state left behind by
-        // the *previous* frame, which has by then had Hamlib's full
-        // timeout to drain -- so bytes still in `outQueue` mean the
-        // chip never put them on the wire, and an empty `outQueue` with
-        // an empty `inQueue` means it did and the radio said nothing.
-        // Probed immediately after a write it would only ever catch a
-        // UART mid-transmission and prove nothing.
+        // Reported before this frame rather than after, so it describes
+        // what the *previous* frame left behind once Hamlib's full
+        // timeout had passed.
+        //
+        // **Two of these fields are weaker than they look, and the
+        // measurement is what taught that.** `outQueue` is read a
+        // second after the write, by which time it is zero whether the
+        // chip sent the bytes or dropped them; `inQueue` is drained
+        // continuously by the read thread, so it is zero even when the
+        // radio does answer. What actually carries information is
+        // `errors` (framing, parity, overrun) and `hold` (why
+        // transmission is being withheld) -- both latched by the chip
+        // rather than sampled -- and `CTS`, since a handshake holding
+        // the transmitter off would show there. Whether the radio
+        // answered at all is already told by `bridge: <- rig`.
         //
         // The read counters ride along because this thread is the one
-        // known to be running.
+        // known to be running, and they retired a wrong theory on their
+        // first run: `last` against the bridge's 500 ms timeout shows
+        // the read loop cycling normally, where the silence of an
+        // earlier heartbeat had been read as a blocked `bulkTransfer`.
         if (tracing() && wrote_once_) {
             const unsigned long started = reads_started_.load(std::memory_order_relaxed);
             const unsigned long returned = reads_returned_.load(std::memory_order_relaxed);

--- a/native/core/rig/android/androidrig.cpp
+++ b/native/core/rig/android/androidrig.cpp
@@ -214,15 +214,17 @@ public:
         if (token_ >= 0) return;
         Env env;
         jclass cls = env.bridge();
-        jmethodID m = env->GetStaticMethodID(cls, "open", "(Ljava/lang/String;IIIII)I");
+        jmethodID m = env->GetStaticMethodID(cls, "open", "(Ljava/lang/String;IIIIIZZ)I");
         if (m == nullptr) {
             env->ExceptionClear();
             throw RigError("android rig: no SerialBridge.open");
         }
         jstring id = env->NewStringUTF(params_.device_id.c_str());
-        const jint token =
-            env->CallStaticIntMethod(cls, m, id, params_.baud, params_.data_bits,
-                                     params_.stop_bits, params_.parity, params_.flow);
+        const jint token = env->CallStaticIntMethod(
+            cls, m, id, params_.baud, params_.data_bits, params_.stop_bits,
+            params_.parity, params_.flow,
+            static_cast<jboolean>(params_.dtr ? JNI_TRUE : JNI_FALSE),
+            static_cast<jboolean>(params_.rts ? JNI_TRUE : JNI_FALSE));
         env->DeleteLocalRef(id);
         env.rethrow("could not open the serial device");
         if (token < 0) throw RigError("could not open " + params_.device_id);
@@ -251,7 +253,8 @@ public:
                   std::to_string(params_.baud) + " " +
                   std::to_string(params_.data_bits) + parity_letter(params_.parity) +
                   std::to_string(params_.stop_bits) + ", flow=" +
-                  flow_name(params_.flow));
+                  flow_name(params_.flow) + ", dtr=" + (params_.dtr ? "1" : "0") +
+                  " rts=" + (params_.rts ? "1" : "0"));
             trace("transport: " + describe_link(env, cls, params_.device_id));
         }
     }

--- a/native/core/rig/android/androidrig.cpp
+++ b/native/core/rig/android/androidrig.cpp
@@ -182,6 +182,12 @@ const char* flow_name(int flow) {
     }
 }
 
+// How many consecutive empty reads between heartbeat lines. The bridge
+// reads with a 500 ms timeout, so this is about five seconds -- often
+// enough to show a stuck transmit queue promptly, rare enough that a
+// working session does not fill its own log.
+constexpr unsigned long kIdleReadsPerReport = 10;
+
 // Never throws and never leaves an exception pending: this runs inside
 // an open that has already succeeded, and a diagnostic that fails the
 // operation it is diagnosing is worse than no diagnostic.
@@ -200,6 +206,26 @@ std::string describe_link(const Env& env, jclass cls, const std::string& id) {
         return id + " (describeLink threw)";
     }
     if (out == nullptr) return id;
+    std::string text = to_std(env.e, out);
+    env->DeleteLocalRef(out);
+    return text;
+}
+
+// The same contract as `describe_link`: never throws, never leaves an
+// exception pending. Called from the bridge's read thread.
+std::string describe_status(const Env& env, jclass cls, int token) {
+    jmethodID m = env->GetStaticMethodID(cls, "describeStatus", "(I)Ljava/lang/String;");
+    if (m == nullptr) {
+        env->ExceptionClear();
+        return "no describeStatus";
+    }
+    auto out = static_cast<jstring>(
+        env->CallStaticObjectMethod(cls, m, static_cast<jint>(token)));
+    if (env->ExceptionCheck() != JNI_FALSE) {
+        env->ExceptionClear();
+        return "describeStatus threw";
+    }
+    if (out == nullptr) return "";
     std::string text = to_std(env.e, out);
     env->DeleteLocalRef(out);
     return text;
@@ -295,7 +321,23 @@ public:
         // Negative means the link is gone; zero means an idle radio,
         // which is not an error and must not be reported as one.
         if (got < 0) throw RigError("the serial device went away");
-        if (got == 0) return 0;
+        if (got == 0) {
+            // **A heartbeat, and the chip's own account with it.** A bulk
+            // write returning its length means the bytes reached the
+            // chip, not that the UART clocked them out -- and from above,
+            // "the radio is ignoring us" and "the chip is holding our
+            // bytes" are the same silence. A CP210x will say which:
+            // `GET_COMM_STATUS` reports how many bytes are still queued
+            // for transmit, how many arrived from the UART, and why
+            // transmission is being held. It also proves this read loop
+            // is running at all, which nothing else in the log does.
+            if (tracing() && ++idle_reads_ % kIdleReadsPerReport == 0) {
+                trace("transport: idle, " + std::to_string(idle_reads_) +
+                      " empty reads; " + describe_status(env, cls, token));
+            }
+            return 0;
+        }
+        idle_reads_ = 0;
         env->GetByteArrayRegion(buffer_, 0, got, reinterpret_cast<jbyte*>(dst));
         return static_cast<std::size_t>(got);
     }
@@ -361,6 +403,9 @@ private:
     SerialParams params_;
     std::atomic<int> token_{-1};
     jbyteArray buffer_ = nullptr;
+    // Consecutive reads that returned nothing. Only read and written by
+    // the bridge's single read thread.
+    unsigned long idle_reads_ = 0;
 };
 
 }  // namespace

--- a/native/core/rig/android/androidrig.cpp
+++ b/native/core/rig/android/androidrig.cpp
@@ -5,6 +5,7 @@
 #include <jni.h>
 
 #include <atomic>
+#include <chrono>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -182,12 +183,6 @@ const char* flow_name(int flow) {
     }
 }
 
-// How many consecutive empty reads between heartbeat lines. The bridge
-// reads with a 500 ms timeout, so this is about five seconds -- often
-// enough to show a stuck transmit queue promptly, rare enough that a
-// working session does not fill its own log.
-constexpr unsigned long kIdleReadsPerReport = 10;
-
 // Never throws and never leaves an exception pending: this runs inside
 // an open that has already succeeded, and a diagnostic that fails the
 // operation it is diagnosing is worse than no diagnostic.
@@ -316,28 +311,27 @@ public:
         }
         const std::size_t cap = static_cast<std::size_t>(kBufferBytes);
         const jint want = static_cast<jint>(n < cap ? n : cap);
+
+        // **Counted and timed here, reported from `write`.** The first
+        // version of this instrument logged from inside this function,
+        // which was the one mistake it could not survive: the question
+        // it exists to answer is whether this loop is running, and a
+        // heartbeat on a thread that is stuck says nothing at all. The
+        // write thread is known to be alive -- its frames are in the
+        // log -- so the numbers are published here and printed there.
+        reads_started_.fetch_add(1, std::memory_order_relaxed);
+        const auto started_at = std::chrono::steady_clock::now();
         const jint got = env->CallStaticIntMethod(cls, m, token, buffer_, want, timeout_ms);
+        last_read_ms_.store(
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - started_at).count(),
+            std::memory_order_relaxed);
+        reads_returned_.fetch_add(1, std::memory_order_relaxed);
         env.rethrow("the serial device stopped answering");
         // Negative means the link is gone; zero means an idle radio,
         // which is not an error and must not be reported as one.
         if (got < 0) throw RigError("the serial device went away");
-        if (got == 0) {
-            // **A heartbeat, and the chip's own account with it.** A bulk
-            // write returning its length means the bytes reached the
-            // chip, not that the UART clocked them out -- and from above,
-            // "the radio is ignoring us" and "the chip is holding our
-            // bytes" are the same silence. A CP210x will say which:
-            // `GET_COMM_STATUS` reports how many bytes are still queued
-            // for transmit, how many arrived from the UART, and why
-            // transmission is being held. It also proves this read loop
-            // is running at all, which nothing else in the log does.
-            if (tracing() && ++idle_reads_ % kIdleReadsPerReport == 0) {
-                trace("transport: idle, " + std::to_string(idle_reads_) +
-                      " empty reads; " + describe_status(env, cls, token));
-            }
-            return 0;
-        }
-        idle_reads_ = 0;
+        if (got == 0) return 0;
         env->GetByteArrayRegion(buffer_, 0, got, reinterpret_cast<jbyte*>(dst));
         return static_cast<std::size_t>(got);
     }
@@ -347,6 +341,27 @@ public:
         if (token < 0) throw RigError("the serial device is not open");
         Env env;
         jclass cls = env.bridge();
+
+        // **Before this frame, not after it, and that is the whole
+        // point.** Reported here it describes the state left behind by
+        // the *previous* frame, which has by then had Hamlib's full
+        // timeout to drain -- so bytes still in `outQueue` mean the
+        // chip never put them on the wire, and an empty `outQueue` with
+        // an empty `inQueue` means it did and the radio said nothing.
+        // Probed immediately after a write it would only ever catch a
+        // UART mid-transmission and prove nothing.
+        //
+        // The read counters ride along because this thread is the one
+        // known to be running.
+        if (tracing() && wrote_once_) {
+            const unsigned long started = reads_started_.load(std::memory_order_relaxed);
+            const unsigned long returned = reads_returned_.load(std::memory_order_relaxed);
+            trace("transport: reads started=" + std::to_string(started) +
+                  " returned=" + std::to_string(returned) + " last=" +
+                  std::to_string(last_read_ms_.load(std::memory_order_relaxed)) +
+                  "ms; " + describe_status(env, cls, token));
+        }
+        wrote_once_ = true;
         jmethodID m = env->GetStaticMethodID(cls, "write", "(I[BI)V");
         if (m == nullptr) {
             env->ExceptionClear();
@@ -403,9 +418,15 @@ private:
     SerialParams params_;
     std::atomic<int> token_{-1};
     jbyteArray buffer_ = nullptr;
-    // Consecutive reads that returned nothing. Only read and written by
-    // the bridge's single read thread.
-    unsigned long idle_reads_ = 0;
+
+    // Written by the read thread, read by the write thread -- which is
+    // why they are atomic and why they are relaxed: nothing is
+    // synchronised through them, they are only ever printed.
+    std::atomic<unsigned long> reads_started_{0};
+    std::atomic<unsigned long> reads_returned_{0};
+    std::atomic<long long> last_read_ms_{-1};
+    // Only touched by the write thread.
+    bool wrote_once_ = false;
 };
 
 }  // namespace

--- a/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
+++ b/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
@@ -102,7 +102,10 @@ public final class SerialBridge {
                 final boolean granted =
                         intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false);
                 final UsbDevice device = usbExtra(intent);
-                nativePermissionResult(device == null ? "" : usbId(device, 0), granted);
+                nativePermissionResult(
+                        device == null ? ""
+                                : usbId(device, usbUnitOf(usbManager(), device), 0),
+                        granted);
             }
         };
         final IntentFilter filter = new IntentFilter(ACTION_GRANT_USB);
@@ -227,10 +230,27 @@ public final class SerialBridge {
             final UsbDevice device = driver.getDevice();
             final boolean permitted = manager.hasPermission(device);
             final int ports = driver.getPorts().size();
+            // **Two things can multiply a row, and they are not the
+            // same thing.** `ports` is one driver's several UARTs (a
+            // CP2105); `units` is several devices that happen to share
+            // a VID:PID, which is how an IC-9700 presents its CI-V port
+            // and its USB serial function. Conflating them is what made
+            // the picker show two identical rows that both addressed
+            // the same chip.
+            final int unit = usbUnitOf(manager, device);
+            final int units =
+                    usbUnits(manager, device.getVendorId(), device.getProductId()).size();
             for (int i = 0; i < ports; i++) {
                 final StringBuilder label = new StringBuilder(describe(device));
                 if (ports > 1) label.append(" port ").append(i + 1);
-                out.add(usbId(device, i) + "\t" + clean(label.toString()) + "\t"
+                // Said plainly, because the operator is the only one who
+                // can tell these apart: nothing readable distinguishes
+                // an Icom's CI-V port from its data port, so the answer
+                // is to try the other one.
+                if (units > 1) {
+                    label.append(" (").append(unit + 1).append(" of ").append(units).append(')');
+                }
+                out.add(usbId(device, unit, i) + "\t" + clean(label.toString()) + "\t"
                         + (permitted ? "1" : "0"));
             }
         }
@@ -292,6 +312,13 @@ public final class SerialBridge {
             out.append(String.format(Locale.US, "%04x:%04x", device.getVendorId(),
                     device.getProductId()));
             out.append(" \"").append(describe(device)).append('"');
+            // Which of the same-VID:PID devices this is, and how many
+            // there are. The fact that answers "are we even talking to
+            // the CI-V port".
+            final int units =
+                    usbUnits(manager, device.getVendorId(), device.getProductId()).size();
+            out.append(", unit ").append(usbUnitOf(manager, device) + 1)
+               .append(" of ").append(units);
             final int interfaces = device.getInterfaceCount();
             out.append(", ").append(interfaces).append(" interface(s) [");
             for (int i = 0; i < interfaces; i++) {
@@ -342,29 +369,110 @@ public final class SerialBridge {
         return s.replace('\t', ' ').replace('\n', ' ');
     }
 
-    private static String usbId(UsbDevice device, int port) {
-        final String base = String.format(Locale.US, "usb:%04x:%04x",
-                device.getVendorId(), device.getProductId());
-        return port == 0 ? base : base + "#" + port;
+    /**
+     * Every attached device with this one's vendor and product ids, in a
+     * stable order.
+     *
+     * <p><b>There can be more than one, and assuming otherwise cost an
+     * Icom.</b> An IC-9700 presents its CI-V port and its USB serial
+     * function as two separate USB devices that share a VID:PID — so
+     * `usb:10c4:ea60` named both, the picker showed two identical rows,
+     * and the lookup returned whichever one {@code getDeviceList()}
+     * happened to yield first. Out of a {@code HashMap}, so not even the
+     * same one twice. Bytes went out of a chip that was never wired to
+     * the radio's CI-V engine, which is exactly what "the chip
+     * transmitted and the radio said nothing" looks like from above.
+     *
+     * <p>Sorted by {@code getDeviceName()} — the {@code
+     * /dev/bus/usb/BBB/DDD} path — because it is the only ordering
+     * available before permission is granted, and a fixed cable on a
+     * fixed hub enumerates in a fixed order. It is not promised across a
+     * replug, which is why the *label* says which is which and the
+     * operator picks; guessing which port is CI-V is not something this
+     * layer can do.
+     */
+    private static List<UsbDevice> usbUnits(UsbManager manager, int vendor, int product) {
+        final List<UsbDevice> units = new ArrayList<>();
+        if (manager == null) return units;
+        for (UsbDevice device : manager.getDeviceList().values()) {
+            if (device.getVendorId() == vendor && device.getProductId() == product) {
+                units.add(device);
+            }
+        }
+        units.sort((a, b) -> {
+            final String an = a.getDeviceName() == null ? "" : a.getDeviceName();
+            final String bn = b.getDeviceName() == null ? "" : b.getDeviceName();
+            return an.compareTo(bn);
+        });
+        return units;
     }
 
-    private static int usbPortIndex(String id) {
-        final int hash = id.indexOf('#');
-        if (hash < 0) return 0;
+    /** Where `device` sits in {@link #usbUnits}, or 0 if it is not there. */
+    private static int usbUnitOf(UsbManager manager, UsbDevice device) {
+        final List<UsbDevice> units =
+                usbUnits(manager, device.getVendorId(), device.getProductId());
+        for (int i = 0; i < units.size(); i++) {
+            if (units.get(i).getDeviceName() != null
+                    && units.get(i).getDeviceName().equals(device.getDeviceName())) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * `usb:VVVV:PPPP`, plus `@u` for the u'th device sharing those ids and
+     * `#p` for the p'th port of a multi-port driver. Both suffixes are
+     * omitted at zero, so an id saved before they existed still means
+     * the first port of the first device.
+     */
+    private static String usbId(UsbDevice device, int unit, int port) {
+        final StringBuilder id = new StringBuilder(String.format(Locale.US, "usb:%04x:%04x",
+                device.getVendorId(), device.getProductId()));
+        if (unit > 0) id.append('@').append(unit);
+        if (port > 0) id.append('#').append(port);
+        return id.toString();
+    }
+
+    private static int usbSuffix(String id, char marker) {
+        final int at = id.indexOf(marker);
+        if (at < 0) return 0;
+        int end = at + 1;
+        while (end < id.length() && Character.isDigit(id.charAt(end))) end++;
         try {
-            return Integer.parseInt(id.substring(hash + 1));
-        } catch (NumberFormatException e) {
+            return Integer.parseInt(id.substring(at + 1, end));
+        } catch (NumberFormatException | StringIndexOutOfBoundsException e) {
             return 0;
         }
+    }
+
+    private static int usbPortIndex(String id) { return usbSuffix(id, '#'); }
+
+    private static int usbUnitIndex(String id) { return usbSuffix(id, '@'); }
+
+    /** `usb:VVVV:PPPP` with both suffixes stripped. */
+    private static String usbBase(String id) {
+        int end = id.length();
+        final int at = id.indexOf('@');
+        if (at >= 0) end = Math.min(end, at);
+        final int hash = id.indexOf('#');
+        if (hash >= 0) end = Math.min(end, hash);
+        return id.substring(0, end);
     }
 
     private static UsbDevice findUsbDevice(String id) {
         final UsbManager manager = usbManager();
         if (manager == null || id == null || !id.startsWith("usb:")) return null;
-        final int hash = id.indexOf('#');
-        final String base = hash < 0 ? id : id.substring(0, hash);
+        final String base = usbBase(id);
         for (UsbDevice device : manager.getDeviceList().values()) {
-            if (usbId(device, 0).equals(base)) return device;
+            if (!usbId(device, 0, 0).equals(base)) continue;
+            // **The unit index, not the first match.** Two devices can
+            // share a VID:PID and only one of them may be the radio's
+            // CI-V port.
+            final List<UsbDevice> units =
+                    usbUnits(manager, device.getVendorId(), device.getProductId());
+            final int unit = usbUnitIndex(id);
+            return unit < units.size() ? units.get(unit) : null;
         }
         return null;
     }

--- a/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
+++ b/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
@@ -19,6 +19,7 @@ import android.hardware.usb.UsbManager;
 import android.os.Build;
 import android.util.Log;
 
+import com.hoho.android.usbserial.driver.Cp21xxSerialDriver;
 import com.hoho.android.usbserial.driver.UsbSerialDriver;
 import com.hoho.android.usbserial.driver.UsbSerialPort;
 import com.hoho.android.usbserial.driver.UsbSerialProber;
@@ -410,6 +411,13 @@ public final class SerialBridge {
         return token;
     }
 
+    /** The chip's own account of itself, or "" for a link that has none. */
+    static String describeStatus(int token) {
+        final Link link = links.get(token);
+        if (!(link instanceof UsbLink)) return "";
+        return ((UsbLink) link).status();
+    }
+
     static void close(int token) {
         final Link link = links.remove(token);
         if (link != null) link.close();
@@ -495,7 +503,7 @@ public final class SerialBridge {
             port.close();
             throw new IOException("could not configure " + id + ": " + e.getMessage());
         }
-        return new UsbLink(port);
+        return new UsbLink(port, connection);
     }
 
     private static int toParity(int parity) {
@@ -545,10 +553,74 @@ public final class SerialBridge {
 
     private static final class UsbLink implements Link {
         private final UsbSerialPort port;
+        private final UsbDeviceConnection connection;
         private volatile boolean closed;
 
-        UsbLink(UsbSerialPort port) {
+        UsbLink(UsbSerialPort port, UsbDeviceConnection connection) {
             this.port = port;
+            this.connection = connection;
+        }
+
+        /**
+         * What the chip says about itself, for the rig trace.
+         *
+         * <p><b>This is the fact nothing else in the stack can supply.</b>
+         * A bulk write returning its length means the bytes reached the
+         * chip over USB — not that the UART clocked them out. A CP210x
+         * will say: {@code GET_COMM_STATUS} returns how many bytes are
+         * still queued for transmit, how many arrived from the UART, and
+         * a bitmask of the reasons transmission is being held. An Icom
+         * that answers a desktop and not a phone is either being held
+         * off, or being transmitted to and not replying, and those two
+         * look identical from above.
+         *
+         * <p>Never throws: it runs on the bridge's read thread inside a
+         * session that is otherwise working.
+         */
+        String status() {
+            final StringBuilder out = new StringBuilder();
+            try {
+                out.append("lines");
+                for (UsbSerialPort.ControlLine line : port.getSupportedControlLines()) {
+                    out.append(' ').append(line).append('=');
+                    switch (line) {
+                        case RTS: out.append(port.getRTS() ? 1 : 0); break;
+                        case CTS: out.append(port.getCTS() ? 1 : 0); break;
+                        case DTR: out.append(port.getDTR() ? 1 : 0); break;
+                        case DSR: out.append(port.getDSR() ? 1 : 0); break;
+                        case CD: out.append(port.getCD() ? 1 : 0); break;
+                        case RI: out.append(port.getRI() ? 1 : 0); break;
+                        default: out.append('?'); break;
+                    }
+                }
+            } catch (IOException | UnsupportedOperationException | RuntimeException e) {
+                out.append(" (unavailable: ").append(e).append(')');
+            }
+
+            // CP210x GET_COMM_STATUS. Silicon Labs AN571: 19 bytes, four
+            // little-endian u32 followed by three bytes.
+            if (!(port.getDriver() instanceof Cp21xxSerialDriver)) return out.toString();
+            try {
+                final byte[] buf = new byte[19];
+                final int n = connection.controlTransfer(0xc1, 0x10, 0, port.getPortNumber(),
+                        buf, buf.length, 500);
+                if (n != buf.length) {
+                    out.append("; comm status unavailable (").append(n).append(')');
+                    return out.toString();
+                }
+                out.append("; errors=0x").append(Integer.toHexString(le32(buf, 0)))
+                   .append(" hold=0x").append(Integer.toHexString(le32(buf, 4)))
+                   .append(" inQueue=").append(le32(buf, 8))
+                   .append(" outQueue=").append(le32(buf, 12));
+            } catch (RuntimeException e) {
+                out.append("; comm status threw ").append(e);
+            }
+            return out.toString();
+        }
+
+        private static int le32(byte[] b, int at) {
+            return (b[at] & 0xff) | ((b[at + 1] & 0xff) << 8)
+                    | ((b[at + 2] & 0xff) << 16) | ((b[at + 3] & 0xff) << 24);
         }
 
         @Override

--- a/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
+++ b/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
@@ -513,14 +513,27 @@ public final class SerialBridge {
             case 2: want = UsbSerialPort.FlowControl.XON_XOFF; break;
             default: want = UsbSerialPort.FlowControl.NONE; break;
         }
+        // **"None" means write nothing, not write zeros.** Setting a
+        // CP210x's flow control to NONE means sending it a 16-byte
+        // structure of zeroes, and an IC-9700's CP2102N stopped
+        // answering CI-V entirely when it got one — every control
+        // transfer succeeded, every bulk write returned its length, and
+        // not one byte ever came back. FT8TW drives the same radio on
+        // the same phone with a copy of this driver that has no
+        // SET_FLOW code in it at all. A chip that was opened fresh is
+        // already in its configured default, which is no flow control,
+        // so there is nothing here to undo. See the matching guard in
+        // the vendored `Cp21xxSerialDriver.openInt`, which does this
+        // write before we are ever asked.
+        if (want == UsbSerialPort.FlowControl.NONE) return;
+
         try {
             // **Not fatal if the chip cannot do it.** Only some drivers
             // implement hardware handshaking, and the alternative to
             // carrying on is refusing to talk to a radio that would have
             // worked — CAT is a few bytes at a time and almost never
             // needs flow control at all.
-            if (want == UsbSerialPort.FlowControl.NONE
-                    || port.getSupportedFlowControl().contains(want)) {
+            if (port.getSupportedFlowControl().contains(want)) {
                 port.setFlowControl(want);
             } else {
                 Log.w(TAG, "flow control " + want + " unsupported; leaving it off");

--- a/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
+++ b/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
@@ -14,6 +14,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbManager;
 import android.os.Build;
 import android.util.Log;
@@ -259,6 +260,60 @@ public final class SerialBridge {
             return new String[0];
         }
         return out.toArray(new String[0]);
+    }
+
+    /**
+     * What was actually opened, for the rig trace.
+     *
+     * <p><b>Written because a failing radio and a mis-driven chip look
+     * identical from above.</b> An Elecraft K4 works over this path and
+     * two Icoms do not, and everything above the USB layer -- Hamlib's
+     * trace, the bridge, the byte counts -- says exactly the same thing
+     * in both cases. What it cannot say is which driver
+     * {@code UsbSerialProber} picked, which USB interface that driver
+     * claimed, or how many interfaces the device has to choose from,
+     * and those are the parts that differ between an FTDI on its own
+     * and a vendor bridge inside a composite device.
+     *
+     * <p>Never throws: this runs on the rig worker thread inside an
+     * open that is already in progress, and a diagnostic that can fail
+     * the operation it is diagnosing is worse than none.
+     */
+    static String describeLink(String id) {
+        if (id == null) return "";
+        try {
+            if (id.startsWith("bt:")) return "bluetooth " + id.substring(3);
+            if (!id.startsWith("usb:")) return id;
+            final UsbManager manager = usbManager();
+            final UsbDevice device = findUsbDevice(id);
+            if (manager == null || device == null) return id + " (not present)";
+            final StringBuilder out = new StringBuilder();
+            out.append(String.format(Locale.US, "%04x:%04x", device.getVendorId(),
+                    device.getProductId()));
+            out.append(" \"").append(describe(device)).append('"');
+            final int interfaces = device.getInterfaceCount();
+            out.append(", ").append(interfaces).append(" interface(s) [");
+            for (int i = 0; i < interfaces; i++) {
+                if (i != 0) out.append(' ');
+                final UsbInterface iface = device.getInterface(i);
+                out.append(i).append(":cls").append(iface.getInterfaceClass())
+                   .append('/').append(iface.getEndpointCount()).append("ep");
+            }
+            out.append(']');
+            final UsbSerialDriver driver =
+                    UsbSerialProber.getDefaultProber().probeDevice(device);
+            if (driver == null) {
+                out.append(", no driver");
+            } else {
+                out.append(", driver ")
+                   .append(driver.getClass().getSimpleName())
+                   .append(", port ").append(usbPortIndex(id))
+                   .append(" of ").append(driver.getPorts().size());
+            }
+            return out.toString();
+        } catch (RuntimeException e) {
+            return id + " (could not describe: " + e + ")";
+        }
     }
 
     private static String describe(UsbDevice device) {

--- a/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
+++ b/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
@@ -396,12 +396,15 @@ public final class SerialBridge {
         void close();
     }
 
-    static int open(String id, int baud, int dataBits, int stopBits, int parity, int flow)
-            throws IOException {
+    static int open(String id, int baud, int dataBits, int stopBits, int parity, int flow,
+                    boolean dtr, boolean rts) throws IOException {
         if (context == null) throw new IOException("SerialBridge.init was never called");
+        // RFCOMM has no modem control lines at all, so `dtr` and `rts`
+        // are simply not offered to it -- rather than silently ignored
+        // in a place that reads as if they applied.
         final Link link = id != null && id.startsWith("bt:")
                 ? openBluetooth(id)
-                : openUsb(id, baud, dataBits, stopBits, parity, flow);
+                : openUsb(id, baud, dataBits, stopBits, parity, flow, dtr, rts);
         final int token = nextToken.getAndIncrement();
         links.put(token, link);
         return token;
@@ -439,7 +442,7 @@ public final class SerialBridge {
     // --- USB --------------------------------------------------------------
 
     private static Link openUsb(String id, int baud, int dataBits, int stopBits, int parity,
-                                int flow) throws IOException {
+                                int flow, boolean dtr, boolean rts) throws IOException {
         final UsbManager manager = usbManager();
         if (manager == null) throw new IOException("no USB service");
         final UsbDevice device = findUsbDevice(id);
@@ -470,6 +473,23 @@ public final class SerialBridge {
         port.open(connection);
         try {
             port.setParameters(baud, dataBits, stopBits, toParity(parity));
+            // **Before the flow control, deliberately.** The CP210x
+            // SET_FLOW structure encodes whether each line is held
+            // active, held inactive or driven by handshaking, and this
+            // library builds it from the driver's current `dtr`/`rts`
+            // fields — so setting the lines afterwards would leave the
+            // chip's flow configuration describing the old state.
+            //
+            // And they are asserted by default because that is what a
+            // serial port looks like everywhere else: the OS raises
+            // both on open and Hamlib relies on it (`src/rig.c`, "Needed
+            // on Linux because the serial port driver sets RTS/DTR on
+            // open"). A bridged transport reaches none of that, and an
+            // IC-9700 handed two low lines never answered a single CAT
+            // command that the same cable answered instantly from a
+            // desktop.
+            port.setDTR(dtr);
+            port.setRTS(rts);
             applyFlowControl(port, flow);
         } catch (IOException | UnsupportedOperationException e) {
             port.close();

--- a/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
+++ b/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
@@ -564,15 +564,21 @@ public final class SerialBridge {
         /**
          * What the chip says about itself, for the rig trace.
          *
-         * <p><b>This is the fact nothing else in the stack can supply.</b>
-         * A bulk write returning its length means the bytes reached the
-         * chip over USB — not that the UART clocked them out. A CP210x
-         * will say: {@code GET_COMM_STATUS} returns how many bytes are
-         * still queued for transmit, how many arrived from the UART, and
-         * a bitmask of the reasons transmission is being held. An Icom
-         * that answers a desktop and not a phone is either being held
-         * off, or being transmitted to and not replying, and those two
-         * look identical from above.
+         * <p>A bulk write returning its length means the bytes reached
+         * the chip over USB — not that the UART clocked them out.
+         * {@code GET_COMM_STATUS} is the chip's own account: an error
+         * mask, a bitmask of reasons transmission is being held, and the
+         * two queue depths.
+         *
+         * <p><b>The queue depths turned out to be the weak half.</b>
+         * The caller reads this a second after the previous frame, by
+         * which time {@code outQueue} is zero whether the chip sent the
+         * bytes or dropped them, and {@code inQueue} is drained
+         * continuously by the read thread, so it is zero even when the
+         * radio does answer. {@code errors} and {@code hold} are latched
+         * by the chip rather than sampled, and those are what carry
+         * information — along with CTS, since a handshake holding the
+         * transmitter off would show up there.
          *
          * <p>Never throws: it runs on the bridge's read thread inside a
          * session that is otherwise working.

--- a/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
+++ b/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
@@ -243,8 +243,29 @@ public final class SerialBridge {
         final UsbManager manager = usbManager();
         final List<String> out = new ArrayList<>();
         if (manager == null) return new String[0];
-        for (UsbSerialDriver driver : UsbSerialProber.getDefaultProber()
-                .findAllDrivers(manager)) {
+        // **Sorted, because `findAllDrivers` is not.** It walks
+        // `getDeviceList().values()` -- a `HashMap` -- so without this
+        // the rows come out in whatever order the map felt like, and
+        // "(2 of 2)" can appear above "(1 of 2)". The unit *index* was
+        // already sorted; this is the same `HashMap` leaking through a
+        // second time, one layer up. Ordered by vendor, product, then
+        // device name so that ports of one radio group together and
+        // their order matches the numbering in their own labels.
+        final List<UsbSerialDriver> drivers =
+                new ArrayList<>(UsbSerialProber.getDefaultProber().findAllDrivers(manager));
+        drivers.sort((a, b) -> {
+            final UsbDevice da = a.getDevice();
+            final UsbDevice db = b.getDevice();
+            if (da.getVendorId() != db.getVendorId()) {
+                return Integer.compare(da.getVendorId(), db.getVendorId());
+            }
+            if (da.getProductId() != db.getProductId()) {
+                return Integer.compare(da.getProductId(), db.getProductId());
+            }
+            return deviceName(da).compareTo(deviceName(db));
+        });
+
+        for (UsbSerialDriver driver : drivers) {
             final UsbDevice device = driver.getDevice();
             final boolean permitted = manager.hasPermission(device);
             final int ports = driver.getPorts().size();
@@ -297,12 +318,16 @@ public final class SerialBridge {
             // in system Settings.
             final Collection<BluetoothDevice> bonded = adapter.getBondedDevices();
             if (bonded == null) return new String[0];
-            for (BluetoothDevice device : bonded) {
-                final String name = device.getName();
-                final String label = (name == null || name.isEmpty())
-                        ? device.getAddress()
-                        : name + " (" + device.getAddress() + ")";
-                out.add("bt:" + device.getAddress() + "\t" + clean(label) + "\t1");
+            // Sorted before the rows are built, for the same reason
+            // the USB list is: `getBondedDevices()` returns a Set, so
+            // without this the rows shuffle between refreshes for no
+            // reason the operator can see. By what they are reading --
+            // the name, falling back to the address when there is none.
+            final List<BluetoothDevice> paired = new ArrayList<>(bonded);
+            paired.sort((a, b) -> bluetoothLabel(a).compareToIgnoreCase(bluetoothLabel(b)));
+            for (BluetoothDevice device : paired) {
+                out.add("bt:" + device.getAddress() + "\t"
+                        + clean(bluetoothLabel(device)) + "\t1");
             }
         } catch (SecurityException e) {
             // The permission was revoked between the check and the call.
@@ -372,6 +397,20 @@ public final class SerialBridge {
         }
     }
 
+    /** "Name (AA:BB:CC:DD:EE:FF)", or just the address when unnamed. */
+    private static String bluetoothLabel(BluetoothDevice device) {
+        String name = null;
+        try {
+            name = device.getName();
+        } catch (SecurityException e) {
+            // Revoked between the check and the call; the address still
+            // identifies it.
+        }
+        return (name == null || name.isEmpty())
+                ? device.getAddress()
+                : name + " (" + device.getAddress() + ")";
+    }
+
     private static String describe(UsbDevice device) {
         String product = null;
         String manufacturer = null;
@@ -427,12 +466,14 @@ public final class SerialBridge {
                 units.add(device);
             }
         }
-        units.sort((a, b) -> {
-            final String an = a.getDeviceName() == null ? "" : a.getDeviceName();
-            final String bn = b.getDeviceName() == null ? "" : b.getDeviceName();
-            return an.compareTo(bn);
-        });
+        units.sort((a, b) -> deviceName(a).compareTo(deviceName(b)));
         return units;
+    }
+
+    /** `getDeviceName()`, never null, so it can be compared and sorted. */
+    private static String deviceName(UsbDevice device) {
+        final String name = device.getDeviceName();
+        return name == null ? "" : name;
     }
 
     /** Where `device` sits in {@link #usbUnits}, or 0 if it is not there. */
@@ -440,10 +481,7 @@ public final class SerialBridge {
         final List<UsbDevice> units =
                 usbUnits(manager, device.getVendorId(), device.getProductId());
         for (int i = 0; i < units.size(); i++) {
-            if (units.get(i).getDeviceName() != null
-                    && units.get(i).getDeviceName().equals(device.getDeviceName())) {
-                return i;
-            }
+            if (deviceName(units.get(i)).equals(deviceName(device))) return i;
         }
         return 0;
     }

--- a/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
+++ b/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
@@ -52,10 +52,28 @@ import java.util.concurrent.atomic.AtomicInteger;
  * <p><b>Device identifiers are vendor and product, never the device node.</b>
  * {@code UsbDevice.getDeviceName()} is {@code /dev/bus/usb/001/007} and changes
  * on every replug, so a setting keyed on it stops working the first time the
- * operator unplugs the radio. {@code usb:10c4:ea60} survives, with {@code #N}
- * for the second and later ports of a multi-port adapter. Two identical
+ * operator unplugs the radio. {@code usb:10c4:ea60} survives.
+ *
+ * <p><b>But a vendor and product pair names a *kind* of device, and a radio can
+ * present two of the same kind.</b> This paragraph used to end "two identical
  * adapters are indistinguishable and the first wins — the same accepted
- * ambiguity the audio layer takes on device names.
+ * ambiguity the audio layer takes on device names", and that was wrong in a way
+ * that cost days: an IC-9700 exposes its CI-V port and its USB serial function
+ * as two separate USB devices sharing {@code 10c4:ea60}, so the id named both,
+ * the picker showed two identical rows, and the lookup returned whichever
+ * {@code getDeviceList()} — a {@code HashMap} — happened to yield first. The
+ * app talked to a healthy chip that is not wired to the radio's CI-V engine,
+ * which from the outside is indistinguishable from a radio that ignores it.
+ *
+ * <p>So an id carries two independent suffixes, and they are <em>not</em> the
+ * same axis: {@code #p} is the p'th port of one multi-port driver (a CP2105),
+ * and {@code @u} is the u'th device sharing a vendor and product pair. Both are
+ * omitted at zero, so an id saved before they existed still means the first
+ * port of the first device. Units are ordered by {@code getDeviceName()},
+ * which is the only ordering available before permission is granted and is not
+ * promised across a replug — hence the row label says which is which and the
+ * operator chooses, because nothing readable tells an Icom's CI-V port from
+ * its data port.
  *
  * <p>Call {@link #init} once with an application context before anything else.
  */
@@ -241,16 +259,26 @@ public final class SerialBridge {
             final int units =
                     usbUnits(manager, device.getVendorId(), device.getProductId()).size();
             for (int i = 0; i < ports; i++) {
-                final StringBuilder label = new StringBuilder(describe(device));
-                if (ports > 1) label.append(" port ").append(i + 1);
-                // Said plainly, because the operator is the only one who
-                // can tell these apart: nothing readable distinguishes
-                // an Icom's CI-V port from its data port, so the answer
-                // is to try the other one.
-                if (units > 1) {
-                    label.append(" (").append(unit + 1).append(" of ").append(units).append(')');
+                // **The marker goes in front of the name, not after
+                // it.** Said plainly because the operator is the only
+                // one who can tell these apart -- nothing readable
+                // distinguishes an Icom's CI-V port from its data port,
+                // so the answer is to try the other one. Put after the
+                // name it is the first thing a narrow combo elides, and
+                // eliding the only distinguishing text leaves two rows
+                // that read identically: "Silicon Labs CP2102N USB to
+                // UART Bridge Contr...". In front it survives both the
+                // closed control and the open list.
+                final StringBuilder marker = new StringBuilder();
+                if (units > 1) marker.append(unit + 1).append(" of ").append(units);
+                if (ports > 1) {
+                    if (marker.length() > 0) marker.append(", ");
+                    marker.append("port ").append(i + 1);
                 }
-                out.add(usbId(device, unit, i) + "\t" + clean(label.toString()) + "\t"
+                final String label = marker.length() > 0
+                        ? "(" + marker + ") " + describe(device)
+                        : describe(device);
+                out.add(usbId(device, unit, i) + "\t" + clean(label) + "\t"
                         + (permitted ? "1" : "0"));
             }
         }

--- a/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
+++ b/native/core/rig/android/java/org/cleverdomain/sstvae/SerialBridge.java
@@ -593,7 +593,7 @@ public final class SerialBridge {
                         default: out.append('?'); break;
                     }
                 }
-            } catch (IOException | UnsupportedOperationException | RuntimeException e) {
+            } catch (IOException | RuntimeException e) {
                 out.append(" (unavailable: ").append(e).append(')');
             }
 

--- a/native/core/rig/bridge.cpp
+++ b/native/core/rig/bridge.cpp
@@ -345,7 +345,11 @@ void LoopbackBridge::pump_out() {
         }
     }
 
-    trace("bridge: stopped reading from the rig");
+    if (tracing()) {
+        const std::string why = last_error();
+        trace("bridge: stopped reading from the rig" +
+              (why.empty() ? std::string(" (session ended)") : ": " + why));
+    }
 
     {
         std::lock_guard<std::mutex> lock(mu_);

--- a/native/core/rig/bridge.cpp
+++ b/native/core/rig/bridge.cpp
@@ -1,5 +1,7 @@
 #include "rig/bridge.hpp"
 
+#include "rig/trace.hpp"
+
 #include <algorithm>
 #include <array>
 #include <cctype>
@@ -133,6 +135,9 @@ void LoopbackBridge::start() {
         std::lock_guard<std::mutex> lock(mu_);
         endpoint_ = "127.0.0.1:" + std::to_string(port);
     }
+
+    trace("bridge: listening on 127.0.0.1:" + std::to_string(port) +
+          ", transport open");
 
     stopping_.store(false);
     in_ = std::thread([this] { pump_in(); });
@@ -272,6 +277,17 @@ void LoopbackBridge::pump_in() {
         }
         try {
             transport_->write(buf.data(), static_cast<std::size_t>(n));
+            // **After the write, not before.** The whole point of this
+            // line is that it is only reached when the transport
+            // accepted the bytes, which is the fact Hamlib's own trace
+            // cannot report: it sees a successful socket write and has
+            // no idea whether anything left the USB port. Logged on the
+            // way in, it would say "delivered" for a write that threw --
+            // the false reassurance this was added to remove.
+            if (tracing()) {
+                trace("bridge: -> rig " + std::to_string(n) + ": " +
+                      hex_bytes(buf.data(), static_cast<std::size_t>(n)));
+            }
         } catch (const std::exception& e) {
             set_error(std::string("bridge: write to rig: ") + e.what());
             break;
@@ -304,6 +320,10 @@ void LoopbackBridge::pump_out() {
             break;
         }
         if (n == 0) continue;  // An idle radio, not a failure.
+        if (tracing()) {
+            trace("bridge: <- rig " + std::to_string(n) + ": " +
+                  hex_bytes(buf.data(), n));
+        }
 
         const std::intptr_t handle = client_fd_.load();
         if (handle == kNoFd) break;
@@ -324,6 +344,8 @@ void LoopbackBridge::pump_out() {
             sent += static_cast<std::size_t>(wrote);
         }
     }
+
+    trace("bridge: stopped reading from the rig");
 
     {
         std::lock_guard<std::mutex> lock(mu_);

--- a/native/core/rig/bridged.cpp
+++ b/native/core/rig/bridged.cpp
@@ -161,6 +161,21 @@ SerialParams resolve_serial_params(const HamlibConfig& config,
         case Handshake::Default: params.flow = defaults.flow; break;
     }
 
+    // The initial line states, which on a real serial port come from
+    // the *operating system* rather than from Hamlib -- see
+    // `SerialParams::dtr`. Default therefore means asserted, not
+    // "leave it alone": leaving it alone is what a desktop never does.
+    params.dtr = config.dtr != LineState::Low;
+    params.rts = config.rts != LineState::Low;
+
+    // ...except the line doing PTT, which `rig_open` explicitly drops
+    // so that opening the radio does not key it. Same rule, same
+    // reason, and the reason it is safe to raise the *other* line: a
+    // desktop already does, so no working station depends on it being
+    // low.
+    if (config.ptt_method == PttMethod::Dtr) params.dtr = false;
+    if (config.ptt_method == PttMethod::Rts) params.rts = false;
+
     // Hamlib's three -RIG_ECONF cases, re-derived because its own are
     // unreachable for a network port. Each one is a setting that cannot
     // do what it says: the flow-control driver and the PTT code would be

--- a/native/core/rig/hamlib.cpp
+++ b/native/core/rig/hamlib.cpp
@@ -2,6 +2,8 @@
 
 
 #include <algorithm>
+#include <cstdarg>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <hamlib/rig.h>
@@ -15,6 +17,17 @@
 namespace sstvae::rig {
 
 namespace {
+
+// The level `SSTVAE_HAMLIB_DEBUG` asks for, which is also the level to
+// go back to when a debug sink is removed. Read every time rather than
+// cached: it is two getenv calls in a lifetime, and a cached copy is one
+// more thing that can be stale.
+enum rig_debug_level_e env_debug_level() {
+    const char* debug = std::getenv("SSTVAE_HAMLIB_DEBUG");
+    const bool verbose =
+        debug != nullptr && *debug != '\0' && std::strcmp(debug, "0") != 0;
+    return verbose ? RIG_DEBUG_TRACE : RIG_DEBUG_NONE;
+}
 
 // Hamlib's backend registry is global and loading it is not reentrant,
 // so it is done once. `list_models` and `rig_init` both need it -- a
@@ -33,10 +46,7 @@ void load_backends_once() {
         // open get -- are answerable only from Hamlib's own trace. The
         // rig tests set it so a failure arrives with that trace already
         // attached rather than needing the run repeated.
-        const char* debug = std::getenv("SSTVAE_HAMLIB_DEBUG");
-        const bool verbose = debug != nullptr && *debug != '\0' &&
-                             std::strcmp(debug, "0") != 0;
-        rig_set_debug(verbose ? RIG_DEBUG_TRACE : RIG_DEBUG_NONE);
+        rig_set_debug(env_debug_level());
         rig_load_all_backends();
     });
 }
@@ -45,6 +55,107 @@ std::string hamlib_error(const char* what, int code) {
     const char* text = rigerror(code);
     return std::string(what) + ": " + (text != nullptr ? text : "unknown error") +
            " (" + std::to_string(code) + ")";
+}
+
+// --- Hamlib's own trace, routed somewhere an app can show it ---------
+//
+// Hamlib formats trace lines with `rig_debug(level, fmt, ...)` and hands
+// a registered callback the *unformatted* fmt plus a `va_list`, so the
+// formatting is ours to do. Three details are load-bearing:
+//
+//   * **A line is not a call.** `dump_hex` and the frame tracers emit a
+//     line in several calls and sometimes several lines in one, so the
+//     text is accumulated and split on newlines. A sink handed raw calls
+//     would show a CI-V frame smeared across a dozen entries.
+//   * **The `va_list` is the caller's.** `vsnprintf` consumes it, so
+//     both the sizing pass and the real one take a `va_copy`.
+//   * **Nothing may escape.** This is called from C, through a function
+//     pointer, while Hamlib holds its own debug mutex -- an exception
+//     crossing that boundary is a terminate, and a call back into
+//     `rig_debug` from the sink is a deadlock. Hence the try/catch and
+//     the contract in the header.
+std::mutex& debug_mu() {
+    static std::mutex m;
+    return m;
+}
+
+DebugSink& debug_sink() {
+    static DebugSink sink;
+    return sink;
+}
+
+std::string& debug_partial() {
+    static std::string partial;
+    return partial;
+}
+
+// A frame trace at 115200 is verbose but bounded; this is only here so a
+// sink that has stopped consuming, or a format with no newline in it at
+// all, cannot grow the buffer without limit.
+constexpr std::size_t kMaxPartialBytes = 8192;
+
+std::string format_debug(const char* fmt, va_list ap) {
+    va_list sizing;
+    va_copy(sizing, ap);
+    char stack[512];
+    const int n = std::vsnprintf(stack, sizeof(stack), fmt, sizing);
+    va_end(sizing);
+    if (n < 0) return {};
+    if (static_cast<std::size_t>(n) < sizeof(stack)) {
+        return std::string(stack, static_cast<std::size_t>(n));
+    }
+    std::string big(static_cast<std::size_t>(n), '\0');
+    va_list again;
+    va_copy(again, ap);
+    // `&big[0]` has n+1 writable chars, the last of which holds the
+    // terminator vsnprintf is going to write there anyway.
+    std::vsnprintf(&big[0], static_cast<std::size_t>(n) + 1, fmt, again);
+    va_end(again);
+    return big;
+}
+
+int debug_trampoline(enum rig_debug_level_e, rig_ptr_t, const char* fmt, va_list ap) {
+    try {
+        if (fmt == nullptr) return 0;
+        const std::string text = format_debug(fmt, ap);
+        if (text.empty()) return 0;
+
+        std::vector<std::string> lines;
+        DebugSink sink;
+        {
+            std::lock_guard<std::mutex> lock(debug_mu());
+            sink = debug_sink();
+            if (!sink) return 0;
+            std::string& partial = debug_partial();
+            partial += text;
+            std::size_t start = 0;
+            for (;;) {
+                const std::size_t nl = partial.find('\n', start);
+                if (nl == std::string::npos) break;
+                lines.emplace_back(partial, start, nl - start);
+                start = nl + 1;
+            }
+            partial.erase(0, start);
+            if (partial.size() > kMaxPartialBytes) {
+                lines.push_back(partial);
+                partial.clear();
+            }
+        }
+
+        // Outside the lock: the sink is the app's, may take a lock of
+        // its own, and holding ours across it would make the ordering
+        // between the two a property of whoever wrote the sink.
+        for (const std::string& line : lines) {
+            if (!line.empty() && line.back() == '\r') {
+                sink(line.substr(0, line.size() - 1));
+            } else {
+                sink(line);
+            }
+        }
+    } catch (...) {
+        // Nowhere to report to, and this is a C boundary.
+    }
+    return 0;
 }
 
 class HamlibBackend final : public RigBackend {
@@ -361,6 +472,28 @@ std::string hamlib_version() {
     // failed only on Windows, with exactly one unresolved symbol.
     const char* v = rig_version();
     return v != nullptr ? v : "";
+}
+
+void set_debug_sink(DebugSink sink) {
+    // Not for the registry, which this does not need, but because it is
+    // where the env-driven level is established -- installing a sink
+    // before it would have that call overwrite the level a moment later.
+    load_backends_once();
+
+    const bool active = static_cast<bool>(sink);
+    {
+        std::lock_guard<std::mutex> lock(debug_mu());
+        debug_sink() = std::move(sink);
+        debug_partial().clear();
+    }
+
+    // **Registered only while a sink exists.** A callback that is
+    // installed permanently and returns early swallows the trace rather
+    // than passing it on: `rig_debug` writes to stderr *or* to the
+    // callback, never both, so leaving ours in place would silently
+    // break `SSTVAE_HAMLIB_DEBUG` for every desktop and test run.
+    rig_set_debug_callback(active ? &debug_trampoline : nullptr, nullptr);
+    rig_set_debug(active ? RIG_DEBUG_TRACE : env_debug_level());
 }
 
 }  // namespace sstvae::rig

--- a/native/core/rig/hamlib.hpp
+++ b/native/core/rig/hamlib.hpp
@@ -28,6 +28,7 @@
 #ifndef SSTVAE_RIG_HAMLIB_HPP
 #define SSTVAE_RIG_HAMLIB_HPP
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -141,6 +142,23 @@ SerialDefaults serial_defaults(int model);
 
 // Hamlib's version string, for an about box or a bug report.
 std::string hamlib_version();
+
+// Route Hamlib's own trace somewhere this app can show it. An empty
+// sink turns it off, which is the default.
+//
+// **`SSTVAE_HAMLIB_DEBUG` was not enough, and Android is why.** That
+// variable raises the level and Hamlib writes to *stderr* -- which a
+// desktop operator can capture and a phone discards, so the one
+// artifact that answers "how far did open get, and which CAT command
+// did the rig refuse" was unreachable on the platform where rig control
+// is newest. A Kenwood worked and two Icoms did not, and neither of us
+// could see a single byte of the difference.
+//
+// The sink is called from the rig worker thread, once per trace line
+// with the trailing newline removed. It must not block and must not
+// call back into Hamlib.
+using DebugSink = std::function<void(const std::string& line)>;
+void set_debug_sink(DebugSink sink);
 
 }  // namespace sstvae::rig
 

--- a/native/core/rig/trace.cpp
+++ b/native/core/rig/trace.cpp
@@ -1,0 +1,74 @@
+#include "rig/trace.hpp"
+
+#include <atomic>
+#include <mutex>
+#include <utility>
+
+namespace sstvae::rig {
+namespace {
+
+std::mutex& trace_mu() {
+    static std::mutex m;
+    return m;
+}
+
+TraceSink& trace_sink() {
+    static TraceSink sink;
+    return sink;
+}
+
+// Read on the hot path, so it is not behind the mutex. Relaxed is
+// enough: the worst a stale read can do is drop or add one line around
+// the moment tracing is switched, and the sink itself is taken under
+// the lock either way.
+std::atomic<bool> g_tracing{false};
+
+char nibble(std::uint8_t v) {
+    return static_cast<char>(v < 10 ? '0' + v : 'a' + (v - 10));
+}
+
+}  // namespace
+
+void set_trace_sink(TraceSink sink) {
+    const bool active = static_cast<bool>(sink);
+    {
+        std::lock_guard<std::mutex> lock(trace_mu());
+        trace_sink() = std::move(sink);
+    }
+    g_tracing.store(active, std::memory_order_relaxed);
+}
+
+bool tracing() { return g_tracing.load(std::memory_order_relaxed); }
+
+void trace(const std::string& line) {
+    if (!tracing()) return;
+    TraceSink sink;
+    {
+        std::lock_guard<std::mutex> lock(trace_mu());
+        sink = trace_sink();
+    }
+    // Outside the lock, for the reason `hamlib.cpp` records: the sink
+    // is the app's and may take a lock of its own, and holding ours
+    // across it would make the order between the two somebody else's
+    // problem to get right.
+    if (sink) sink(line);
+}
+
+std::string hex_bytes(const std::uint8_t* data, std::size_t n, std::size_t max) {
+    std::string out;
+    const std::size_t shown = n < max ? n : max;
+    out.reserve(shown * 3 + 16);
+    for (std::size_t i = 0; i < shown; ++i) {
+        if (i != 0) out += ' ';
+        out += nibble(static_cast<std::uint8_t>(data[i] >> 4));
+        out += nibble(static_cast<std::uint8_t>(data[i] & 0x0f));
+    }
+    if (shown < n) {
+        out += " ... (";
+        out += std::to_string(n);
+        out += " bytes)";
+    }
+    return out;
+}
+
+}  // namespace sstvae::rig

--- a/native/core/rig/trace.hpp
+++ b/native/core/rig/trace.hpp
@@ -1,0 +1,57 @@
+// A place for the rig path to say what it is doing, below Hamlib.
+//
+// **This exists because a trace stopped exactly where the interesting
+// part began.** `rig::set_debug_sink` gives an app Hamlib's own view --
+// which for a radio that never answers is "I wrote six bytes and read
+// nothing", repeated. That is one end of a chain whose other end is a
+// USB endpoint on a phone, and nothing in between said anything: not
+// the loopback bridge, not the transport, not which driver the Android
+// USB layer picked for the device. So a failure inside our own code and
+// a radio ignoring a correctly delivered command produced *byte for
+// byte the same log*.
+//
+// Qt-free and Hamlib-free, in `sstvae_core`, so `bridge.cpp` and the
+// Android transport can both write to it -- and so a `--no-rig` build
+// still compiles and tests every line of it.
+//
+// **Off costs one relaxed atomic load.** This sits in the byte pump
+// between Hamlib and the radio, so the check has to be cheap enough
+// that leaving the calls in is not a decision anybody has to think
+// about. Formatting the message is the caller's job and must be guarded
+// by `tracing()`, which is why that is public rather than an
+// implementation detail.
+
+#ifndef SSTVAE_RIG_TRACE_HPP
+#define SSTVAE_RIG_TRACE_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+
+namespace sstvae::rig {
+
+// Called once per line, with no trailing newline, from whichever thread
+// produced it -- the bridge's two pump threads and the rig worker, so
+// possibly three at once. It must not block.
+using TraceSink = std::function<void(const std::string& line)>;
+
+// An empty sink turns tracing off, which is the default.
+void set_trace_sink(TraceSink sink);
+
+// Whether anything is listening. Guard message construction with it.
+bool tracing();
+
+// Emit one line. A no-op when nothing is listening.
+void trace(const std::string& line);
+
+// `fe fe a2 e0 03 fd` -- the spelling Hamlib's own `dump_hex` uses, so
+// a frame in this log can be compared against one in that log without
+// translating between two formats. Long blocks are truncated with a
+// count, because a trace is for frames and a picture's worth of bytes
+// in one line helps nobody.
+std::string hex_bytes(const std::uint8_t* data, std::size_t n, std::size_t max = 32);
+
+}  // namespace sstvae::rig
+
+#endif

--- a/native/core/rig/transport.hpp
+++ b/native/core/rig/transport.hpp
@@ -81,6 +81,27 @@ struct SerialParams {
 
     enum Flow { kNoFlow = 0, kRtsCts = 1, kXonXoff = 2 };
     int flow = kNoFlow;
+
+    // The state to leave DTR and RTS in once the link is open.
+    //
+    // **These are not a nicety, and they default to true for a reason
+    // Hamlib states outright.** `src/rig.c`, opening a PTT-by-line
+    // port: *"Needed on Linux because the serial port driver sets
+    // RTS/DTR on open - only need to address the PTT line as we offer
+    // config parameters to control the other (dtr_state &
+    // rts_state)"*. Hamlib never raises them itself; it relies on the
+    // OS having done so, and only ever explicitly drops the line that
+    // is doing PTT. A serial port opened by `rigctl` therefore presents
+    // a radio with both lines high.
+    //
+    // A bridged transport reaches none of that -- `serial_open` is not
+    // in its path -- and `usb-serial-for-android` deasserts both in
+    // `openInt()`. So an Icom that was silent on a phone and answered
+    // instantly on a desktop, same cable, same chip, same baud, was
+    // being handed a different pair of control lines. This is the same
+    // omission `resolve_serial_params` exists to fix, one field later.
+    bool dtr = true;
+    bool rts = true;
 };
 
 // What a given Hamlib backend would have configured a serial port with.

--- a/native/tests/test_rig_bridge.cpp
+++ b/native/tests/test_rig_bridge.cpp
@@ -45,6 +45,7 @@
 
 #include "check.hpp"
 #include "rig/bridge.hpp"
+#include "rig/trace.hpp"
 
 using namespace sstvae;
 
@@ -283,6 +284,133 @@ void test_binary_bytes_are_not_mangled() {
                  "bridge: a binary answer survives the crossing");
 }
 
+// The trace is the diagnostic this bridge exists to make possible, so
+// it is tested rather than eyeballed.
+//
+// **What it is for**: from above, a radio that ignores a command and a
+// bridge that never delivered one are the same log -- Hamlib writes to
+// a socket, the write succeeds, and nothing comes back. The only line
+// that separates them is one emitted *after* the transport accepted
+// the bytes. Both directions and the hex spelling are checked, because
+// the whole value of the line is that a frame in it can be compared
+// byte for byte against the one in Hamlib's own `dump_hex` output.
+void test_the_trace_reports_both_directions() {
+    std::mutex mu;
+    std::vector<std::string> lines;
+    rig::set_trace_sink([&](const std::string& line) {
+        std::lock_guard<std::mutex> lock(mu);
+        lines.push_back(line);
+    });
+
+    {
+        auto probe = std::make_shared<Probe>();
+        rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
+        bridge.start();
+
+        Client client(bridge.port());
+        const std::string icom("\xFE\xFE\xA2\xE0\x03\xFD", 6);
+        client.send_text(icom);
+        check::is_true(probe->wait_for_written(icom), "bridge/trace: (setup) command arrived");
+
+        const std::string reply("\xFE\xFE\xE0\xA2\xFB\xFD", 6);
+        probe->deliver(reply);
+        check::equal(client.receive(reply.size()), reply, "bridge/trace: (setup) answer arrived");
+    }
+
+    bool saw_out = false;
+    bool saw_in = false;
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        for (const std::string& line : lines) {
+            if (line.find("-> rig 6: fe fe a2 e0 03 fd") != std::string::npos) saw_out = true;
+            if (line.find("<- rig 6: fe fe e0 a2 fb fd") != std::string::npos) saw_in = true;
+        }
+    }
+    check::is_true(saw_out, "bridge/trace: what reached the radio, in Hamlib's hex spelling");
+    check::is_true(saw_in, "bridge/trace: and what came back");
+
+    // Removing the sink must actually stop it: this sits in the byte
+    // pump, and a sink left installed after the view that owns it is
+    // gone is the shape of every use-after-free in a logging path.
+    rig::set_trace_sink({});
+    check::is_true(!rig::tracing(), "bridge/trace: removing the sink turns it off");
+
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        lines.clear();
+    }
+    {
+        auto probe = std::make_shared<Probe>();
+        rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
+        bridge.start();
+        Client client(bridge.port());
+        client.send_text("FA;");
+        check::is_true(probe->wait_for_written("FA;"), "bridge/trace: (setup) still bridging");
+    }
+    std::size_t after = 0;
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        after = lines.size();
+    }
+    check::equal(static_cast<int>(after), 0, "bridge/trace: and nothing is delivered after");
+}
+
+// The placement is the claim: **after** the transport accepted the
+// bytes, never before it. A line logged on the way in would say
+// "delivered" for a write that threw, which is precisely the false
+// reassurance this trace was added to remove.
+void test_a_failed_write_is_never_reported_as_delivered() {
+    std::mutex mu;
+    std::vector<std::string> lines;
+    rig::set_trace_sink([&](const std::string& line) {
+        std::lock_guard<std::mutex> lock(mu);
+        lines.push_back(line);
+    });
+
+    {
+        auto probe = std::make_shared<Probe>();
+        rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
+        bridge.start();
+        Client client(bridge.port());
+
+        // The transport now refuses every write, the way an unplugged
+        // device does.
+        {
+            std::lock_guard<std::mutex> lock(probe->m);
+            probe->closed = true;
+        }
+        client.send_text("FA;");
+
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (bridge.last_error().empty() &&
+               std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        check::is_true(!bridge.last_error().empty(),
+                       "bridge/trace: (setup) the write failed");
+    }
+
+    bool claimed = false;
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        for (const std::string& line : lines) {
+            if (line.find("-> rig") != std::string::npos) claimed = true;
+        }
+    }
+    check::is_true(!claimed,
+                   "bridge/trace: a write that threw is not logged as delivered");
+    rig::set_trace_sink({});
+}
+
+void test_hex_bytes_truncates_rather_than_floods() {
+    const std::vector<std::uint8_t> big(200, 0xAB);
+    const std::string out = rig::hex_bytes(big.data(), big.size());
+    check::is_true(out.find("(200 bytes)") != std::string::npos,
+                   "bridge/trace: a long block says how long it was");
+    check::is_true(out.size() < 200,
+                   "bridge/trace: ...without printing all of it");
+}
+
 void test_a_client_hanging_up_ends_the_session() {
     auto probe = std::make_shared<Probe>();
     rig::LoopbackBridge bridge(std::make_shared<FakeTransport>(probe));
@@ -417,6 +545,12 @@ int main() {
         test_a_device_that_cannot_be_opened_fails_start();
         check::current_step.store("device_strings");
         test_device_strings_are_read_the_way_hamlib_reads_them();
+        check::current_step.store("trace");
+        test_the_trace_reports_both_directions();
+        check::current_step.store("trace_failed_write");
+        test_a_failed_write_is_never_reported_as_delivered();
+        check::current_step.store("trace_hex");
+        test_hex_bytes_truncates_rather_than_floods();
     } catch (const std::exception& e) {
         std::fprintf(stderr, "FATAL: %s\n", e.what());
         return 1;

--- a/native/tests/test_rig_bridged.cpp
+++ b/native/tests/test_rig_bridged.cpp
@@ -365,6 +365,61 @@ void test_an_explicit_line_setting_wins() {
                  "resolve: ...and the handshake");
 }
 
+// The initial state of DTR and RTS, which is the one serial-port
+// property that does not come from Hamlib at all.
+//
+// **This was a real bug and the trace that found it is worth keeping.**
+// An IC-9700 on a phone was handed a correct CI-V frame at the correct
+// baud (`-> rig 6: fe fe a2 e0 03 fd`, 19200 8N1, CP2102N, flow=none)
+// and never answered a byte; the same cable, chip, baud and Hamlib
+// backend answered instantly from `rigctl -r /dev/ttyUSB0`. The
+// difference was two wires. Hamlib never raises them -- it relies on
+// the OS having done so, and says as much in `src/rig.c`: *"Needed on
+// Linux because the serial port driver sets RTS/DTR on open - only
+// need to address the PTT line as we offer config parameters to
+// control the other"*. A bridged transport reaches no `serial_open`,
+// and `usb-serial-for-android` deasserts both.
+//
+// So `Default` here means **asserted**, matching a desktop, and the
+// only line deliberately left low is the one doing PTT -- which is the
+// single exception `rig_open` itself makes, for the same reason:
+// opening a radio must not key it.
+void test_the_control_lines_open_the_way_a_desktop_leaves_them() {
+    const rig::SerialDefaults defaults;
+
+    rig::HamlibConfig config;
+    config.device = "usb:10c4:ea60";
+    rig::SerialParams p = rig::resolve_serial_params(config, defaults);
+    check::is_true(p.dtr, "resolve: DTR is asserted on open, as the OS would");
+    check::is_true(p.rts, "resolve: and so is RTS");
+
+    // PTT by a line: that one stays low, or connecting transmits.
+    config.ptt_method = rig::PttMethod::Dtr;
+    p = rig::resolve_serial_params(config, defaults);
+    check::is_true(!p.dtr, "resolve: except the line doing PTT...");
+    check::is_true(p.rts, "resolve: ...which is only that line");
+
+    config.ptt_method = rig::PttMethod::Rts;
+    p = rig::resolve_serial_params(config, defaults);
+    check::is_true(p.dtr, "resolve: the same the other way round...");
+    check::is_true(!p.rts, "resolve: ...for RTS keying");
+
+    // And an operator who pins a line still gets what they asked for:
+    // `dtr_state`/`rts_state` are the config parameters Hamlib's own
+    // comment says exist for the non-PTT line.
+    config.ptt_method = rig::PttMethod::Cat;
+    config.dtr = rig::LineState::Low;
+    config.rts = rig::LineState::Low;
+    p = rig::resolve_serial_params(config, defaults);
+    check::is_true(!p.dtr, "resolve: an explicit low DTR is honoured");
+    check::is_true(!p.rts, "resolve: and an explicit low RTS");
+
+    config.dtr = rig::LineState::High;
+    config.rts = rig::LineState::High;
+    p = rig::resolve_serial_params(config, defaults);
+    check::is_true(p.dtr && p.rts, "resolve: as is an explicit high");
+}
+
 void test_control_line_conflicts_are_refused() {
     // Hamlib refuses all three of these with -RIG_ECONF -- and every
     // one of its checks sits inside `if (rp->type.rig ==
@@ -463,6 +518,8 @@ int main() {
         test_default_line_settings_come_from_the_backend();
         check::current_step.store("resolve_explicit");
         test_an_explicit_line_setting_wins();
+        check::current_step.store("resolve_lines");
+        test_the_control_lines_open_the_way_a_desktop_leaves_them();
         check::current_step.store("resolve_conflicts");
         test_control_line_conflicts_are_refused();
         check::current_step.store("rig_open_failure");

--- a/native/tests/test_rig_hamlib.cpp
+++ b/native/tests/test_rig_hamlib.cpp
@@ -31,6 +31,11 @@
 #include <utility>
 #include <vector>
 
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
 #include "check.hpp"
 #include "rig/bridged.hpp"
 #include "rig/controller.hpp"
@@ -213,6 +218,120 @@ namespace {
 // test here and by the bridged tests below.
 constexpr int MODEL_TS2000 = 2014;
 }  // namespace
+
+// The trace an operator's bug report needs, routed somewhere an app can
+// show it.
+//
+// **This exists because two Icoms failed where a Kenwood worked and
+// nobody could see a byte of the difference.** `SSTVAE_HAMLIB_DEBUG`
+// answers that question on a desktop, by writing to stderr; on a phone
+// stderr goes nowhere, so on the platform where rig control is newest
+// the one artifact that says how far `rig_open` got was unreachable.
+//
+// Three things are checked, and the third is the one worth having: the
+// sink receives whole lines rather than raw `rig_debug` calls; clearing
+// it stops delivery; and clearing it *restores* whatever the
+// environment asked for, since a callback left registered would swallow
+// the stderr trace for every later test and every desktop run -- silently,
+// because a callback that returns 0 looks exactly like a quiet library.
+void test_the_debug_sink_captures_and_releases() {
+    // Both halves need it: `set_debug_sink({})` restores the level this
+    // asks for, and the stderr check below is a check that it did.
+    // ctest sets it for this test already; setting it here is what makes
+    // running the binary by hand mean the same thing.
+#ifndef _WIN32
+    ::setenv("SSTVAE_HAMLIB_DEBUG", "1", 1);
+#endif
+
+    std::mutex mu;
+    std::vector<std::string> lines;
+
+    rig::set_debug_sink([&](const std::string& line) {
+        std::lock_guard<std::mutex> lock(mu);
+        lines.push_back(line);
+    });
+
+    auto poke_the_dummy = [] {
+        rig::HamlibConfig config;
+        config.model = rig::MODEL_DUMMY;
+        std::unique_ptr<rig::RigBackend> backend = rig::make_hamlib_backend(config);
+        backend->open();
+        (void)backend->frequency_hz();
+        backend->close();
+    };
+
+    poke_the_dummy();
+
+    std::size_t captured = 0;
+    bool has_newline = false;
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        captured = lines.size();
+        for (const std::string& line : lines) {
+            if (line.find('\n') != std::string::npos) has_newline = true;
+        }
+    }
+    check::is_true(captured > 0,
+                   "hamlib/debug: a sink sees the trace (" +
+                       std::to_string(captured) + " lines)");
+    check::is_true(!has_newline,
+                   "hamlib/debug: split into lines, not raw rig_debug calls");
+
+    rig::set_debug_sink({});
+
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        lines.clear();
+    }
+    poke_the_dummy();
+    std::size_t after = 0;
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        after = lines.size();
+    }
+    check::equal(static_cast<int>(after), 0,
+                 "hamlib/debug: removing the sink stops delivery");
+
+#ifndef _WIN32
+    // **The one that is not obvious.** `rig_debug` writes to stderr
+    // *or* to a registered callback, never both, so a callback left
+    // registered -- even one that returns immediately because it has no
+    // sink -- silently swallows the trace for every later test and
+    // every desktop run with `SSTVAE_HAMLIB_DEBUG` set. Nothing else
+    // here can see that: a swallowed trace and a quiet library produce
+    // the same output. So capture stderr and require it to be non-empty.
+    //
+    // POSIX only because restoring stderr afterwards is `dup`/`dup2`
+    // and the Windows spelling buys nothing -- the behaviour under test
+    // is `rig_vprintf_cb`, which has no platform in it.
+    const char* path = "hamlib_trace_check.txt";
+    std::remove(path);
+    const int saved = ::dup(STDERR_FILENO);
+    check::is_true(saved >= 0, "hamlib/debug: stderr can be saved");
+    std::fflush(stderr);
+    const int capture = ::open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    check::is_true(capture >= 0, "hamlib/debug: a capture file opens");
+    ::dup2(capture, STDERR_FILENO);
+    ::close(capture);
+
+    poke_the_dummy();
+
+    std::fflush(stderr);
+    ::dup2(saved, STDERR_FILENO);
+    ::close(saved);
+
+    long size = -1;
+    if (std::FILE* f = std::fopen(path, "rb")) {
+        std::fseek(f, 0, SEEK_END);
+        size = std::ftell(f);
+        std::fclose(f);
+    }
+    std::remove(path);
+    check::is_true(size > 0,
+                   "hamlib/debug: the stderr trace is restored, not swallowed (" +
+                       std::to_string(size) + " bytes)");
+#endif
+}
 
 void test_serial_defaults_come_from_the_backend_caps() {
     // The other half of the bridged path's line settings. `rig_init`
@@ -572,6 +691,7 @@ int main() {
         STEP(test_using_a_closed_rig_reports_rather_than_crashes);
         STEP(test_the_controller_drives_a_real_backend);
         STEP(test_serial_defaults_come_from_the_backend_caps);
+        STEP(test_the_debug_sink_captures_and_releases);
 #ifndef _WIN32
         STEP(test_a_native_backend_works_over_a_socket);
         STEP(test_dtr_keying_never_reaches_hamlib);

--- a/native/third_party/usb-serial-for-android/PATCHES.md
+++ b/native/third_party/usb-serial-for-android/PATCHES.md
@@ -24,6 +24,16 @@ setFlowControl(mFlowControl);
 **Here:** the last call is guarded by `if (mFlowControl !=
 FlowControl.NONE)`.
 
+**This did not fix the bug it was written for, and is kept anyway.** An
+IC-9700 still does not answer, so the CP2102N's flow configuration was
+not what was stopping it. It stays because both reference
+implementations avoid this write and one of them is the kernel, and
+because Silicon Labs' own erratum says the structure is misread on some
+parts — a blind write of zeroes over four registers is wrong on its own
+terms whether or not it was Andrew's fault. Treat it as a candidate for
+removal at the next re-vendor if upstream has adopted a
+read-modify-write.
+
 **Why.** An Icom IC-9700 would not answer a single CI-V frame from this
 app on a phone, while `rigctl -m 3081 -r /dev/ttyUSB0 -s 19200` on the
 same cable answered instantly. The app's own trace showed a correct
@@ -38,10 +48,16 @@ chip a 16-byte `SET_FLOW` structure of zeroes, clobbering
 one blind write. Two independent implementations that work with this
 chip do not do that:
 
-* **FT8TW** drives the same radio on the same phone. Its fork of this
+* **FT8TW** drives the same radio on the same phone. Its copy of this
   file has no `SILABSER_SET_FLOW_REQUEST_CODE` constant and no
   `setFlowControl` method at all — `openInt` is `IFC_ENABLE` plus
-  `SET_MHS` and stops.
+  `SET_MHS` and stops. (It is an *older snapshot*, from before upstream
+  added flow control, rather than a deliberate removal: its
+  `openInt(UsbDeviceConnection)` signature and two-argument `read` both
+  predate 3.11. Its `setParameters` is behaviourally identical to
+  this one, so with this guard in place the two now program the chip
+  the same way — and the Icom still fails, which is what rules the
+  chip's *configuration* out entirely.)
 * **The Linux `cp210x` kernel driver**, which is what the working
   `rigctl` run goes through, never writes the structure blind: it does
   `GET_FLOW`, modifies the handshake bits, and writes it back,

--- a/native/third_party/usb-serial-for-android/PATCHES.md
+++ b/native/third_party/usb-serial-for-android/PATCHES.md
@@ -1,0 +1,68 @@
+# Patches carried against usb-serial-for-android
+
+The vendored `java/` tree is upstream tag **3.11.0**, and was pristine
+until 2026-08-23. Every deviation from upstream is listed here and is
+marked in the source with a `// SSTVAE PATCH` comment naming this file,
+so a future re-vendor cannot silently drop one.
+
+Keep this list short. A patch here is a maintenance cost paid on every
+upgrade; prefer fixing things in `core/rig/android/java/`, which is
+ours, whenever the behaviour can be reached from outside the library.
+
+---
+
+## 1. `Cp21xxSerialDriver.openInt()` — do not write SET_FLOW for "none"
+
+**Upstream:**
+
+```java
+setConfigSingle(SILABSER_IFC_ENABLE_REQUEST_CODE, UART_ENABLE);
+setConfigSingle(SILABSER_SET_MHS_REQUEST_CODE, ...);
+setFlowControl(mFlowControl);
+```
+
+**Here:** the last call is guarded by `if (mFlowControl !=
+FlowControl.NONE)`.
+
+**Why.** An Icom IC-9700 would not answer a single CI-V frame from this
+app on a phone, while `rigctl -m 3081 -r /dev/ttyUSB0 -s 19200` on the
+same cable answered instantly. The app's own trace showed a correct
+frame reaching the transport (`-> rig 6: fe fe a2 e0 03 fd`) against a
+CP2102N at 19200 8N1, one vendor-class interface, two endpoints,
+`Cp21xxSerialDriver` port 0 of 1 — every control transfer returning 0,
+every bulk write returning its length, and nothing ever coming back.
+
+Setting a CP210x's flow control to `NONE` is not a no-op: it sends the
+chip a 16-byte `SET_FLOW` structure of zeroes, clobbering
+`ulControlHandshake`, `ulFlowReplace`, `ulXonLimit` and `ulXoffLimit` in
+one blind write. Two independent implementations that work with this
+chip do not do that:
+
+* **FT8TW** drives the same radio on the same phone. Its fork of this
+  file has no `SILABSER_SET_FLOW_REQUEST_CODE` constant and no
+  `setFlowControl` method at all — `openInt` is `IFC_ENABLE` plus
+  `SET_MHS` and stops.
+* **The Linux `cp210x` kernel driver**, which is what the working
+  `rigctl` run goes through, never writes the structure blind: it does
+  `GET_FLOW`, modifies the handshake bits, and writes it back,
+  preserving `ulXonLimit`/`ulXoffLimit` — it only ever sets them itself
+  (to 128) when IXOFF is actually requested.
+
+The kernel also carries erratum **CP2102N_E104**: firmware `<= 0x10004`
+interprets `ulXonLimit` as `ulFlowReplace`, i.e. the chip reads the
+structure one word out of alignment, which makes a blind 16-byte write
+land partly on fields the sender never meant to set — and makes the
+chip's own `ulXoffLimit` come from past the end of the buffer. Linux's
+response is to declare flow control unsupported on those parts.
+
+**Guarded rather than deleted** so RTS/CTS and XON/XOFF still work
+where an operator asks for them: the write is only skipped in the case
+where it has nothing to say. A chip opened fresh is already in its
+configured default, which is no flow control, so there is nothing to
+undo. `SerialBridge.applyFlowControl` carries the matching early
+return; both are needed, because `openInt` does this write before
+anything of ours is asked.
+
+**On upgrade:** check whether upstream has adopted a read-modify-write
+`SET_FLOW` (or a CP2102N firmware-version quirk like the kernel's). If
+it has, drop this patch and re-test against an Icom.

--- a/native/third_party/usb-serial-for-android/README.md
+++ b/native/third_party/usb-serial-for-android/README.md
@@ -42,6 +42,23 @@ this file**, not bumping a version string. Do it deliberately, in step
 with checking that `SerialBridge.java` still compiles -- upstream has
 changed the `read` and flow-control signatures within the 3.x series.
 
+## `PATCHES.md` — deviations from the release
+
+`java/` was a byte-for-byte drop of the release until 2026-08-23 and is
+no longer. **One line is patched**, and `PATCHES.md` is the exhaustive
+list: `Cp21xxSerialDriver.openInt()` no longer writes the CP210x
+`SET_FLOW` structure when no flow control is wanted, because sending
+that chip sixteen zero bytes stopped an IC-9700 answering CI-V at all.
+Read that file before re-vendoring -- every deviation is also marked in
+the source with `// SSTVAE PATCH`, so a replacement drop cannot lose one
+without the marker going with it.
+
+The rule the `shim/` directory exists for still stands and is why there
+is exactly one patch: **anything reachable from outside the library
+belongs in `core/rig/android/java/`**, which is ours. This one is not --
+`openInt` runs inside `port.open()`, before any of our code is asked
+anything.
+
 ## `shim/` — one class Gradle would have generated
 
 Gradle synthesises a `BuildConfig` per Android *module*, in that module's
@@ -53,10 +70,11 @@ at all for the library's package — so `Ch34xSerialDriver` and
 full Gradle run.
 
 `shim/com/hoho/android/usbserial/BuildConfig.java` supplies it. It is in
-`shim/` rather than in `java/` precisely so `java/` stays a byte-for-byte
-drop of the release: an edit in there would have to be diffed back out
-at every update, which is the sort of thing that gets forgotten once and
-then silently reverted.
+`shim/` rather than in `java/` to keep edits out of the upstream drop:
+anything in there has to be diffed back out at every update, which is
+the sort of thing that gets forgotten once and then silently reverted.
+`PATCHES.md` above exists because one such edit turned out to be
+unavoidable; this one was not.
 
 `DEBUG` is `false`, and that is the correct value rather than a
 convenient one. The single place upstream reads it

--- a/native/third_party/usb-serial-for-android/REUSE.toml
+++ b/native/third_party/usb-serial-for-android/REUSE.toml
@@ -19,6 +19,14 @@ SPDX-FileCopyrightText = "Copyright the SSTVAE authors"
 SPDX-License-Identifier = "Artistic-2.0"
 
 [[annotations]]
-path = ["LICENSE", "README.md"]
+path = "LICENSE"
 SPDX-FileCopyrightText = "Copyright 2011-2013 Google Inc., Copyright 2013 Mike Wakerly and contributors"
 SPDX-License-Identifier = "MIT"
+
+# Ours, like `shim/`: `README.md` says why this is vendored and
+# `PATCHES.md` is the exhaustive list of deviations from the release.
+# Neither is upstream's text.
+[[annotations]]
+path = ["README.md", "PATCHES.md"]
+SPDX-FileCopyrightText = "Copyright the SSTVAE authors"
+SPDX-License-Identifier = "Artistic-2.0"

--- a/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriver.java
+++ b/native/third_party/usb-serial-for-android/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriver.java
@@ -154,7 +154,15 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
 
             setConfigSingle(SILABSER_IFC_ENABLE_REQUEST_CODE, UART_ENABLE);
             setConfigSingle(SILABSER_SET_MHS_REQUEST_CODE, (dtr ? DTR_ENABLE : DTR_DISABLE) | (rts ? RTS_ENABLE : RTS_DISABLE));
-            setFlowControl(mFlowControl);
+            // SSTVAE PATCH -- see ../../../../../../../../PATCHES.md
+            // Do not write SET_FLOW when no flow control is wanted. An
+            // IC-9700's CP2102N accepted every control transfer and every
+            // bulk write and never answered a CI-V frame until this write
+            // was removed. Guarded rather than deleted so RTS/CTS and
+            // XON/XOFF are unaffected.
+            if (mFlowControl != FlowControl.NONE) {
+                setFlowControl(mFlowControl);
+            }
         }
 
         @Override

--- a/tools/check_android_java.sh
+++ b/tools/check_android_java.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Type-check the app's Android Java without the Android SDK.
+#
+# **Written because a one-line Java mistake cost a build round on
+# hardware.** `native/`'s C++ is checked six ways -- ctest, the golden
+# vectors, `pytest --native`, `check_includes.py`, `check_layering.py`, a
+# mingw cross-compile -- and its Java was checked by nobody until an APK
+# was built. `catch (IOException | UnsupportedOperationException |
+# RuntimeException e)` is not a syntax error and no parser would have
+# caught it; javac catches it in two seconds, and the only thing missing
+# was an `android.jar`.
+#
+# Robolectric's `android-all` is that jar, on Maven Central, pinned and
+# checksummed like onnxruntime, Hamlib and NSIS. It is the real API
+# surface rather than a stub set, so it cannot quietly drift from what
+# the app compiles against. **This checks types, not behaviour** -- it
+# cannot run anything, and Robolectric's implementations are not
+# Android's.
+#
+# Usage: tools/check_android_java.sh [--cache DIR]
+set -euo pipefail
+
+# Pinned, with a checksum, for the reason `native/cmake/onnxruntime.cmake`
+# records: a version resolved at build time makes a build's success a
+# property of somebody else's current contents.
+ANDROID_ALL_VERSION="14-robolectric-10818077"
+ANDROID_ALL_SHA256="6be2218c6a53fe3c57bc22ebdc723edcb7270a8a6f187545708aa5c0ed813977"
+ANDROID_ALL_URL="https://repo1.maven.org/maven2/org/robolectric/android-all/${ANDROID_ALL_VERSION}/android-all-${ANDROID_ALL_VERSION}.jar"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cache="${SSTVAE_ANDROID_JAR_CACHE:-${TMPDIR:-/tmp}/sstvae-android-jar}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cache) cache="$2"; shift 2 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if ! command -v javac >/dev/null 2>&1; then
+    echo "check_android_java: no javac on PATH; skipping" >&2
+    exit 0
+fi
+
+mkdir -p "$cache"
+jar="$cache/android-all-${ANDROID_ALL_VERSION}.jar"
+if [ ! -f "$jar" ]; then
+    echo "check_android_java: fetching android-all ${ANDROID_ALL_VERSION} (~130 MB)"
+    if ! curl -fsSL --max-time 600 -o "$jar.part" "$ANDROID_ALL_URL"; then
+        rm -f "$jar.part"
+        echo "check_android_java: could not fetch the Android jar; skipping" >&2
+        exit 0
+    fi
+    # Renamed only after the checksum passes, like `qt_fetcher`: a
+    # truncated jar left in the cache would be found on the next run and
+    # fail a long way from its cause.
+    got="$(sha256sum "$jar.part" | cut -d' ' -f1)"
+    if [ "$got" != "$ANDROID_ALL_SHA256" ]; then
+        rm -f "$jar.part"
+        echo "check_android_java: sha256 mismatch: got $got" >&2
+        exit 1
+    fi
+    mv "$jar.part" "$jar"
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Three classes that are neither `android.*` nor ours: two from AndroidX
+# and one from Qt. Stubbed rather than fetched, and the trade is worth
+# stating -- a stub makes the *import* resolve and pins the *signature we
+# use*, so a wrong argument list here still fails; what it cannot catch
+# is upstream changing that signature. `IntDef` is `@Retention(SOURCE)`
+# and has no runtime meaning at all. `FileProvider.getUriForFile` has had
+# this shape for a decade. `QtActivity` is only ever named as a class
+# literal, and Qt's own jar is not on Maven Central to fetch.
+mkdir -p "$work/stub/androidx/annotation" "$work/stub/androidx/core/content" \
+         "$work/stub/org/qtproject/qt/android/bindings"
+cat > "$work/stub/androidx/annotation/IntDef.java" <<'EOF'
+package androidx.annotation;
+import java.lang.annotation.*;
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.PARAMETER,
+         ElementType.FIELD, ElementType.LOCAL_VARIABLE})
+public @interface IntDef {
+    int[] value() default {};
+    boolean flag() default false;
+    boolean open() default false;
+}
+EOF
+cat > "$work/stub/androidx/core/content/FileProvider.java" <<'EOF'
+package androidx.core.content;
+import android.content.Context;
+import android.net.Uri;
+import java.io.File;
+public class FileProvider {
+    public static Uri getUriForFile(Context context, String authority, File file) {
+        throw new UnsupportedOperationException("stub");
+    }
+    public static Uri getUriForFile(Context context, String authority, File file,
+                                    String displayName) {
+        throw new UnsupportedOperationException("stub");
+    }
+}
+EOF
+cat > "$work/stub/org/qtproject/qt/android/bindings/QtActivity.java" <<'EOF'
+package org.qtproject.qt.android.bindings;
+public class QtActivity extends android.app.Activity {}
+EOF
+
+# Every Java source the APK carries, in the same layout
+# `native/android-app/CMakeLists.txt` assembles. The vendored library is
+# on the sourcepath rather than the file list: it is compiled only as far
+# as our code reaches into it, which is what we want to check.
+sources="$work/stub"
+for d in \
+    "$repo_root/native/android-app/android/src" \
+    "$repo_root/native/core/audio/android/java" \
+    "$repo_root/native/core/rig/android/java" \
+    "$repo_root/native/third_party/usb-serial-for-android/java" \
+    "$repo_root/native/third_party/usb-serial-for-android/shim"
+do
+    sources="$sources:$d"
+done
+
+mapfile -t files < <(find \
+    "$repo_root/native/android-app/android/src" \
+    "$repo_root/native/core/audio/android/java" \
+    "$repo_root/native/core/rig/android/java" \
+    -name '*.java' | sort)
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "check_android_java: no sources found" >&2
+    exit 1
+fi
+
+# `-nowarn` because Robolectric's jar is a different API level than the
+# app targets and the deprecation noise is not ours to act on; a real
+# error still fails.
+#
+# **javac's exit status, not whether anything was printed.** Piping it
+# straight into `grep` and testing that reads correctly and is wrong
+# under `pipefail`, which reports the *pipeline's* first failure -- so a
+# failing javac made the `if` false and the check passed while printing
+# its own errors. Caught on this script's first run, by the compile
+# errors it was written to find.
+set +e
+output="$(javac -nowarn -proc:none -d "$work/out" \
+    -cp "$jar" -sourcepath "$sources" "${files[@]}" 2>&1)"
+status=$?
+set -e
+
+# JAVA_TOOL_OPTIONS is echoed by the JVM when the environment sets it,
+# which some sandboxes do; `Note:` lines are deprecation summaries.
+filtered="$(printf '%s\n' "$output" | grep -v 'JAVA_TOOL_OPTIONS' | grep -v '^Note:' || true)"
+
+if [ "$status" -ne 0 ]; then
+    printf '%s\n' "$filtered" >&2
+    echo "check_android_java: FAILED" >&2
+    exit 1
+fi
+
+echo "android java ok (${#files[@]} source files checked)"


### PR DESCRIPTION
CAT worked on an Elecraft K4 over USB and failed completely on an IC-9700 and an IC-7100. Confirmed fixed on the IC-9700 (Andrew, on hardware).

## The bug

`usb:VID:PID` names a *kind* of device, not a device. An IC-9700 presents its CI-V port and its USB serial function as **two separate USB devices sharing `10c4:ea60`**, each with one interface and one port — so the id named both, the picker showed two identical rows, and `findUsbDevice` returned whichever `getDeviceList()` yielded first. Out of a `HashMap`, so not reliably the same one twice.

The app was writing to a real, correctly configured, healthy CP2102N that is not wired to the radio's CI-V engine. From above that is indistinguishable from a radio ignoring us, which is why every chip-level measurement came back clean: no errors, nothing held, CTS high, bytes accepted. All true, all of the wrong chip.

Ids now carry `@unit` beside the existing `#port`. The two are **not the same axis** — `#port` is one driver's several UARTs (a CP2105), `@unit` is several devices with one VID:PID — and conflating them was the bug. Both suffixes are omitted at zero, so an id saved before they existed still means the first port of the first device.

Units are ordered by `getDeviceName()`, the only ordering available before permission is granted. That is not promised across a replug, so the row label says "(1 of 2)" and the operator picks: nothing readable distinguishes an Icom's CI-V port from its data port, and this layer should not pretend otherwise. The marker is a *prefix* because put after the name it is the first thing a narrow combo elides, which leaves two identical rows again by a different route.

## What made it findable

The bug was invisible for several rounds because nothing below Hamlib could speak. Two sinks now feed one ring:

- **`rig::set_debug_sink`** — Hamlib's own trace. `SSTVAE_HAMLIB_DEBUG` writes to stderr, which a phone discards, so on the platform where rig control is newest the artifact that says how far `rig_open` got was unreachable. Registered only while a sink exists, since `rig_debug` writes to stderr *or* to a callback and one left registered swallows the trace everywhere else — the test captures stderr and requires it back, mutation-tested.
- **`core/rig/trace.hpp`** — our half, Qt-free and Hamlib-free in `sstvae_core` so a `--no-rig` build tests every line of it. The bridge logs each direction's bytes in Hamlib's own `dump_hex` spelling (after the transport accepted them, never before — logged on the way in it would claim "delivered" for a write that threw); the transport logs the resolved line settings, which driver and interface the USB layer picked, and the chip's own `GET_COMM_STATUS`.

Off costs one relaxed atomic load. **Settings → Rig control → Log rig traffic**, off by default, keeps 600 lines and mirrors to logcat.

## Also here

- **`tools/check_android_java.sh`**, wired into CI. `native/`'s C++ is checked six ways and its Java was checked by nobody until an APK was built on a machine with an NDK. Robolectric's `android-all` from Maven Central, pinned with a sha256 — the real API surface, not a stub set. Verified by reintroducing the bug that motivated it.
- **`Default` control-line states now mean *asserted*.** Hamlib never raises DTR or RTS; `src/rig.c` says so outright and relies on the OS having done it, dropping only the PTT line. A bridged transport reaches no `serial_open`. Desktop parity, and **not** the Icom fix — Andrew's point that CI-V has no flow control and an Icom uses those lines only for keying is correct, and the docs say so.
- **One patch carried against the vendored `usb-serial-for-android`**: `Cp21xxSerialDriver.openInt()` no longer writes the CP210x `SET_FLOW` structure when no flow control is wanted. Also not the fix, kept because both reference implementations avoid the blind sixteen-zero-byte write, one of them is the kernel, and erratum CP2102N_E104 is real. `PATCHES.md` is the exhaustive list and says plainly that it fixed nothing.
- **Both device lists sorted** — `findAllDrivers` walks that same `HashMap` and `getBondedDevices()` returns a `Set`.
- Wrapping delegates on the device and radio pickers, so a long row is legible on a phone.

## Testing

- 20/20 ctest, `check_includes`, `check_layering`, `check_xml_comments`, `check_android_java` all clean.
- New assertions in `test_rig_hamlib.cpp`, `test_rig_bridge.cpp`, `test_rig_bridged.cpp`; the sink-removal, trace-placement and line-state resolution checks are each mutation-tested.
- **On hardware:** IC-9700 CAT confirmed working. IC-7100 untested but very likely the same two-port cause. Bluetooth still untested for want of a device.

The docs keep the wrong turns rather than tidying them away — a misplaced liveness probe on the thread whose liveness was in question, two status fields I over-sold, and the class javadoc whose "two identical adapters are indistinguishable and the first wins" is exactly how this bug survived review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YWM59wJ1LpbMkx9Jo6uQG

---
_Generated by [Claude Code](https://claude.ai/code/session_019YWM59wJ1LpbMkx9Jo6uQG)_