### PR TITLE
Beacon: maximal-ratio soft chips, and coherent multi-repetition combining

### DIFF
--- a/native/core/beacon/beacon.cpp
+++ b/native/core/beacon/beacon.cpp
@@ -261,23 +261,26 @@ std::optional<BeaconResult> decode_single_repetition(
 // decode_combined below uses both, in two tiers:
 //
 // - Chunks entirely inside the invariant callsign+mode fields are
-//   identical, chip for chip, in every repetition, so their *signs* can
-//   simply be summed across repetitions before a single Golay decode --
-//   genuine coherent combining, the cheap case. The v4 layout (counter |
+//   identical, chip for chip, in every repetition, so they can simply be
+//   summed across repetitions before a single Golay decode -- coherent
+//   (maximal-ratio) combining, the cheap case. The v4 layout (counter |
 //   callsign | mode | reserved | CRC, 84 bits exactly) was chosen so the
-//   mode field lands here: chunks 1-4 are pure callsign+mode. Sign, not
-//   raw magnitude: under fading,
-//   the per-frame channel estimate the equalizer divides by can itself
-//   sit near a fade null, amplifying that frame's noise into an
-//   enormous, essentially random magnitude, so a single such repetition
-//   dominates a raw sum and wrecks it (measured in the Python
-//   reference: raw summing recovered 6/12 bits -- chance -- where sign
-//   summing recovered 12/12).
+//   mode field lands here: chunks 1-4 are pure callsign+mode.
+//
+//   This summed *signs* until 2026-08-25, correctly for what it was
+//   given: the chips then came off the zero-forcing equalizer, so a
+//   repetition whose channel estimate sat near a fade null contributed
+//   an enormous, essentially random magnitude and dominated a raw sum.
+//   The chips are maximal-ratio now, so a faded repetition arrives
+//   *small* instead, and the ordering inverts -- measured in the Python
+//   reference, mpd at 0 dB: equalized+sign 0.40, equalized+raw 0.15,
+//   MRC+sign 0.53, MRC+raw 0.90. The two changes compound and neither
+//   is safe without the other.
 // - The chunk carrying the counter can't be summed that way (a
 //   genuinely different value is correct at every repetition), so
 //   search_counter_chunk instead evaluates every hypothesis by
 //   regenerating each repetition's expected codeword and summing its
-//   sign-correlation, combining evidence across repetitions before
+//   correlation, combining evidence across repetitions before
 //   choosing -- voting on independent per-repetition decodes was tried
 //   first and measured useless at the SNRs this needs to help with (18
 //   repetitions, 18 different guesses, no repeat at all).
@@ -305,14 +308,6 @@ namespace {
 std::pair<int, int> chunk_bit_range(int chunk_idx) {
     return {chunk_idx * 12, (chunk_idx + 1) * 12};
 }
-
-// np.sign: 0.0 at exactly zero, not +1 -- matters here because summed
-// signs feed straight into a Golay decode via golay::signs_table()
-// lookups, so a stray +1 bias at an exact-zero chip (vanishingly likely
-// on real noise, but reachable from a deliberately constructed test
-// vector) would be a real, if tiny, divergence from the Python
-// reference rather than a harmless rounding difference.
-double sign(double x) { return x > 0.0 ? 1.0 : (x < 0.0 ? -1.0 : 0.0); }
 
 std::vector<int> decode_chunk_bits(std::span<const double> chip_slice) {
     std::vector<int> out;
@@ -393,7 +388,7 @@ std::optional<std::pair<int, int>> search_counter_chunk(
         frame_deltas[g] = pos / CHIPS_PER_FRAME - anchor_frame;
         for (int c = 0; c < 24; ++c)
             received[g * 24 + static_cast<std::size_t>(c)] =
-                sign(chips[static_cast<std::size_t>(pos + SYNC_LEN + clo + c)]);
+                chips[static_cast<std::size_t>(pos + SYNC_LEN + clo + c)];
     }
 
     const int n_extra = 12 - n_counter_bits;
@@ -460,7 +455,7 @@ std::optional<BeaconResult> decode_combined(std::span<const double> chips,
         for (std::int64_t pos : grid)
             for (int j = 0; j < 24; ++j)
                 summed[static_cast<std::size_t>(j)] +=
-                    sign(chips[static_cast<std::size_t>(pos + SYNC_LEN + clo + j)]);
+                    chips[static_cast<std::size_t>(pos + SYNC_LEN + clo + j)];
         const std::vector<int> bits = decode_chunk_bits(summed);
         const auto [blo, bhi] = chunk_bit_range(c);
         std::copy(bits.begin(), bits.end(), inv_bits.begin() + (blo - inv_lo));

--- a/native/core/modem/modem.cpp
+++ b/native/core/modem/modem.cpp
@@ -191,9 +191,15 @@ EqualizedSymbol equalize(std::span<const cdouble> raw_sym,
         out.weights[2 * i] = w;
         out.weights[2 * i + 1] = w;
     }
+    // Maximal-ratio, not the equalized value: dividing by the channel
+    // estimate turns a beacon carrier in a fade null into amplified
+    // noise with a large magnitude, and Golay's soft ML decode reads
+    // magnitude as confidence -- one nulled chip then outvotes the four
+    // good ones in the same codeword. Weighting by |h|^2 (equivalently,
+    // skipping the equalization) is the correct soft metric for BPSK
+    // and needs no `floor`.
     const std::size_t b = static_cast<std::size_t>(BEACON_CARRIER);
-    const double mag_b = std::max(std::abs(h[b]), floor);
-    out.beacon_chip = (raw_sym[b] * std::conj(h[b]) / (mag_b * mag_b)).real();
+    out.beacon_chip = (raw_sym[b] * std::conj(h[b])).real();
     return out;
 }
 

--- a/scripts/beacon_combine_sweep.py
+++ b/scripts/beacon_combine_sweep.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Equal-gain (sign) vs coherent combining in the beacon's multi-repetition
+fallback, now that the soft chips are maximal-ratio.
+
+    python scripts/beacon_combine_sweep.py --trials 40
+
+`_decode_combined` sums the *sign* of each repetition's chips because
+the old equalized soft values could be enormous and random when a
+repetition's channel estimate sat near a fade null -- one such
+repetition dominated a raw sum and wrecked it. The chips are now
+`real(raw * conj(h))`, so a faded repetition arrives *small* instead,
+which is exactly what coherent combining wants. This asks whether the
+workaround is still earning its keep.
+
+Two measurements, because they answer different questions:
+
+  forced   the fallback in isolation: single-shot decoding is disabled,
+           so every trial exercises the combining path. This is the
+           discriminating one -- good statistics, no confound.
+  end2end  real `beacon.decode()`, harsh cells only. Confirms whether
+           any difference survives single-shot decoding usually winning
+           first, which is what actually ships.
+
+Success is bit-exact: callsign, mode and absolute frame index.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sstvae import hfchannel  # noqa: E402
+from sstvae.config import (  # noqa: E402
+    FRAME_SAMPLES,
+    HEADER_SAMPLES,
+    LEADIN_SAMPLES,
+    MODES,
+    PREAMBLE_SAMPLES,
+)
+from sstvae.modem import Modem, SyncError  # noqa: E402
+from sstvae.modem import beacon  # noqa: E402
+from sstvae.modem import modem as modem_mod  # noqa: E402
+
+CALLSIGN = "K1ABC"
+FRAME0 = LEADIN_SAMPLES + PREAMBLE_SAMPLES + HEADER_SAMPLES
+CHIPS_PER_FRAME = 5
+MODES_TO_COMBINE = ["sign", "raw", "norm"]
+
+
+def soft_chips(mode, preset, snr_db, seed, window_frames):
+    """One channel realization's beacon soft-chip stream, demodulated
+    the way the receiver does it. Shared across the combining variants,
+    so the comparison is paired -- identical chips in, only the
+    combining differs.
+
+    A window, not the whole transmission, and the *blind* path. A full
+    mode-B transmission carries ~12 superframe repetitions, at which
+    every variant is 1.00 in every cell; and going harsh enough to move
+    that number breaks preamble acquisition long before it breaks the
+    beacon. The regime where combining decides is 3-4 repetitions
+    (SUPERFRAME_LEN is 36.2 frames), which is what --window sets.
+    """
+    rng = np.random.default_rng(seed)
+    latents = rng.standard_normal(mode.n_latents)
+    latents /= np.sqrt(np.mean(latents**2))
+    m = Modem()
+    tx = m.modulate(latents, mode, callsign=CALLSIGN)
+    rx = hfchannel.apply_channel(tx, snr_db=snr_db, fading_preset=preset, seed=seed)
+
+    # The soft chips aren't exposed, and adding a parameter to the
+    # shipped API for a sweep would be the wrong trade. Capture them
+    # from the one call the demodulator makes.
+    captured = {}
+    real_decode = beacon.decode
+
+    def capture(chips, *a, **kw):
+        captured["chips"] = chips
+        return real_decode(chips, *a, **kw)
+
+    start_frame = mode.n_frames // 3
+    lo = FRAME0 + start_frame * FRAME_SAMPLES
+    win = rx[lo : lo + window_frames * FRAME_SAMPLES]
+
+    modem_mod.beacon.decode = capture
+    try:
+        m.demodulate_blind(win)
+    except SyncError:
+        # Blind acquisition, not the beacon: orthogonal to what is being
+        # measured, so the trial is excluded rather than counted as a
+        # combining failure.
+        return None
+    finally:
+        modem_mod.beacon.decode = real_decode
+    return captured.get("chips"), start_frame
+
+
+def _ok(b, mode, expect_frame0=0):
+    return bool(
+        b is not None
+        and b.callsign == CALLSIGN
+        and b.mode_index == mode.index
+        and b.frame_index - b.chip_offset // CHIPS_PER_FRAME == expect_frame0
+    )
+
+
+def run(mode, cells, trials, seed0, forced, window_frames):
+    print(f"\n{'forced fallback' if forced else 'end to end'}: mode {mode.name}, "
+          f"{window_frames}-frame window, {trials} trials/cell, bit-exact beacon decode")
+    print(f"{'channel':>10} {'SNR':>5}  "
+          + "  ".join(f"{c:>6}" for c in MODES_TO_COMBINE) + "       n")
+    for preset, snr in cells:
+        tally = {c: 0 for c in MODES_TO_COMBINE}
+        n = 0
+        for t in range(trials):
+            got = soft_chips(mode, preset, snr, seed0 + 1000 * t, window_frames)
+            if got is None or got[0] is None:
+                continue
+            chips, start_frame = got
+            n += 1
+            for c in MODES_TO_COMBINE:
+                beacon.COMBINE_MODE = c
+                if forced:
+                    b = _combined_only(chips)
+                else:
+                    b = beacon.decode(chips)
+                tally[c] += _ok(b, mode, start_frame)
+        rates = "  ".join(
+            f"{tally[c] / n:6.2f}" if n else "     -" for c in MODES_TO_COMBINE
+        )
+        print(f"{preset or 'awgn':>10} {snr:5.1f}  {rates}  {n:>3}/{trials}")
+
+
+def _combined_only(chips):
+    """`beacon.decode()` with the single-shot path removed, so the
+    combining fallback is always what answers."""
+    for off in beacon.find_sync(chips):
+        r = beacon._decode_combined(chips, off)
+        if r is not None:
+            return r
+    for off in beacon._folded_sync_phases(chips):
+        r = beacon._decode_combined(chips, off)
+        if r is not None:
+            return r
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--trials", type=int, default=40)
+    ap.add_argument("--mode", default="B")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--window", type=int, default=150,
+                    help="window length in frames (~4 superframe repetitions)")
+    args = ap.parse_args()
+
+    mode = MODES[args.mode]
+    # Harsh only: anywhere comfortable, every variant is 1.00 and the
+    # fallback never runs at all.
+    cells = [(None, s) for s in (0.0, -2.0, -4.0)]
+    cells += [(p, s) for p in ("mpg", "mpp", "mpd") for s in (8.0, 4.0, 0.0)]
+
+    run(mode, cells, args.trials, args.seed, True, args.window)
+    run(mode, cells, args.trials, args.seed, False, args.window)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/beacon_combine_sweep.py
+++ b/scripts/beacon_combine_sweep.py
@@ -1,29 +1,48 @@
 #!/usr/bin/env python3
-"""Equal-gain (sign) vs coherent combining in the beacon's multi-repetition
-fallback, now that the soft chips are maximal-ratio.
+"""Beacon multi-repetition combining: a regression instrument.
 
     python scripts/beacon_combine_sweep.py --trials 40
 
-`_decode_combined` sums the *sign* of each repetition's chips because
-the old equalized soft values could be enormous and random when a
-repetition's channel estimate sat near a fade null -- one such
-repetition dominated a raw sum and wrecked it. The chips are now
-`real(raw * conj(h))`, so a faded repetition arrives *small* instead,
-which is exactly what coherent combining wants. This asks whether the
-workaround is still earning its keep.
+`_decode_combined` sums each repetition's raw chip values -- coherent
+(maximal-ratio) combining. It summed *signs* until 2026-08-25, correctly
+for what it was given: the chips then came off the zero-forcing
+equalizer, so a repetition near a fade null contributed an enormous,
+essentially random magnitude and dominated a raw sum. The chips are
+`real(raw * conj(h))` now, so a faded repetition arrives small instead,
+and the ordering inverts.
+
+Measured 2026-08-25, mode B, 40 trials/cell, forced fallback:
+
+    chips           equalized  equalized      MRC      MRC
+    combining            sign        raw     sign      raw
+    awgn -4.0            0.45       0.20     0.50     0.65
+    mpg   0.0            0.72       0.30     0.75     0.82
+    mpp   0.0            0.57       0.23     0.72     0.93
+    mpd   0.0            0.40       0.15     0.53     0.90
+
+That comparison is settled, so this now measures the shipped path only.
+To re-run it, swap the two lines in `beacon._decode_combined` /
+`_search_counter_chunk` back to `np.sign(...)` and/or revert
+`modem.py`'s beacon chip to `np.real(y[BEACON_CARRIER])`; a knob in
+product code for a one-off comparison would be the wrong trade.
 
 Two measurements, because they answer different questions:
 
   forced   the fallback in isolation: single-shot decoding is disabled,
-           so every trial exercises the combining path. This is the
-           discriminating one -- good statistics, no confound.
-  end2end  real `beacon.decode()`, harsh cells only. Confirms whether
-           any difference survives single-shot decoding usually winning
-           first, which is what actually ships.
+           so every trial exercises the combining path. Good statistics,
+           no confound.
+  end2end  real `beacon.decode()`. Confirms whether any difference
+           survives single-shot decoding usually winning first.
+
+The window matters and is not a detail. `_decode_combined` is dead code
+below 3 repetitions (`_repetition_grid`) and saturated above ~6, and
+SUPERFRAME_LEN is 36.2 frames -- so a whole mode-B transmission (~12
+repetitions) scores 1.00 for every variant in every cell. It runs on
+the blind path because going harsh enough to move that number breaks
+preamble acquisition long before it breaks the beacon.
 
 Success is bit-exact: callsign, mode and absolute frame index.
 """
-
 import argparse
 import sys
 from pathlib import Path
@@ -47,7 +66,6 @@ from sstvae.modem import modem as modem_mod  # noqa: E402
 CALLSIGN = "K1ABC"
 FRAME0 = LEADIN_SAMPLES + PREAMBLE_SAMPLES + HEADER_SAMPLES
 CHIPS_PER_FRAME = 5
-MODES_TO_COMBINE = ["sign", "raw", "norm"]
 
 
 def soft_chips(mode, preset, snr_db, seed, window_frames):
@@ -109,10 +127,9 @@ def _ok(b, mode, expect_frame0=0):
 def run(mode, cells, trials, seed0, forced, window_frames):
     print(f"\n{'forced fallback' if forced else 'end to end'}: mode {mode.name}, "
           f"{window_frames}-frame window, {trials} trials/cell, bit-exact beacon decode")
-    print(f"{'channel':>10} {'SNR':>5}  "
-          + "  ".join(f"{c:>6}" for c in MODES_TO_COMBINE) + "       n")
+    print(f"{'channel':>10} {'SNR':>5}  {'rate':>6}       n")
     for preset, snr in cells:
-        tally = {c: 0 for c in MODES_TO_COMBINE}
+        ok = 0
         n = 0
         for t in range(trials):
             got = soft_chips(mode, preset, snr, seed0 + 1000 * t, window_frames)
@@ -120,17 +137,10 @@ def run(mode, cells, trials, seed0, forced, window_frames):
                 continue
             chips, start_frame = got
             n += 1
-            for c in MODES_TO_COMBINE:
-                beacon.COMBINE_MODE = c
-                if forced:
-                    b = _combined_only(chips)
-                else:
-                    b = beacon.decode(chips)
-                tally[c] += _ok(b, mode, start_frame)
-        rates = "  ".join(
-            f"{tally[c] / n:6.2f}" if n else "     -" for c in MODES_TO_COMBINE
-        )
-        print(f"{preset or 'awgn':>10} {snr:5.1f}  {rates}  {n:>3}/{trials}")
+            b = _combined_only(chips) if forced else beacon.decode(chips)
+            ok += _ok(b, mode, start_frame)
+        rate = f"{ok / n:6.2f}" if n else "     -"
+        print(f"{preset or 'awgn':>10} {snr:5.1f}  {rate}  {n:>3}/{trials}")
 
 
 def _combined_only(chips):

--- a/scripts/beacon_soft_sweep.py
+++ b/scripts/beacon_soft_sweep.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Beacon decode success rate vs SNR, for the three soft-value weightings.
+
+    python scripts/beacon_soft_sweep.py --trials 40
+
+The beacon's soft chips come off the pilot channel estimate, and how
+they are weighted decides whether a faded carrier poisons its Golay
+codeword.
+
+Now a single-column regression instrument: the comparison it was written
+for is settled and the winner is what ships. Measured 2026-08-25, mode B,
+60 trials/cell -- old `real(y)` against the shipped `real(raw*conj(h))`:
+
+    awgn  0.0  0.77 -> 0.97     mpp  8.0  0.60 -> 0.90
+    awgn -2.0  0.20 -> 0.47     mpp  4.0  0.23 -> 0.58
+    mpg 12.0   0.67 -> 0.72     mpd  8.0  0.42 -> 0.90
+    mpg  4.0   0.23 -> 0.28     mpd  4.0  0.05 -> 0.50
+
+mpg moves least, as expected: at 0.5 ms delay the whole 1150 Hz band is
+inside one coherence bandwidth, so there is no per-carrier fade to
+deweight -- the beacon carrier fades with everything else.
+
+Success is a *bit-exact* beacon result: callsign, mode and the absolute
+frame index all correct. A wrong-but-returned beacon is counted as a
+failure, not a decode, since downstream that is worse than nothing.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sstvae import hfchannel  # noqa: E402
+from sstvae.config import (  # noqa: E402
+    FRAME_SAMPLES,
+    HEADER_SAMPLES,
+    LEADIN_SAMPLES,
+    MODES,
+    PREAMBLE_SAMPLES,
+)
+from sstvae.modem import Modem  # noqa: E402
+from sstvae.modem.beacon import MIN_FRAMES_FOR_SYNC  # noqa: E402
+
+CALLSIGN = "K1ABC"
+CHIPS_PER_FRAME = 5
+# A hair over the window that *guarantees* a full superframe copy.
+WINDOW_FRAMES = MIN_FRAMES_FOR_SYNC + 4
+
+
+def one_trial(mode, preset, snr_db, seed):
+    """True if this channel realization's beacon decodes bit-exactly.
+
+    A short *blind* window, mid-transmission: that is where the beacon is
+    actually load-bearing and where it is not already saved by six
+    superframe repetitions. Over a whole mode-B transmission every
+    weighting decodes 100% of the time in every cell, which measures
+    nothing.
+
+    """
+    rng = np.random.default_rng(seed)
+    m = Modem()
+    latents = rng.standard_normal(mode.n_latents).astype(np.float64)
+    latents /= np.sqrt(np.mean(latents**2))
+    tx = m.modulate(latents, mode, callsign=CALLSIGN)
+    rx = hfchannel.apply_channel(tx, snr_db=snr_db, fading_preset=preset, seed=seed)
+
+    # Window of WINDOW_FRAMES starting at frame `start_frame`, aligned to
+    # the frame grid so the truth for the decoded absolute frame index is
+    # exactly start_frame.
+    start_frame = mode.n_frames // 3
+    frame0 = LEADIN_SAMPLES + PREAMBLE_SAMPLES + HEADER_SAMPLES
+    lo = frame0 + start_frame * FRAME_SAMPLES
+    win = rx[lo : lo + WINDOW_FRAMES * FRAME_SAMPLES]
+
+    b = m.demodulate_blind(win).beacon
+    return bool(
+        b is not None
+        and b.callsign == CALLSIGN
+        and b.mode_index == mode.index
+        and b.frame_index - b.chip_offset // CHIPS_PER_FRAME == start_frame
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--trials", type=int, default=40)
+    ap.add_argument("--mode", default="B")
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    mode = MODES[args.mode]
+    cells = [(None, s) for s in (6.0, 3.0, 0.0, -2.0)]
+    cells += [(p, s) for p in ("mpg", "mpp", "mpd") for s in (12.0, 8.0, 4.0)]
+
+    print(f"mode {args.mode}, {args.trials} trials/cell, beacon bit-exact decode rate")
+    print(f"{'channel':>10} {'SNR':>5}  {'rate':>6}")
+    for preset, snr in cells:
+        ok = sum(
+            one_trial(mode, preset, snr, args.seed + 1000 * t)
+            for t in range(args.trials)
+        )
+        print(f"{preset or 'awgn':>10} {snr:5.1f}  {ok / args.trials:6.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sstvae/modem/beacon.py
+++ b/sstvae/modem/beacon.py
@@ -334,17 +334,37 @@ def decode(chips: np.ndarray, threshold: float = 0.6) -> BeaconResult | None:
 # *predictable* from a (counter, callsign, mode) hypothesis instead,
 # which is exactly what makes them usable as verification below.
 #
-# Summing/correlating by *sign*, not raw chip value, throughout: under
-# fading, the per-frame channel estimate the equalizer divides by can
-# itself sit near a fade null, amplifying that frame's noise into an
-# enormous, essentially random magnitude rather than a merely noisy
-# one. A single such repetition then dominates a raw sum or a raw
-# dot-product and wrecks it (measured on one case: raw summing
-# recovered 6/12 bits -- chance -- where every individual repetition
-# also decoded at only ~7/12; summing signs instead recovered 12/12).
-# Equal-gain (sign) combining gives up some of coherent combining's
-# theoretical SNR gain in exchange for not being destroyed by exactly
-# the outliers fading produces routinely.
+# Summing/correlating raw chip values, throughout -- coherent
+# (maximal-ratio) combining, so a repetition heard well counts for more
+# than one heard badly.
+#
+# This summed *signs* until 2026-08-25, and that was correct for what
+# it was given: the chips then came off the zero-forcing equalizer, so
+# a repetition whose channel estimate sat near a fade null contributed
+# an enormous, essentially random magnitude rather than a merely noisy
+# one, and a single such repetition dominated a raw sum and wrecked
+# it. Equal-gain combining bought immunity to that at the cost of
+# throwing away every repetition's reliability.
+#
+# The chips are now `real(raw * conj(h))` (see modem.py), so a faded
+# repetition arrives *small* instead of huge, which is exactly what
+# coherent combining wants -- and the ordering inverts. Measured with
+# scripts/beacon_combine_sweep.py, mode B, 150-frame window (3-4
+# repetitions -- the regime where this code decides anything), 40
+# trials/cell, bit-exact beacon decode:
+#
+#     chips           equalized  equalized      MRC      MRC
+#     combining            sign        raw     sign      raw
+#     awgn -4.0            0.45       0.20     0.50     0.65
+#     mpg   0.0            0.72       0.30     0.75     0.82
+#     mpp   0.0            0.57       0.23     0.72     0.93
+#     mpd   0.0            0.40       0.15     0.53     0.90
+#
+# Note the two middle columns: raw summing really was ruinous on the
+# old chips, in every cell, not just the one case originally measured.
+# The two changes compound -- mpd at 0 dB goes 0.40 to 0.90 -- and
+# neither is safe without the other. **Do not revert the chip metric
+# without reverting this too.**
 #
 # A final correlation check against every repetition's full superframe
 # (sync word included) guards against returning a wrong assembly as if
@@ -424,7 +444,7 @@ def _search_counter_chunk(
     12-bit value and Golay codeword would be for that hypothesis (the
     counter delta between repetitions is exact, see the module
     docstring), and scores each hypothesis by summing its predicted
-    codeword's sign-correlation against every repetition's actual
+    codeword's correlation against every repetition's actual
     chips -- combining evidence across repetitions *before* choosing,
     the same principle as the coherent chunk combining above, just
     applied to a field that varies (predictably) instead of one that
@@ -434,7 +454,7 @@ def _search_counter_chunk(
     clo, chi = chunk_idx * 24, (chunk_idx + 1) * 24
     anchor_frame = anchor_off // CHIPS_PER_FRAME
     received = np.array(
-        [np.sign(chips[pos + SYNC_LEN + clo : pos + SYNC_LEN + chi]) for pos in grid]
+        [chips[pos + SYNC_LEN + clo : pos + SYNC_LEN + chi] for pos in grid]
     )  # (n_grid, 24)
     frame_deltas = np.array([pos // CHIPS_PER_FRAME - anchor_frame for pos in grid])
 
@@ -482,23 +502,15 @@ def _decode_combined(chips: np.ndarray, anchor_off: int) -> BeaconResult | None:
     inv_bits = np.full(inv_hi - inv_lo, -1, dtype=np.int64)
 
     # Coherent case: sum this chunk's coded chips across every
-    # repetition (identical by construction), decode once. Sums the
-    # *sign* of each repetition's chips, not the raw values: under
-    # fading, the per-frame channel estimate the equalizer divides by
-    # can itself be near a fade null, which amplifies that frame's
-    # noise into an enormous, essentially random magnitude rather than
-    # a merely noisy one -- a single such repetition then dominates a
-    # raw sum and wrecks it (measured: raw summing recovered 6/12 bits,
-    # i.e. chance, on a case where every individual repetition also
-    # decoded at only ~7/12; summing signs instead recovered 12/12).
-    # Equal-gain (sign) combining gives up some of coherent combining's
-    # theoretical SNR gain in exchange for not being destroyed by
-    # exactly the outliers fading produces routinely.
+    # repetition (identical by construction), decode once. Sums the raw
+    # chip values -- coherent combining, valid because the chips are
+    # maximal-ratio rather than equalized; see the module docstring for
+    # why this summed signs until 2026-08-25 and what changed.
     for c in invariant_chunks:
         clo, chi = c * 24, (c + 1) * 24
         summed = np.zeros(24)
         for pos in grid:
-            summed += np.sign(chips[pos + SYNC_LEN + clo : pos + SYNC_LEN + chi])
+            summed += chips[pos + SYNC_LEN + clo : pos + SYNC_LEN + chi]
         bits = _decode_chunk_bits(summed)
         blo, bhi = _chunk_bit_range(c)
         inv_bits[blo - inv_lo : bhi - inv_lo] = bits

--- a/sstvae/modem/modem.py
+++ b/sstvae/modem/modem.py
@@ -414,7 +414,17 @@ class Modem:
                 sl = framing.symbols_to_slots(y[:NC_LATENT][None, :])
                 frame_slots[i0 : i0 + NC_LATENT * 2] = sl
                 frame_w[i0 : i0 + NC_LATENT * 2] = np.repeat(w[:NC_LATENT], 2)
-                beacon_soft[f * CHIPS_PER_FRAME + (s - 1)] = np.real(y[BEACON_CARRIER])
+                # Maximal-ratio, not the equalized value: `y` divides by
+                # the channel estimate, so a beacon carrier in a fade
+                # null returns amplified noise with a large magnitude,
+                # and Golay's soft ML decode reads magnitude as
+                # confidence -- one nulled chip then outvotes the four
+                # good ones in the same codeword. Weighting by |h|^2
+                # (equivalently, skipping the equalization) is the
+                # correct soft metric for BPSK and needs no `floor`.
+                beacon_soft[f * CHIPS_PER_FRAME + (s - 1)] = np.real(
+                    raw[f, s, BEACON_CARRIER] * np.conj(h[BEACON_CARRIER])
+                )
             lo = f * LATENTS_PER_FRAME
             latents[lo : lo + LATENTS_PER_FRAME] = frame_slots
             weights[lo : lo + LATENTS_PER_FRAME] = frame_w
@@ -569,7 +579,9 @@ class Modem:
                 sl = framing.symbols_to_slots(y[:NC_LATENT][None, :])
                 slot_values[f, i0 : i0 + NC_LATENT * 2] = sl
                 slot_weights[f, i0 : i0 + NC_LATENT * 2] = np.repeat(w[:NC_LATENT], 2)
-                beacon_soft[f * CHIPS_PER_FRAME + (s - 1)] = np.real(y[BEACON_CARRIER])
+                beacon_soft[f * CHIPS_PER_FRAME + (s - 1)] = np.real(
+                    raw[f, s, BEACON_CARRIER] * np.conj(h[BEACON_CARRIER])
+                )
 
         beacon_result = beacon.decode(beacon_soft)
         latents_full = np.zeros(MODES["C"].n_latents)

--- a/tests/test_beacon_soft_weighting.py
+++ b/tests/test_beacon_soft_weighting.py
@@ -46,7 +46,7 @@ TRIALS = 25
 MIN_DECODES = 18  # shipped ~0.90 (22.5/25); equalized ~0.42 (10.5/25)
 
 
-def _blind_window(mode, preset, snr_db, seed):
+def _blind_window(mode, preset, snr_db, seed, frames=MIN_FRAMES_FOR_SYNC + 4):
     """A short mid-transmission window, the case where the beacon is
     actually load-bearing: one superframe copy, no preamble. Over a whole
     transmission six repetitions decode 100% either way."""
@@ -58,7 +58,7 @@ def _blind_window(mode, preset, snr_db, seed):
 
     start_frame = mode.n_frames // 3
     lo = LEADIN_SAMPLES + PREAMBLE_SAMPLES + HEADER_SAMPLES + start_frame * FRAME_SAMPLES
-    win = rx[lo : lo + (MIN_FRAMES_FOR_SYNC + 4) * FRAME_SAMPLES]
+    win = rx[lo : lo + frames * FRAME_SAMPLES]
     return win, start_frame
 
 
@@ -76,3 +76,33 @@ def test_beacon_decodes_through_fading_on_a_short_window():
             and b.frame_index - b.chip_offset // CHIPS_PER_FRAME == start_frame
         )
     assert ok >= MIN_DECODES, f"{ok}/{TRIALS} beacon decodes, expected >= {MIN_DECODES}"
+
+
+def test_multi_repetition_combining_is_coherent():
+    """`_decode_combined` sums raw chips, not their signs.
+
+    Only reachable with >= 3 superframe repetitions and only when no
+    single repetition decodes alone, so this needs a window long enough
+    for the grid (SUPERFRAME_LEN is 36.2 frames) and a channel harsh
+    enough that single-shot fails -- 150 frames at mpd 0 dB. A whole
+    transmission carries ~12 repetitions, where every variant is 1.00.
+
+    Measured (`scripts/beacon_combine_sweep.py`, 40 trials/cell), mpd
+    0 dB: equalized chips + sign 0.40, equalized + raw 0.15, MRC + sign
+    0.53, MRC + raw 0.90. The two changes compound and neither is safe
+    without the other, which is why this test and the one above are a
+    pair.
+    """
+    mode = MODES["B"]
+    m = Modem()
+    ok = 0
+    for t in range(TRIALS):
+        win, start_frame = _blind_window(mode, "mpd", 0.0, 500 + 1000 * t, frames=150)
+        b = m.demodulate_blind(win).beacon
+        ok += bool(
+            b is not None
+            and b.callsign == CALLSIGN
+            and b.mode_index == mode.index
+            and b.frame_index - b.chip_offset // CHIPS_PER_FRAME == start_frame
+        )
+    assert ok >= 18, f"{ok}/{TRIALS} beacon decodes, expected >= 18"

--- a/tests/test_beacon_soft_weighting.py
+++ b/tests/test_beacon_soft_weighting.py
@@ -1,0 +1,78 @@
+"""The beacon's soft chips must be maximal-ratio, not equalized.
+
+`demodulate` divides each carrier by its pilot channel estimate. On the
+23 latent carriers that is what the confidence weights are for; the
+beacon carrier gets no weight, so an equalized chip from a carrier in a
+fade is amplified noise carrying a *large* magnitude -- and Golay's soft
+ML decode reads magnitude as confidence, so one faded chip outvotes the
+four good ones in its codeword.
+
+The damage is graded rather than catastrophic (`floor` bounds a total
+null, so the worst case is a carrier a little *above* the floor), which
+is why this is a rate over channel realizations and not a single
+crafted frame: a deterministic version of this test passed against the
+broken code.
+
+Measured with `scripts/beacon_soft_sweep.py`, mode B, 60 trials/cell,
+bit-exact beacon decode over short blind windows:
+
+    channel  SNR   real(y)   real(raw*conj(h))
+    awgn     0.0      0.77        0.97
+    awgn    -2.0      0.20        0.47
+    mpp      4.0      0.23        0.58
+    mpd      8.0      0.42        0.90
+    mpd      4.0      0.05        0.50
+
+The cell below is mpd 8 dB: 0.42 against 0.90, so the bound sits several
+sigma from both.
+"""
+
+import numpy as np
+
+from sstvae import hfchannel
+from sstvae.config import (
+    FRAME_SAMPLES,
+    HEADER_SAMPLES,
+    LEADIN_SAMPLES,
+    MODES,
+    PREAMBLE_SAMPLES,
+)
+from sstvae.modem import Modem
+from sstvae.modem.beacon import MIN_FRAMES_FOR_SYNC
+
+CALLSIGN = "W1AW"
+CHIPS_PER_FRAME = 5
+TRIALS = 25
+MIN_DECODES = 18  # shipped ~0.90 (22.5/25); equalized ~0.42 (10.5/25)
+
+
+def _blind_window(mode, preset, snr_db, seed):
+    """A short mid-transmission window, the case where the beacon is
+    actually load-bearing: one superframe copy, no preamble. Over a whole
+    transmission six repetitions decode 100% either way."""
+    rng = np.random.default_rng(seed)
+    latents = rng.standard_normal(mode.n_latents)
+    latents /= np.sqrt(np.mean(latents**2))
+    tx = Modem().modulate(latents, mode, callsign=CALLSIGN)
+    rx = hfchannel.apply_channel(tx, snr_db=snr_db, fading_preset=preset, seed=seed)
+
+    start_frame = mode.n_frames // 3
+    lo = LEADIN_SAMPLES + PREAMBLE_SAMPLES + HEADER_SAMPLES + start_frame * FRAME_SAMPLES
+    win = rx[lo : lo + (MIN_FRAMES_FOR_SYNC + 4) * FRAME_SAMPLES]
+    return win, start_frame
+
+
+def test_beacon_decodes_through_fading_on_a_short_window():
+    mode = MODES["B"]
+    m = Modem()
+    ok = 0
+    for t in range(TRIALS):
+        win, start_frame = _blind_window(mode, "mpd", 8.0, 1000 * t)
+        b = m.demodulate_blind(win).beacon
+        ok += bool(
+            b is not None
+            and b.callsign == CALLSIGN
+            and b.mode_index == mode.index
+            and b.frame_index - b.chip_offset // CHIPS_PER_FRAME == start_frame
+        )
+    assert ok >= MIN_DECODES, f"{ok}/{TRIALS} beacon decodes, expected >= {MIN_DECODES}"


### PR DESCRIPTION
Stacked on #45 — merge that first. The base is
`claude/sstvae-beacon-4bit-field-fl8d8t` because the new tests assert
`beacon.mode_index`, which is #45's field.

Two commits, one unit of work: a soft-metric fix, and the combining
strategy that was built around the bug. Neither is safe without the
other and they are measured together throughout.

## The bug

The beacon carrier's soft chips came off the zero-forcing equalizer as
`real(y)`, unweighted. The 23 latent carriers have the confidence
weights for exactly this; the beacon carrier had nothing. So a chip
from a carrier sitting in a fade arrived as amplified noise carrying a
*large* magnitude — and Golay's soft ML decode reads magnitude as
confidence, so one faded chip outvotes the four good ones in its
codeword.

That pathology was already known downstream. `_decode_combined` summed
the **sign** of each repetition's chips rather than their values,
because "the per-frame channel estimate the equalizer divides by can
itself sit near a fade null, amplifying that frame's noise into an
enormous, essentially random magnitude." It was treating the symptom at
the far end of the pipe. This fixes the source and then removes the
workaround.

## The changes

```python
# 1. sstvae/modem/modem.py — both demodulate() and demodulate_blind()
beacon_soft[...] = np.real(raw[f, s, BEACON_CARRIER] * np.conj(h[BEACON_CARRIER]))

# 2. sstvae/modem/beacon.py — _decode_combined and _search_counter_chunk
summed += chips[pos + SYNC_LEN + clo : pos + SYNC_LEN + chi]   # was np.sign(...)
```

Maximal-ratio in both places. The first is the correct soft metric for
BPSK, is a shorter line than what it replaced, and drops the beacon's
dependence on `floor`/`med_h`; the second is what becomes correct once
a faded repetition arrives *small* instead of huge. Both mirrored in
C++ (the shared `equalize()`, and `beacon.cpp` — whose `sign()` helper
is deleted with its last caller).

## Measured

### The chip metric

`scripts/beacon_soft_sweep.py`, mode B, 60 trials/cell, paired (same
waveform and channel realization per variant). Bit-exact beacon decode
— callsign, mode and absolute frame index all correct — over a short
mid-transmission blind window:

| channel | SNR | `real(y)` | `real(y)·w` | shipped `real(raw·conj(h))` |
|---|---|---|---|---|
| awgn | 0.0 | 0.77 | 0.92 | **0.97** |
| awgn | −2.0 | 0.20 | 0.38 | **0.47** |
| mpg | 12.0 | 0.67 | 0.70 | **0.72** |
| mpg | 8.0 | 0.48 | **0.57** | 0.55 |
| mpg | 4.0 | 0.23 | 0.28 | **0.28** |
| mpp | 12.0 | 0.85 | 0.97 | **0.97** |
| mpp | 8.0 | 0.60 | 0.90 | **0.90** |
| mpp | 4.0 | 0.23 | 0.53 | **0.58** |
| mpd | 12.0 | 0.75 | 0.98 | **0.98** |
| mpd | 8.0 | 0.42 | 0.88 | **0.90** |
| mpd | 4.0 | 0.05 | 0.40 | **0.50** |

**mpg moves least**, because at 0.5 ms delay the whole 1150 Hz band
sits inside one coherence bandwidth, so there is no per-carrier fade to
deweight. That is also the answer to the question this started from —
whether hopping the beacon across carriers per frame would help — and
it is why a one-line change was preferred to a format break.

### The combining strategy

`scripts/beacon_combine_sweep.py`, mode B, 40 trials/cell, all four
combinations:

| chips | equalized | equalized | MRC | MRC |
|---|---|---|---|---|
| **combining** | **sign** | **raw** | **sign** | **raw** |
| awgn −4.0 | 0.45 | 0.20 | 0.50 | **0.65** |
| mpg 0.0 | 0.72 | 0.30 | 0.75 | **0.82** |
| mpp 0.0 | 0.57 | 0.23 | 0.72 | **0.93** |
| mpd 0.0 | 0.40 | 0.15 | 0.53 | **0.90** |

The two middle columns are why both old-chip variants were measured
rather than only the two that answer the question: raw summing really
was ruinous on the old chips, in **every** cell, not just the single
case the original comment cited. The workaround was right for its
input; the ordering inverts once the input is fixed. The changes
compound — mpd at 0 dB goes 0.40 → 0.90 — and **neither is safe
without the other**, which both files' comments now say explicitly.

An RMS-normalized middle ground was measured too. It sits between the
two everywhere and is never above plain coherent. Not kept.

## Getting a signal at all

Both sweeps needed rewriting before they measured anything, and the
reason is the same in each case and worth keeping:

- Over a **whole transmission** every variant decodes 1.00 in every
  cell — ~12 superframe repetitions hide everything. The first harness
  written for each of these measured nothing.
- Pushing the channel hard enough to move that number breaks
  **preamble acquisition** long before it breaks the beacon, which is
  why both sweeps run on the blind path.
- The combining sweep additionally needs a **150-frame** window: it is
  dead code below 3 repetitions (`_repetition_grid`) and saturated
  above ~6, and `SUPERFRAME_LEN` is 36.2 frames.

## Tests

Both pins are rates over channel realizations, not crafted frames.
`floor` bounds a *total* null, so the damage is graded rather than
catastrophic — a deterministic version of the first test passed against
the broken code before being thrown away.

`tests/test_beacon_soft_weighting.py`:

- mpd 8 dB, ≥18/25 — reverting the chip metric gives ~10/25.
- mpd 0 dB, ≥18/25 — reverting the combining gives ~13/25.

Both mutation-checked. Green: 252 fast, 18 slow, 118 parity, 29 ctest,
and 402 under `pytest --native`, so the C++ side is verified by the
same pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
