### PR TITLE
android: group Settings into collapsible sections

### DIFF
--- a/native/android-app/CMakeLists.txt
+++ b/native/android-app/CMakeLists.txt
@@ -92,7 +92,7 @@ add_subdirectory(.. sstvae_native EXCLUDE_FROM_ALL)
 qt_add_executable(sstvae_android main.cpp listener.cpp session.cpp service_jni.cpp java_fetcher.cpp
     assets.cpp waterfall.cpp pictures.cpp composition.cpp transmitter.cpp rigcontrol.cpp)
 qt_add_qml_module(sstvae_android URI SSTVAE VERSION 1.0
-    QML_FILES Main.qml LevelMeter.qml CropView.qml TransmitPane.qml RigPane.qml)
+    QML_FILES Main.qml LevelMeter.qml CropView.qml TransmitPane.qml RigPane.qml SettingsSection.qml)
 target_link_libraries(sstvae_android PRIVATE Qt6::Quick Qt6::Gui sstvae_core
                                              sstvae_audio_android
                                              sstvae_codec)

--- a/native/android-app/Main.qml
+++ b/native/android-app/Main.qml
@@ -804,6 +804,93 @@ ApplicationWindow {
                     Layout.rightMargin: 12
                     wrapMode: Text.Wrap
                 }
+
+                // Rig traffic logging -- Hamlib's own CAT trace. It moved
+                // out of the Rig control section (where it sat in the
+                // middle of the connection controls) to here beside the
+                // other debug toggle. Shown only when rig control is on,
+                // so an operator with no cable never sees a rig knob in
+                // Advanced; there is nothing to log otherwise.
+                Label {
+                    text: "Rig traffic"
+                    font.bold: true
+                    font.pixelSize: 12
+                    color: "#888"
+                    visible: rigControl.enabled
+                    Layout.leftMargin: 12
+                    Layout.topMargin: 8
+                }
+                Switch {
+                    text: "Log rig traffic"
+                    visible: rigControl.enabled
+                    Layout.leftMargin: 4
+                    checked: rigControl.debugLog
+                    onToggled: rigControl.debugLog = checked
+                }
+                Label {
+                    text: "For bug reports. Records every CAT command and reply, "
+                          + "which slows things down and fills the log quickly — "
+                          + "leave it off unless a radio will not work."
+                    font.pixelSize: 11
+                    color: "#666"
+                    visible: rigControl.enabled
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
+                ColumnLayout {
+                    visible: rigControl.enabled && rigControl.debugLog
+                    spacing: 4
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+
+                    RowLayout {
+                        // **Refreshed by hand, not bound to the
+                        // property.** The rig republishes at 1 Hz, and a
+                        // bound text property would reset this view's
+                        // scroll position every second — unreadable in
+                        // exactly the situation it is for. A trace is
+                        // read after the failure anyway.
+                        Button {
+                            text: "Refresh"
+                            onClicked: logArea.text = rigControl.logText
+                        }
+                        Button {
+                            text: "Copy"
+                            onClicked: {
+                                logArea.selectAll();
+                                logArea.copy();
+                                logArea.deselect();
+                            }
+                        }
+                        Button {
+                            text: "Clear"
+                            onClicked: {
+                                rigControl.clearLog();
+                                logArea.text = "";
+                            }
+                        }
+                    }
+
+                    ScrollView {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 260
+                        clip: true
+
+                        TextArea {
+                            id: logArea
+                            readOnly: true
+                            // No wrapping: a CI-V frame dump read across
+                            // wrapped lines is worse than one read sideways.
+                            wrapMode: Text.NoWrap
+                            font.family: "monospace"
+                            font.pixelSize: 10
+                            placeholderText: "Press Refresh after the radio fails to connect."
+                        }
+                    }
+                }
             }
 
             // Breathing room under the last section, so it is not

--- a/native/android-app/Main.qml
+++ b/native/android-app/Main.qml
@@ -374,19 +374,23 @@ ApplicationWindow {
 
         // ---- Settings -----------------------------------------------
         //
-        // **Scrolled, because a settings page that does not fit does not
-        // compress -- it truncates**, and what goes first is the
-        // explanatory text at the bottom of the last section. The
-        // desktop has the identical construct for the identical reason
-        // (`QScrollArea` per settings tab): there is no default size
-        // that is right on every panel, and a reader cannot tell
-        // clipped text from text that simply ends. It became true here
-        // the moment the transmit settings landed -- before them the
-        // page fitted, and "Model" was the first thing to disappear
-        // behind the tab bar.
+        // Grouped into collapsible sections (`SettingsSection.qml`)
+        // rather than one flat scroll of every control. The page opens
+        // as a short list of headings an operator can scan -- Receive,
+        // Transmit, Rig control, Model, Advanced -- with the debug
+        // toggle and the multi-sentence help text folded away until a
+        // section is tapped open. See that file for why sub-sections
+        // rather than a second tab bar, and why folding keeps the back
+        // gesture simple.
         //
-        // Horizontal scrolling off: the width is the window's, so a
-        // horizontal bar could only ever mean a label refusing to wrap.
+        // **Still scrolled, because a settings page that does not fit
+        // does not compress -- it truncates**, and what goes first is
+        // the explanatory text at the bottom. Even collapsed the list of
+        // headings can outrun a short phone once every section is open,
+        // and the desktop has the identical construct for the identical
+        // reason (`QScrollArea` per settings tab). Horizontal scrolling
+        // off: the width is the window's, so a horizontal bar could only
+        // ever mean a label refusing to wrap.
         ScrollView {
             id: settingsScroll
             contentWidth: availableWidth
@@ -402,369 +406,407 @@ ApplicationWindow {
             // symptom is not a missing scrollbar but text running off the
             // right edge with nothing to scroll it back.
             width: settingsScroll.availableWidth
-            spacing: 12
+            spacing: 0
 
-            Label {
-                text: "Audio input"
-                font.bold: true
-                Layout.margins: 12
-                Layout.bottomMargin: 0
-            }
-            ComboBox {
-                id: deviceBox
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                model: listener.inputDevices
-                enabled: !listener.listening
-            }
-            Label {
-                text: listener.listening ? listener.audioRoute
-                                         : "Choose before starting; the device cannot change mid-session."
-                font.family: "monospace"
-                font.pixelSize: 11
-                color: "#666"
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
-            }
-            // **One button, both directions.** It sits under "Audio
-            // input" because that is where the first device picker is,
-            // but plugging in a USB interface adds a capture *and* a
-            // playback device at the same instant, and a rescan that
-            // refreshed only the list you happened to be looking at is
-            // a button that appears not to work. Two buttons would be
-            // worse: two lists that can disagree about when they were
-            // last looked at.
-            Button {
-                text: "Rescan audio devices"
-                Layout.leftMargin: 12
-                enabled: !listener.listening && !transmitter.transmitting
-                onClicked: {
-                    listener.refreshDevices()
-                    transmitter.refreshDevices()
+            // ---- Receive --------------------------------------------
+            SettingsSection {
+                title: "Receive"
+
+                Label {
+                    text: "Audio input"
+                    font.bold: true
+                    font.pixelSize: 12
+                    color: "#888"
+                    Layout.leftMargin: 12
                 }
-            }
-            Label {
-                text: "Refreshes both the input and output lists."
-                font.pixelSize: 11
-                color: "#666"
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
-            }
-
-            Label {
-                text: "Station"
-                font.bold: true
-                Layout.margins: 12
-                Layout.bottomMargin: 0
-            }
-            TextField {
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                placeholderText: "Callsign"
-                text: transmitter.callsign
-                // Written on every keystroke rather than on editing
-                // finished: a phone keyboard is dismissed by the back
-                // gesture as often as by a done key, and that path fires
-                // no editingFinished at all — so the callsign would be
-                // silently lost by the most ordinary way of leaving the
-                // field.
-                onTextEdited: transmitter.callsign = text
-                inputMethodHints: Qt.ImhUppercaseOnly | Qt.ImhNoPredictiveText
-            }
-            Label {
-                text: "Sent on the beacon carrier with every transmission, and "
-                      + "used by the CW ID. Every receiver decodes it, so nothing "
-                      + "is written into the picture."
-                font.pixelSize: 11
-                color: "#666"
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
-            }
-
-            Label {
-                text: "Transmit"
-                font.bold: true
-                Layout.margins: 12
-                Layout.bottomMargin: 0
-            }
-            ComboBox {
-                id: outputBox
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                model: transmitter.outputDevices
-                enabled: !transmitter.transmitting
-                currentIndex: Math.max(0, model.indexOf(transmitter.outputDevice))
-                onActivated: transmitter.outputDevice = currentValue
-            }
-            RowLayout {
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                Label { text: "Level" }
-                Slider {
+                ComboBox {
+                    id: deviceBox
                     Layout.fillWidth: true
-                    from: 0.1
-                    to: 1.0
-                    value: transmitter.level
-                    enabled: !transmitter.transmitting
-                    onMoved: transmitter.level = value
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    model: listener.inputDevices
+                    enabled: !listener.listening
                 }
                 Label {
-                    text: Math.round(transmitter.level * 100) + "%"
+                    text: listener.listening ? listener.audioRoute
+                                             : "Choose before starting; the device cannot change mid-session."
+                    font.family: "monospace"
+                    font.pixelSize: 11
                     color: "#666"
-                }
-            }
-            Label {
-                text: "Set this so the radio's ALC barely moves. The waveform is "
-                      + "already clipped to its designed 4.2 dB peak-to-average; "
-                      + "driving it harder splatters rather than getting out further."
-                font.pixelSize: 11
-                color: "#666"
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
-            }
-
-            Switch {
-                text: "VOX leader tone"
-                Layout.leftMargin: 4
-                checked: transmitter.voxLead > 0
-                enabled: !transmitter.transmitting
-                onToggled: transmitter.voxLead = checked ? 0.5 : 0.0
-            }
-            Label {
-                text: "Half a second of swept tone before each transmission, to "
-                      + "bring a VOX-keyed radio up before the signal starts. "
-                      + "Leave it off if the radio is keyed any other way — it is "
-                      + "airtime."
-                font.pixelSize: 11
-                color: "#666"
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
-            }
-
-            Switch {
-                text: "CW identification"
-                Layout.leftMargin: 4
-                checked: transmitter.cwId
-                enabled: !transmitter.transmitting
-                onToggled: transmitter.cwId = checked
-            }
-            TextField {
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                visible: transmitter.cwId
-                text: transmitter.cwMessage
-                onTextEdited: transmitter.cwMessage = text
-            }
-            Label {
-                text: "Morse at 18 wpm after the picture, under the same key-up. "
-                      + "{callsign} is replaced. The default also advertises the "
-                      + "mode, so someone who hears the signal and does not know "
-                      + "what it is can find out."
-                font.pixelSize: 11
-                color: "#666"
-                visible: transmitter.cwId
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
-            }
-            // Shown here as well as on the transmit screen, because this
-            // is the screen the fix is on. Send is disabled while this
-            // has anything to say.
-            Label {
-                text: transmitter.cwIdProblem
-                font.pixelSize: 11
-                color: "#c00"
-                visible: text.length > 0
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
-            }
-
-            Label {
-                text: "Receive"
-                font.bold: true
-                Layout.margins: 12
-                Layout.bottomMargin: 0
-            }
-            // Both take effect on the *next* Start, not mid-session --
-            // same as the device picker above, and disabled the same
-            // way, so there is nothing here that looks live while
-            // listening and silently isn't.
-            Switch {
-                text: "Wide frequency search"
-                Layout.leftMargin: 4
-                enabled: !listener.listening
-                checked: listener.blindWide
-                onToggled: listener.blindWide = checked
-            }
-            Label {
-                text: "Picks up a station whose dial is off by up to 625 Hz, at "
-                      + "some extra CPU cost. Only affects picking up a "
-                      + "transmission already in progress — finding the *start* "
-                      + "of one is always this wide, because there it's free."
-                font.pixelSize: 11
-                color: "#666"
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
-            }
-            RowLayout {
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                Label { text: "Track drift" }
-                ComboBox {
-                    id: driftTrackBox
                     Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
+                // **One button, both directions.** It sits under "Audio
+                // input" because that is where the first device picker
+                // is, but plugging in a USB interface adds a capture
+                // *and* a playback device at the same instant, and a
+                // rescan that refreshed only the list you happened to be
+                // looking at is a button that appears not to work. Two
+                // buttons would be worse: two lists that can disagree
+                // about when they were last looked at.
+                Button {
+                    text: "Rescan audio devices"
+                    Layout.leftMargin: 12
+                    enabled: !listener.listening && !transmitter.transmitting
+                    onClicked: {
+                        listener.refreshDevices()
+                        transmitter.refreshDevices()
+                    }
+                }
+                Label {
+                    text: "Refreshes both the input and output lists."
+                    font.pixelSize: 11
+                    color: "#666"
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
+
+                Label {
+                    text: "Tuning"
+                    font.bold: true
+                    font.pixelSize: 12
+                    color: "#888"
+                    Layout.leftMargin: 12
+                    Layout.topMargin: 8
+                }
+                // Both take effect on the *next* Start, not mid-session
+                // -- same as the device picker above, and disabled the
+                // same way, so there is nothing here that looks live
+                // while listening and silently isn't.
+                Switch {
+                    text: "Wide frequency search"
+                    Layout.leftMargin: 4
                     enabled: !listener.listening
-                    textRole: "text"
-                    valueRole: "value"
-                    model: [
-                        { text: "Off", value: "off" },
-                        { text: "Slow (drifting radio)", value: "slow" },
-                        { text: "Fast (VHF, satellite)", value: "fast" }
-                    ]
-                    Component.onCompleted: currentIndex = indexOfValue(listener.driftTrack)
-                    onActivated: listener.driftTrack = currentValue
+                    checked: listener.blindWide
+                    onToggled: listener.blindWide = checked
+                }
+                Label {
+                    text: "Picks up a station whose dial is off by up to 625 Hz, at "
+                          + "some extra CPU cost. Only affects picking up a "
+                          + "transmission already in progress — finding the *start* "
+                          + "of one is always this wide, because there it's free."
+                    font.pixelSize: 11
+                    color: "#666"
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    Label { text: "Track drift" }
+                    ComboBox {
+                        id: driftTrackBox
+                        Layout.fillWidth: true
+                        enabled: !listener.listening
+                        textRole: "text"
+                        valueRole: "value"
+                        model: [
+                            { text: "Off", value: "off" },
+                            { text: "Slow (drifting radio)", value: "slow" },
+                            { text: "Fast (VHF, satellite)", value: "fast" }
+                        ]
+                        Component.onCompleted: currentIndex = indexOfValue(listener.driftTrack)
+                        onActivated: listener.driftTrack = currentValue
+                    }
+                }
+                Label {
+                    // Off/slow/fast, not a gain: the two settings are
+                    // not more and less of one thing, so "fast" is not
+                    // simply better at everything "slow" does — see the
+                    // desktop dialog's identical note.
+                    text: "Follows a carrier that moves during a transmission. Off "
+                          + "suits HF with a modern radio, which usually doesn't "
+                          + "drift far enough to matter. Fast is for VHF, satellite "
+                          + "and EME use, where it costs more if the signal is "
+                          + "fading heavily rather than drifting."
+                    font.pixelSize: 11
+                    color: "#666"
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
+
+                Label {
+                    text: "Received pictures"
+                    font.bold: true
+                    font.pixelSize: 12
+                    color: "#888"
+                    Layout.leftMargin: 12
+                    Layout.topMargin: 8
+                }
+                Switch {
+                    text: "Save to gallery"
+                    Layout.leftMargin: 4
+                    checked: listener.saveToGallery
+                    onToggled: listener.saveToGallery = checked
+                }
+                Label {
+                    // Says what it does *and* what follows from it. The
+                    // consequence is the part an operator cannot guess:
+                    // "save to gallery" sounds local, and on a phone
+                    // with photo backup switched on it is not.
+                    text: "Copies each reception into Pictures/SSTVAE, where the "
+                          + "gallery and Google Photos will show it as a device "
+                          + "folder. Whatever arrives on the band goes into your "
+                          + "camera roll — and into your photo backup, if you have "
+                          + "one. Receptions are always kept in the app either way."
+                    font.pixelSize: 11
+                    color: "#666"
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
+                Label {
+                    // The export runs in the service, after the operator
+                    // has stopped looking, so this is the only place a
+                    // failure can surface at all. Cleared by the next
+                    // success.
+                    text: "Last export failed: " + listener.galleryError
+                    visible: listener.saveToGallery && listener.galleryError !== ""
+                    font.pixelSize: 11
+                    color: "#a60"
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
                 }
             }
-            Label {
-                // Off/slow/fast, not a gain: the two settings are not
-                // more and less of one thing, so "fast" is not simply
-                // better at everything "slow" does — see the desktop
-                // dialog's identical note.
-                text: "Follows a carrier that moves during a transmission. Off "
-                      + "suits HF with a modern radio, which usually doesn't "
-                      + "drift far enough to matter. Fast is for VHF, satellite "
-                      + "and EME use, where it costs more if the signal is "
-                      + "fading heavily rather than drifting."
-                font.pixelSize: 11
-                color: "#666"
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
+
+            // ---- Transmit -------------------------------------------
+            SettingsSection {
+                title: "Transmit"
+                summary: transmitter.callsign !== "" ? transmitter.callsign
+                                                     : "No callsign set"
+
+                Label {
+                    text: "Callsign"
+                    font.bold: true
+                    font.pixelSize: 12
+                    color: "#888"
+                    Layout.leftMargin: 12
+                }
+                TextField {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    placeholderText: "Callsign"
+                    text: transmitter.callsign
+                    // Written on every keystroke rather than on editing
+                    // finished: a phone keyboard is dismissed by the
+                    // back gesture as often as by a done key, and that
+                    // path fires no editingFinished at all — so the
+                    // callsign would be silently lost by the most
+                    // ordinary way of leaving the field.
+                    onTextEdited: transmitter.callsign = text
+                    inputMethodHints: Qt.ImhUppercaseOnly | Qt.ImhNoPredictiveText
+                }
+                Label {
+                    text: "Sent on the beacon carrier with every transmission, and "
+                          + "used by the CW ID. Every receiver decodes it, so nothing "
+                          + "is written into the picture."
+                    font.pixelSize: 11
+                    color: "#666"
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
+
+                Label {
+                    text: "Output"
+                    font.bold: true
+                    font.pixelSize: 12
+                    color: "#888"
+                    Layout.leftMargin: 12
+                    Layout.topMargin: 8
+                }
+                ComboBox {
+                    id: outputBox
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    model: transmitter.outputDevices
+                    enabled: !transmitter.transmitting
+                    currentIndex: Math.max(0, model.indexOf(transmitter.outputDevice))
+                    onActivated: transmitter.outputDevice = currentValue
+                }
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    Label { text: "Level" }
+                    Slider {
+                        Layout.fillWidth: true
+                        from: 0.1
+                        to: 1.0
+                        value: transmitter.level
+                        enabled: !transmitter.transmitting
+                        onMoved: transmitter.level = value
+                    }
+                    Label {
+                        text: Math.round(transmitter.level * 100) + "%"
+                        color: "#666"
+                    }
+                }
+                Label {
+                    text: "Set this so the radio's ALC barely moves. The waveform is "
+                          + "already clipped to its designed 4.2 dB peak-to-average; "
+                          + "driving it harder splatters rather than getting out further."
+                    font.pixelSize: 11
+                    color: "#666"
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
+
+                Switch {
+                    text: "VOX leader tone"
+                    Layout.leftMargin: 4
+                    Layout.topMargin: 8
+                    checked: transmitter.voxLead > 0
+                    enabled: !transmitter.transmitting
+                    onToggled: transmitter.voxLead = checked ? 0.5 : 0.0
+                }
+                Label {
+                    text: "Half a second of swept tone before each transmission, to "
+                          + "bring a VOX-keyed radio up before the signal starts. "
+                          + "Leave it off if the radio is keyed any other way — it is "
+                          + "airtime."
+                    font.pixelSize: 11
+                    color: "#666"
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
+
+                Switch {
+                    text: "CW identification"
+                    Layout.leftMargin: 4
+                    checked: transmitter.cwId
+                    enabled: !transmitter.transmitting
+                    onToggled: transmitter.cwId = checked
+                }
+                TextField {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    visible: transmitter.cwId
+                    text: transmitter.cwMessage
+                    onTextEdited: transmitter.cwMessage = text
+                }
+                Label {
+                    text: "Morse at 18 wpm after the picture, under the same key-up. "
+                          + "{callsign} is replaced. The default also advertises the "
+                          + "mode, so someone who hears the signal and does not know "
+                          + "what it is can find out."
+                    font.pixelSize: 11
+                    color: "#666"
+                    visible: transmitter.cwId
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
+                // Shown here as well as on the transmit screen, because
+                // this is the screen the fix is on. Send is disabled
+                // while this has anything to say.
+                Label {
+                    text: transmitter.cwIdProblem
+                    font.pixelSize: 11
+                    color: "#c00"
+                    visible: text.length > 0
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
             }
 
-            RigPane {
-                rig: rigControl
-                Layout.fillWidth: true
+            // ---- Rig control ----------------------------------------
+            //
+            // RigPane draws its own body; the section supplies the
+            // heading and the on/off summary, so its internal title
+            // label was dropped when it moved in here.
+            SettingsSection {
+                title: "Rig control"
+                summary: rigControl.enabled
+                         ? (rigControl.running ? "Connected" : "On")
+                         : "Off"
+
+                RigPane {
+                    rig: rigControl
+                    Layout.fillWidth: true
+                }
             }
 
-            Label {
-                text: "Received pictures"
-                font.bold: true
-                Layout.margins: 12
-                Layout.bottomMargin: 0
-            }
-            Switch {
-                text: "Save to gallery"
-                Layout.leftMargin: 4
-                checked: listener.saveToGallery
-                onToggled: listener.saveToGallery = checked
-            }
-            Label {
-                // Says what it does *and* what follows from it. The
-                // consequence is the part an operator cannot guess:
-                // "save to gallery" sounds local, and on a phone with
-                // photo backup switched on it is not.
-                text: "Copies each reception into Pictures/SSTVAE, where the "
-                      + "gallery and Google Photos will show it as a device "
-                      + "folder. Whatever arrives on the band goes into your "
-                      + "camera roll — and into your photo backup, if you have "
-                      + "one. Receptions are always kept in the app either way."
-                font.pixelSize: 11
-                color: "#666"
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
-            }
-            Label {
-                // The export runs in the service, after the operator has
-                // stopped looking, so this is the only place a failure
-                // can surface at all. Cleared by the next success.
-                text: "Last export failed: " + listener.galleryError
-                visible: listener.saveToGallery && listener.galleryError !== ""
-                font.pixelSize: 11
-                color: "#a60"
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
+            // ---- Model ----------------------------------------------
+            SettingsSection {
+                title: "Model"
+                summary: listener.modelReady ? "Ready" : "Not ready"
+
+                Label {
+                    text: listener.modelStatus
+                    font.family: "monospace"
+                    font.pixelSize: 11
+                    color: listener.modelReady ? "#3a3" : "#a60"
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
+                Button {
+                    text: "Retry model download"
+                    Layout.leftMargin: 12
+                    visible: !listener.modelReady
+                    onClicked: listener.loadModel()
+                }
             }
 
-            Label {
-                text: "Model"
-                font.bold: true
-                Layout.margins: 12
-                Layout.bottomMargin: 0
-            }
-            Label {
-                text: listener.modelStatus
-                font.family: "monospace"
-                font.pixelSize: 11
-                color: listener.modelReady ? "#3a3" : "#a60"
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
-            }
-            Button {
-                text: "Retry model download"
-                Layout.leftMargin: 12
-                visible: !listener.modelReady
-                onClicked: listener.loadModel()
+            // ---- Advanced -------------------------------------------
+            //
+            // The debug toggle, on its own and last: an operator never
+            // reaches for it, and folding it here is what keeps it out
+            // of the column the callsign and the device picker are in.
+            SettingsSection {
+                title: "Advanced"
+                summary: listener.showTechnical ? "Technical details on" : ""
+
+                Switch {
+                    text: "Show technical details"
+                    Layout.leftMargin: 4
+                    checked: listener.showTechnical
+                    onToggled: listener.showTechnical = checked
+                }
+                Label {
+                    // Says what it is *for*, not what it shows. Someone
+                    // reading this is either curious or being walked
+                    // through a problem by whoever wrote the app, and
+                    // the second reader is the one who needs to know the
+                    // switch exists.
+                    text: "Signal levels, capture timing, decode cost and poll counts, "
+                          + "on the Listen screen and in the notification. Useful when "
+                          + "something is not decoding and worth reporting with a bug."
+                    font.pixelSize: 11
+                    color: "#666"
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 12
+                    Layout.rightMargin: 12
+                    wrapMode: Text.Wrap
+                }
             }
 
-            Label {
-                text: "Advanced"
-                font.bold: true
-                Layout.margins: 12
-                Layout.bottomMargin: 0
-            }
-            Switch {
-                text: "Show technical details"
-                Layout.leftMargin: 4
-                checked: listener.showTechnical
-                onToggled: listener.showTechnical = checked
-            }
-            Label {
-                // Says what it is *for*, not what it shows. Someone
-                // reading this is either curious or being walked
-                // through a problem by whoever wrote the app, and the
-                // second reader is the one who needs to know the
-                // switch exists.
-                text: "Signal levels, capture timing, decode cost and poll counts, "
-                      + "on the Listen screen and in the notification. Useful when "
-                      + "something is not decoding and worth reporting with a bug."
-                font.pixelSize: 11
-                color: "#666"
-                Layout.fillWidth: true
-                Layout.leftMargin: 12
-                Layout.rightMargin: 12
-                wrapMode: Text.Wrap
-            }
-
-            // Breathing room under the last control, so it is not
+            // Breathing room under the last section, so it is not
             // pressed against the tab bar at the end of the scroll.
             Item { Layout.preferredHeight: 24 }
         }

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -937,10 +937,14 @@ framing, process-wide, so a rotation mid-crop loses nothing.
   one-line `summary` of current state (rig on/off, model ready), the way
   Android's own settings show a preference's value under its title, so
   the common questions are answerable without expanding anything. The
-  debug switch (`Show technical details`) now lives alone in its own
-  `Advanced` section, last — which is what "kept out of the way" meant.
-  `RigPane` lost its internal "Rig control" title label when it moved
-  in, since the section supplies the heading.
+  debug controls collect in their own `Advanced` section, last — which
+  is what "kept out of the way" meant: `Show technical details`, and the
+  rig CAT trace (`Log rig traffic`), which moved out of the middle of
+  `RigPane`'s connection controls to sit beside it. That rig subgroup is
+  shown only when rig control is on, so an operator with no cable never
+  meets a rig knob in Advanced. `RigPane` lost its internal "Rig
+  control" title label when it moved in, since the section supplies the
+  heading.
 
 ### Picking a picture
 

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -915,6 +915,32 @@ framing, process-wide, so a rotation mid-crop loses nothing.
   `contentItem`, so `parent` is neither the ScrollView nor anything with
   its width. The symptom is not a missing scrollbar but text running off
   the right edge with nothing to scroll it back.
+- **Settings is grouped into collapsible sections**
+  (`SettingsSection.qml`). Even scrolled, the page had grown into one
+  flat run of every control the app has — the debug toggle in the same
+  column as the callsign, and a multi-sentence help label under each
+  switch — so finding one setting meant reading past all the others.
+  Each group (Receive, Transmit, Rig control, Model, Advanced) is now a
+  section that **starts collapsed**: the page opens as a short list of
+  headings, and the descriptive text and the rarely-touched controls
+  fold away until one is tapped open. Three things made this the right
+  shape rather than a second tab bar. The bottom tab bar already carries
+  five and `RigPane.qml` records why a sixth was refused on a phone —
+  a second strip inside the page is the same crowding one level down.
+  Folding costs no navigation stack, so `Main.qml`'s deliberately
+  careful `onClosing` back handling is untouched (a drill-down would
+  have added a fourth case to it). And a `ColumnLayout` with
+  `visible: false` is excluded from its parent layout entirely, so a
+  collapsed section costs only its header, while `Component.onCompleted`
+  on the controls inside still runs — a ComboBox that reads its stored
+  index once is correct on first expand. Each header carries an optional
+  one-line `summary` of current state (rig on/off, model ready), the way
+  Android's own settings show a preference's value under its title, so
+  the common questions are answerable without expanding anything. The
+  debug switch (`Show technical details`) now lives alone in its own
+  `Advanced` section, last — which is what "kept out of the way" meant.
+  `RigPane` lost its internal "Rig control" title label when it moved
+  in, since the section supplies the heading.
 
 ### Picking a picture
 

--- a/native/android-app/RigPane.qml
+++ b/native/android-app/RigPane.qml
@@ -397,79 +397,12 @@ ColumnLayout {
             Layout.rightMargin: 12
         }
 
-        // ---- diagnostics ----------------------------------------------
-        //
-        // Hamlib's own trace, which is the only thing that answers "how
-        // far did open get, and what did the radio say" -- the library
-        // writes it to stderr, which on a phone is nowhere.
-        Switch {
-            text: "Log rig traffic"
-            Layout.leftMargin: 4
-            checked: pane.rig.debugLog
-            onToggled: pane.rig.debugLog = checked
-        }
-        Label {
-            text: "For bug reports. Records every CAT command and reply, "
-                  + "which slows things down and fills the log quickly — "
-                  + "leave it off unless a radio will not work."
-            font.pixelSize: 11
-            color: "#666"
-            Layout.fillWidth: true
-            Layout.leftMargin: 12
-            Layout.rightMargin: 12
-            wrapMode: Text.Wrap
-        }
-        ColumnLayout {
-            visible: pane.rig.debugLog
-            spacing: 4
-            Layout.fillWidth: true
-            Layout.leftMargin: 12
-            Layout.rightMargin: 12
-
-            RowLayout {
-                // **Refreshed by hand, not bound to the property.** The
-                // rig screen republishes at 1 Hz, and a bound text
-                // property would reset this view's scroll position
-                // every second — unreadable in exactly the situation it
-                // is for. A trace is read after the failure anyway.
-                Button {
-                    text: "Refresh"
-                    onClicked: logArea.text = pane.rig.logText
-                }
-                Button {
-                    text: "Copy"
-                    onClicked: {
-                        logArea.selectAll();
-                        logArea.copy();
-                        logArea.deselect();
-                    }
-                }
-                Button {
-                    text: "Clear"
-                    onClicked: {
-                        pane.rig.clearLog();
-                        logArea.text = "";
-                    }
-                }
-            }
-
-            ScrollView {
-                Layout.fillWidth: true
-                Layout.preferredHeight: 260
-                clip: true
-
-                TextArea {
-                    id: logArea
-                    readOnly: true
-                    // No wrapping: a CI-V frame dump read across
-                    // wrapped lines is worse than one read sideways.
-                    wrapMode: Text.NoWrap
-                    font.family: "monospace"
-                    font.pixelSize: 10
-                    placeholderText: "Press Refresh after the radio fails to connect."
-                }
-            }
-        }
+        // Hamlib's own trace -- the one thing that answers "how far did
+        // open get, and what did the radio say" -- is the "Log rig
+        // traffic" switch, and it lives in Settings > Advanced rather
+        // than here: it is a debug tool an operator reaches for once in
+        // the life of a radio, so it belongs with the other debug
+        // toggle, not in the middle of the connection controls.
     }
 
     // ---- the radio picker ---------------------------------------------

--- a/native/android-app/RigPane.qml
+++ b/native/android-app/RigPane.qml
@@ -4,11 +4,13 @@ import QtQuick.Layouts
 
 // Rig control settings: CAT and PTT over USB, Bluetooth or a network.
 //
-// A section of the Settings tab rather than a tab of its own. The tab
-// bar already carries five and a sixth is a crowded row on a phone --
-// and this is a screen an operator visits once per radio, not once per
-// session. What *is* worth seeing every session, the dial frequency,
-// goes on the Listen screen where the waterfall is.
+// A collapsible section of the Settings tab (`SettingsSection.qml`)
+// rather than a tab of its own. The tab bar already carries five and a
+// sixth is a crowded row on a phone -- and this is a screen an operator
+// visits once per radio, not once per session. What *is* worth seeing
+// every session, the dial frequency, goes on the Listen screen where the
+// waterfall is. The section supplies the "Rig control" heading and the
+// on/off summary, so there is no title label here.
 //
 // **Why any of this exists**: `docs/android.md` recorded rig control as
 // structurally impossible here, because Hamlib's serial layer opens a
@@ -25,15 +27,10 @@ ColumnLayout {
 
     // Re-enumerate whenever this becomes visible: USB devices come and
     // go with the cable, and a picker showing a radio that was
-    // unplugged five minutes ago is worse than an empty one.
+    // unplugged five minutes ago is worse than an empty one. The
+    // enclosing section is collapsed by default, so this now fires when
+    // the operator opens Rig control rather than on every Settings visit.
     onVisibleChanged: if (visible) rig.refreshDevices()
-
-    Label {
-        text: "Rig control"
-        font.bold: true
-        Layout.margins: 12
-        Layout.bottomMargin: 0
-    }
 
     Switch {
         text: "Control the radio"

--- a/native/android-app/SettingsSection.qml
+++ b/native/android-app/SettingsSection.qml
@@ -43,10 +43,25 @@ ColumnLayout {
         Layout.fillWidth: true
         padding: 12
         onClicked: section.expanded = !section.expanded
-        contentItem: RowLayout {
-            spacing: 8
-            ColumnLayout {
-                Layout.fillWidth: true
+
+        // **Anchored, not a RowLayout.** The chevron must sit on the
+        // content's right edge on every row, and a fill-width layout
+        // child pushing it there proved unreliable inside a Control's
+        // contentItem -- rows with a summary and rows without ended up
+        // with the chevron at different x. Anchoring the chevron to
+        // `parent.right` and the text column between the left edge and
+        // the chevron pins it regardless of what the row contains. The
+        // Control resizes this Item to the full content width, so
+        // `parent` is the right thing to anchor to.
+        contentItem: Item {
+            implicitHeight: Math.max(titleCol.implicitHeight, chevron.implicitHeight)
+
+            Column {
+                id: titleCol
+                anchors.left: parent.left
+                anchors.right: chevron.left
+                anchors.rightMargin: 8
+                anchors.verticalCenter: parent.verticalCenter
                 spacing: 0
                 Label {
                     text: section.title
@@ -54,18 +69,21 @@ ColumnLayout {
                     font.pixelSize: 15
                 }
                 Label {
+                    width: parent.width
                     text: section.summary
                     visible: text.length > 0
                     font.pixelSize: 11
                     color: "#888"
                     elide: Text.ElideRight
-                    Layout.fillWidth: true
                 }
             }
             // Rotated rather than swapped for a different glyph, so the
             // change reads as one control turning rather than two
             // characters trading places.
             Label {
+                id: chevron
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
                 text: "▼"
                 color: "#888"
                 rotation: section.expanded ? 180 : 0

--- a/native/android-app/SettingsSection.qml
+++ b/native/android-app/SettingsSection.qml
@@ -1,0 +1,99 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// A collapsible group for the Settings page.
+//
+// The Settings tab used to be one long scroll of every control the app
+// has, with the debug switches and the multi-sentence help text inline
+// between the things an operator actually reaches for -- so finding one
+// setting meant reading past all the others, and the debug toggle sat in
+// the same column as the callsign. Each group is now a section that
+// starts collapsed: the page is a short, scannable list of headings, and
+// the descriptive text and the rarely-touched controls are one tap away
+// rather than always on screen.
+//
+// **Sub-sections rather than a sub-tab bar.** The bottom tab bar already
+// carries five and `RigPane.qml` records why a sixth was refused on a
+// phone; a second strip of tabs *inside* the page would be the same
+// crowding one level down, and it would not shorten the page the way
+// collapsing does. Collapsing is also what keeps the back gesture simple
+// -- there is no navigation stack to pop, so `Main.qml`'s deliberately
+// careful `onClosing` is untouched.
+//
+// The header carries an optional one-line `summary` of the section's
+// current state, the way Android's own settings show a preference's
+// value under its title -- so "is the rig on, is the model ready" is
+// answerable without expanding anything.
+ColumnLayout {
+    id: section
+
+    // Children written between the tags land in the expandable body.
+    default property alias content: body.data
+    property string title
+    property string summary: ""
+    property bool expanded: false
+
+    Layout.fillWidth: true
+    spacing: 0
+
+    // The whole header is the touch target, not a chevron beside it: a
+    // thumb on a phone should not have to find a 24 px glyph.
+    ItemDelegate {
+        Layout.fillWidth: true
+        padding: 12
+        onClicked: section.expanded = !section.expanded
+        contentItem: RowLayout {
+            spacing: 8
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+                Label {
+                    text: section.title
+                    font.bold: true
+                    font.pixelSize: 15
+                }
+                Label {
+                    text: section.summary
+                    visible: text.length > 0
+                    font.pixelSize: 11
+                    color: "#888"
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
+                }
+            }
+            // Rotated rather than swapped for a different glyph, so the
+            // change reads as one control turning rather than two
+            // characters trading places.
+            Label {
+                text: "▼"
+                color: "#888"
+                rotation: section.expanded ? 180 : 0
+                Behavior on rotation { NumberAnimation { duration: 120 } }
+            }
+        }
+    }
+
+    // A hairline under a collapsed header, so the closed list reads as a
+    // list. Dropped while open, where the body's own spacing separates it
+    // from the next section.
+    Rectangle {
+        Layout.fillWidth: true
+        Layout.preferredHeight: 1
+        color: "#33808080"
+        visible: !section.expanded
+    }
+
+    // A ColumnLayout with `visible: false` is excluded from its parent
+    // layout entirely, so a collapsed section costs only its header --
+    // which is the whole point. `Component.onCompleted` on the controls
+    // inside still runs (creation is independent of visibility), so a
+    // ComboBox that reads its index once is correct on first expand.
+    ColumnLayout {
+        id: body
+        Layout.fillWidth: true
+        Layout.bottomMargin: section.expanded ? 8 : 0
+        visible: section.expanded
+        spacing: 8
+    }
+}


### PR DESCRIPTION
The Settings tab had grown into one flat scroll of every control the
app has, with the debug toggle in the same column as the callsign and a
multi-sentence help label under each switch, so finding one setting
meant reading past all the others.

Introduce SettingsSection.qml, a collapsible group, and regroup the
page into Receive, Transmit, Rig control, Model, and Advanced sections
that start collapsed: the page opens as a short, scannable list of
headings, and the descriptive text and rarely-touched controls fold
away until a section is tapped open. Each header carries an optional
one-line summary of current state (rig on/off, model ready), the way
Android's own settings show a preference's value under its title.

The debug switch (Show technical details) now lives alone in its own
Advanced section, last -- out of the way of the controls an operator
actually reaches for. RigPane loses its internal title label since the
section supplies the heading.

Sub-sections rather than a second tab bar: the bottom tab bar already
carries five and a sixth was refused on a phone, and folding costs no
navigation stack, so Main.qml's careful onClosing back handling is
untouched.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V83qXahTtFxAn4Bn7oy48i