### PR TITLE
Rig: select the mic or data audio input for CAT keying (#49)

### DIFF
--- a/native/android-app/RigPane.qml
+++ b/native/android-app/RigPane.qml
@@ -340,6 +340,33 @@ ColumnLayout {
             onModelChanged: sync()
             onActivated: pane.rig.pttMethod = currentValue
         }
+        // Only a handful of radios key the mic and the rear data input
+        // with different CAT commands, so this appears only when the
+        // chosen model is one of them -- on a phone a permanently
+        // disabled row is a row worth scrolling past.
+        ComboBox {
+            id: pttAudioBox
+            Layout.fillWidth: true
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+            visible: pane.rig.pttAudioSupported && pane.rig.pttMethod === "cat"
+            enabled: !pane.rig.running
+            model: ["mic", "data"]
+            function label(v) {
+                return v === "data" ? "Transmit audio: data / rear input"
+                                    : "Transmit audio: mic / front input"
+            }
+            displayText: label(currentValue !== undefined ? currentValue : pane.rig.pttAudio)
+            delegate: ItemDelegate {
+                width: pttAudioBox.width
+                text: pttAudioBox.label(modelData)
+                highlighted: pttAudioBox.highlightedIndex === index
+            }
+            function sync() { currentIndex = Math.max(0, model.indexOf(pane.rig.pttAudio)) }
+            Component.onCompleted: sync()
+            onVisibleChanged: sync()
+            onActivated: pane.rig.pttAudio = currentValue
+        }
         Label {
             text: "VOX means this app does not key the radio at all — the "
                   + "transmit audio does, and the leader tone on the Send screen "

--- a/native/android-app/rigcontrol.cpp
+++ b/native/android-app/rigcontrol.cpp
@@ -82,6 +82,7 @@ constexpr auto kDeviceKey = "rig/device";
 constexpr auto kHostKey = "rig/host";
 constexpr auto kBaudKey = "rig/baud";
 constexpr auto kPttKey = "rig/ptt";
+constexpr auto kPttAudioKey = "rig/pttaudio";
 constexpr auto kDebugLogKey = "rig/debuglog";
 
 // Hamlib's trace, ring-buffered for the settings screen.
@@ -244,6 +245,7 @@ void RigControl::load() {
     host_ = s.value(QLatin1String(kHostKey), QString()).toString();
     baud_ = s.value(QLatin1String(kBaudKey), 0).toInt();
     ptt_ = s.value(QLatin1String(kPttKey), ptt_).toString();
+    ptt_audio_ = s.value(QLatin1String(kPttAudioKey), ptt_audio_).toString();
     debug_log_ = s.value(QLatin1String(kDebugLogKey), false).toBool();
 }
 
@@ -256,6 +258,7 @@ void RigControl::save() {
     s.setValue(QLatin1String(kHostKey), host_);
     s.setValue(QLatin1String(kBaudKey), baud_);
     s.setValue(QLatin1String(kPttKey), ptt_);
+    s.setValue(QLatin1String(kPttAudioKey), ptt_audio_);
     s.setValue(QLatin1String(kDebugLogKey), debug_log_);
 }
 
@@ -373,6 +376,21 @@ void RigControl::setPttMethod(const QString& m) {
     emit changed();
 }
 
+void RigControl::setPttAudio(const QString& a) {
+    if (a == ptt_audio_) return;
+    ptt_audio_ = a;
+    save();
+    emit changed();
+}
+
+bool RigControl::pttAudioSupported() const {
+#ifdef SSTVAE_ANDROID_HAVE_RIG
+    return rig::supports_ptt_audio_source(model_);
+#else
+    return false;
+#endif
+}
+
 QStringList RigControl::pttMethods() const {
     QStringList out{QStringLiteral("vox"), QStringLiteral("cat")};
     // **DTR and RTS are not offered over Bluetooth**, because RFCOMM has
@@ -482,6 +500,8 @@ bool RigControl::connectRig() {
     config.model = model_;
     config.baud = baud_;
     config.ptt_method = ptt_from(ptt_);
+    config.ptt_audio = ptt_audio_ == QLatin1String("data") ? rig::PttAudio::Data
+                                                          : rig::PttAudio::Mic;
 
     std::shared_ptr<rig::SerialTransport> transport;
     if (connection_ == QLatin1String("network")) {

--- a/native/android-app/rigcontrol.hpp
+++ b/native/android-app/rigcontrol.hpp
@@ -88,6 +88,12 @@ class RigControl : public QObject {
     Q_PROPERTY(QString pttMethod READ pttMethod WRITE setPttMethod NOTIFY changed)
     Q_PROPERTY(QStringList pttMethods READ pttMethods NOTIFY changed)
 
+    // "mic" | "data": which audio input CAT keying selects on a radio
+    // that keys the two differently (a TS-480 and friends). Meaningless
+    // on every other rig, which is what `pttAudioSupported` says.
+    Q_PROPERTY(QString pttAudio READ pttAudio WRITE setPttAudio NOTIFY changed)
+    Q_PROPERTY(bool pttAudioSupported READ pttAudioSupported NOTIFY changed)
+
     // --- live state --------------------------------------------------
     Q_PROPERTY(bool running READ running NOTIFY changed)
     // One line an operator can act on, which `running` cannot be.
@@ -159,6 +165,10 @@ public:
     void setPttMethod(const QString& m);
     QStringList pttMethods() const;
 
+    QString pttAudio() const { return ptt_audio_; }
+    void setPttAudio(const QString& a);
+    bool pttAudioSupported() const;
+
     bool running() const;
     QString connectionState() const;
     bool failed() const;
@@ -215,6 +225,7 @@ private:
     QString host_;
     int baud_ = 0;  // 0 = whatever the chosen backend would have used
     QString ptt_ = QStringLiteral("cat");
+    QString ptt_audio_ = QStringLiteral("mic");
     bool debug_log_ = false;
 
     // False when `init_rig_bridge` could not hand the layer a VM and a

--- a/native/core/rig/hamlib.cpp
+++ b/native/core/rig/hamlib.cpp
@@ -230,8 +230,16 @@ public:
 
     void set_ptt(bool on) override {
         require_open();
-        const int rc =
-            rig_set_ptt(rig_, RIG_VFO_CURR, on ? RIG_PTT_ON : RIG_PTT_OFF);
+        // RIG_PTT_ON for the mic, not RIG_PTT_ON_MIC: they differ on a
+        // MICDATA rig (`TX` against `TX0`) and only the first is what
+        // this app has always sent, so the default keys the radio the
+        // way it did before this setting existed. Hamlib downgrades
+        // ON_DATA to ON on a rig that is not MICDATA, so the branch is
+        // safe even if a config claims otherwise.
+        const ptt_t key = config_.ptt_audio == PttAudio::Data && key_by_cat()
+                              ? RIG_PTT_ON_DATA
+                              : RIG_PTT_ON;
+        const int rc = rig_set_ptt(rig_, RIG_VFO_CURR, on ? key : RIG_PTT_OFF);
         if (rc != RIG_OK) {
             throw RigError(hamlib_error(on ? "PTT on failed" : "PTT off failed", rc));
         }
@@ -324,6 +332,8 @@ private:
         }
     }
 
+    bool key_by_cat() const { return config_.ptt_method == PttMethod::Cat; }
+
     void apply_ptt_settings() {
         switch (config_.ptt_method) {
             // Vox means the rig is keyed by its own audio detector, so
@@ -331,7 +341,13 @@ private:
             // says exactly that. Callers are additionally expected not
             // to hand this backend to the transmit engine as a PTT.
             case PttMethod::Vox: set_conf("ptt_type", "None"); break;
-            case PttMethod::Cat: set_conf("ptt_type", "RIG"); break;
+            // "RIG" would *downgrade* a MICDATA rig: the token
+            // overwrites caps->ptt_type, and RIG_PTT_RIG makes Hamlib
+            // fold ON_DATA back into a plain mic key.
+            case PttMethod::Cat:
+                set_conf("ptt_type",
+                         config_.ptt_audio == PttAudio::Data ? "RIGMICDATA" : "RIG");
+                break;
             case PttMethod::Dtr: set_conf("ptt_type", "DTR"); break;
             case PttMethod::Rts: set_conf("ptt_type", "RTS"); break;
         }
@@ -455,6 +471,12 @@ SerialDefaults serial_defaults(int model) {
     // better message than this function could give. 9600 8-N-1 rather
     // than throwing, so a settings screen can still render.
     return search.out;
+}
+
+bool supports_ptt_audio_source(int model) {
+    load_backends_once();
+    return rig_get_caps_int(static_cast<rig_model_t>(model), RIG_CAPS_PTT_TYPE) ==
+           RIG_PTT_RIG_MICDATA;
 }
 
 std::unique_ptr<RigBackend> make_hamlib_backend(const HamlibConfig& config) {

--- a/native/core/rig/hamlib.hpp
+++ b/native/core/rig/hamlib.hpp
@@ -75,6 +75,15 @@ std::vector<RigModel> list_models();
 // that fails.
 enum class PttMethod { Vox, Cat, Dtr, Rts };
 
+// Which audio input the rig should key, on the radios that have two of
+// them (Hamlib's `RIG_PTT_RIG_MICDATA`: a TS-480 keys the mic with
+// `TX0` and the rear data input with `TX1`). `Mic` is what a plain
+// `RIG_PTT_ON` has always done, so it is the default and changes
+// nothing; `Data` is the one this exists for, and is only offered for
+// CAT keying on a model whose caps declare the pair --
+// `supports_ptt_audio_source()` below.
+enum class PttAudio { Mic, Data };
+
 // Serial line settings. `Default` means do not set the token, leaving
 // the backend's own value -- which is right for almost every rig, and
 // is why it is a distinct choice rather than a guess at 8-N-1.
@@ -105,6 +114,7 @@ struct HamlibConfig {
     LineState rts = LineState::Default;
 
     PttMethod ptt_method = PttMethod::Cat;
+    PttAudio ptt_audio = PttAudio::Mic;
     // Empty means the CAT device. Often different: a serial adapter
     // whose control lines key the rig while CAT runs elsewhere.
     std::string ptt_device;
@@ -139,6 +149,11 @@ std::unique_ptr<RigBackend> make_hamlib_backend(const HamlibConfig& config);
 // Windows shim's type sizes cannot silently misplace its fields.
 // Falls back to 9600 8-N-1 for a model Hamlib does not know.
 SerialDefaults serial_defaults(int model);
+
+// Whether this model keys its mic and data inputs with different CAT
+// commands, i.e. whether `HamlibConfig::ptt_audio` means anything to
+// it. False for every other rig, including one Hamlib does not know.
+bool supports_ptt_audio_source(int model);
 
 // Hamlib's version string, for an about box or a bug report.
 std::string hamlib_version();

--- a/native/core/settings/settings.cpp
+++ b/native/core/settings/settings.cpp
@@ -215,6 +215,7 @@ void read_rig(const Reader& r, RigConfig& c) {
     r.get("rts", c.rts);
     r.get("ptt_method", c.ptt_method);
     r.get("ptt_device", c.ptt_device);
+    r.get("ptt_audio", c.ptt_audio);
     r.get("mode", c.mode);
     // The v1 keys are listed as known so that a config written by the
     // Python app is *quietly* migrated rather than reported as four
@@ -227,7 +228,7 @@ void read_rig(const Reader& r, RigConfig& c) {
     r.report_unknown({"enabled", "model", "poll_interval_s", "ptt_lead_s",
                       "ptt_tail_s", "device", "baud", "data_bits", "stop_bits",
                       "parity", "handshake", "dtr", "rts", "ptt_method",
-                      "ptt_device", "mode",
+                      "ptt_device", "ptt_audio", "mode",
                       // v1, ignored:
                       "host", "port", "spawn_local"});
 }
@@ -434,6 +435,7 @@ std::string to_json(const Config& c) {
           {"rts", c.rig.rts},
           {"ptt_method", c.rig.ptt_method},
           {"ptt_device", c.rig.ptt_device},
+          {"ptt_audio", c.rig.ptt_audio},
           {"mode", c.rig.mode}}},
         {"folders",
          {{"receive_dir", c.folders.receive_dir},

--- a/native/core/settings/settings.hpp
+++ b/native/core/settings/settings.hpp
@@ -124,6 +124,10 @@ struct RigConfig {
     // whose control lines key the rig while CAT runs elsewhere, or a
     // rig with no CAT keying at all. Empty means "the CAT device".
     std::string ptt_device;
+    // Which audio input CAT keying should select on a radio that has
+    // two (a TS-480 and friends: Hamlib's RIG_PTT_RIG_MICDATA). "mic"
+    // is what every rig did before this key existed.
+    std::string ptt_audio = "mic";  // mic | data
 
     // Set on the rig when the session opens; "none" leaves whatever the
     // operator has dialled in alone.

--- a/native/gui/rig_config.cpp
+++ b/native/gui/rig_config.cpp
@@ -69,6 +69,9 @@ std::unique_ptr<rig::RigBackend> make_backend(const settings::RigConfig& config)
                                                 {"rts", rig::PttMethod::Rts}},
                                                rig::PttMethod::Cat);
     hamlib.ptt_device = config.ptt_device;
+    hamlib.ptt_audio = lookup<rig::PttAudio>(config.ptt_audio,
+                                             {{"data", rig::PttAudio::Data}},
+                                             rig::PttAudio::Mic);
     hamlib.mode = lookup<rig::RigMode>(
         config.mode, {{"usb", rig::RigMode::Usb}, {"pkt_usb", rig::RigMode::PktUsb}},
         rig::RigMode::None);

--- a/native/gui/settings_dialog.cpp
+++ b/native/gui/settings_dialog.cpp
@@ -610,10 +610,20 @@ QWidget* SettingsDialog::rig_tab() {
     ptt_device_->setPlaceholderText(tr("(the device above)"));
     form->addRow(tr("PTT"),
                  style::row(page, {ptt_method_, new QLabel(tr("Port"), page), ptt_device_}, 2));
+    // Only a few radios key their mic and rear data inputs with
+    // different CAT commands, so the choice is disabled rather than
+    // hidden on the rest: hiding it would read as "this app cannot",
+    // which is the question the operator arrived with.
+    ptt_audio_ = compact(choice(page, {{"mic", "Mic / front"}, {"data", "Data / rear"}},
+                                rig.ptt_audio));
+    connect(rig_model_, &QComboBox::currentTextChanged, this,
+            &SettingsDialog::sync_ptt_enabled);
+    form->addRow(tr("Transmit audio"), style::row(page, {ptt_audio_}));
     form->addRow(QString(),
                  style::note(tr("VOX means do not key at all — the radio is keyed "
                                 "by the audio. DTR and RTS may use a different "
-                                "port from CAT."),
+                                "port from CAT. Transmit audio picks which input "
+                                "CAT keying selects, on the radios that have two."),
                              page));
     sync_ptt_enabled();
     add_gap(form);
@@ -682,6 +692,8 @@ void SettingsDialog::sync_filename_preview() {
 void SettingsDialog::sync_ptt_enabled() {
     const std::string method = chosen(ptt_method_);
     ptt_device_->setEnabled(method == "dtr" || method == "rts");
+    ptt_audio_->setEnabled(method == "cat" &&
+                           rig::supports_ptt_audio_source(rig_model_number()));
 }
 
 int SettingsDialog::rig_model_number() const {
@@ -722,6 +734,9 @@ settings::RigConfig SettingsDialog::pending_rig() const {
     rig.rts = rts_forced_->isChecked() ? chosen(rts_) : std::string("default");
     rig.ptt_method = chosen(ptt_method_);
     rig.ptt_device = ptt_device_->text().trimmed().toStdString();
+    // Written back whether or not the control is enabled: a rig chosen
+    // today does not settle what the operator's saved setting meant.
+    rig.ptt_audio = chosen(ptt_audio_);
     rig.mode = chosen(rig_mode_);
     rig.poll_interval_s = poll_interval_s_->value();
     rig.ptt_lead_s = ptt_lead_->value();

--- a/native/gui/settings_dialog.hpp
+++ b/native/gui/settings_dialog.hpp
@@ -110,6 +110,7 @@ private:
     QComboBox* rts_ = nullptr;
     QComboBox* ptt_method_ = nullptr;
     QLineEdit* ptt_device_ = nullptr;
+    QComboBox* ptt_audio_ = nullptr;
     QComboBox* rig_mode_ = nullptr;
     QDoubleSpinBox* poll_interval_s_ = nullptr;
     QDoubleSpinBox* ptt_lead_ = nullptr;

--- a/native/tests/test_rig_hamlib.cpp
+++ b/native/tests/test_rig_hamlib.cpp
@@ -217,6 +217,9 @@ namespace {
 // Kenwood TS-2000: a real serial backend, used both by the caps
 // test here and by the bridged tests below.
 constexpr int MODEL_TS2000 = 2014;
+// A TS-480, which is one of the radios whose mic and rear data inputs
+// key with *different* CAT commands (`RIG_PTT_RIG_MICDATA`).
+constexpr int MODEL_TS480 = 2028;
 }  // namespace
 
 // The trace an operator's bug report needs, routed somewhere an app can
@@ -393,6 +396,10 @@ struct Kenwood {
     std::condition_variable cv;
     bool closed = false;
 
+    // The TS-2000's identifier by default; a MICDATA radio answers with
+    // its own, and the Kenwood backend refuses to open on a mismatch.
+    std::string id = "ID019;";
+
     long long freq = 14'074'000;
     std::vector<std::string> commands;   // every command, in order
     std::deque<char> pending;            // bytes waiting to go back
@@ -408,7 +415,7 @@ struct Kenwood {
     void handle(const std::string& command) {
         commands.push_back(command);
         if (command == "ID") {
-            reply("ID019;");  // the TS-2000's identifier
+            reply(id);
         } else if (command == "FA") {
             char buf[32];
             std::snprintf(buf, sizeof(buf), "FA%011lld;", freq);
@@ -604,6 +611,57 @@ void test_dtr_keying_never_reaches_hamlib() {
     check::equal(radio->dtr, 0, "hamlib/bridge: unkeying releases it");
 }
 
+// Issue #49: a TS-480 keys its mic with `TX0` and its rear data input
+// with `TX1`, and this app sent a plain `TX` -- the mic -- whatever the
+// operator had wired up. Two halves have to be right at once, which is
+// why this is one test: `ptt_type` must be left as RIGMICDATA (setting
+// it to "RIG" overwrites the rig's caps and makes Hamlib fold the
+// request back into a mic key, silently), *and* the keying call has to
+// ask for the data input.
+void test_the_data_input_can_be_keyed_instead_of_the_mic() {
+    auto radio = std::make_shared<Kenwood>();
+    radio->id = "ID020;";  // the TS-480's
+    rig::HamlibConfig config;
+    config.model = MODEL_TS480;
+    config.ptt_method = rig::PttMethod::Cat;
+    config.ptt_audio = rig::PttAudio::Data;
+    config.device = "usb:10c4:ea60";
+
+    check::is_true(rig::supports_ptt_audio_source(MODEL_TS480),
+                   "hamlib: the TS-480 is known to key mic and data apart");
+    check::is_true(!rig::supports_ptt_audio_source(MODEL_TS2000),
+                   "hamlib: ...and a rig without the pair is not");
+
+    auto backend = bridged(config, radio);
+    backend->open();
+    backend->set_ptt(true);
+    check::is_true(radio->wait_for("TX1"),
+                   "hamlib: data keying reaches the radio as TX1");
+    backend->set_ptt(false);
+    check::is_true(radio->wait_for("RX"), "hamlib: and unkeying is unchanged");
+    backend->close();
+}
+
+// The default keys the radio exactly as it did before the setting
+// existed -- a bare `TX`, not `TX0`. They differ on this radio, and
+// only the first is what every previous version sent.
+void test_mic_keying_is_the_command_it_always_was() {
+    auto radio = std::make_shared<Kenwood>();
+    radio->id = "ID020;";
+    rig::HamlibConfig config;
+    config.model = MODEL_TS480;
+    config.ptt_method = rig::PttMethod::Cat;
+    config.device = "usb:10c4:ea60";
+
+    auto backend = bridged(config, radio);
+    backend->open();
+    backend->set_ptt(true);
+    check::is_true(radio->wait_for("TX"),
+                   "hamlib: the default keys the radio with a plain TX");
+    backend->set_ptt(false);
+    backend->close();
+}
+
 void test_the_controller_drives_a_bridged_rig() {
     // The same threading design, over the new transport: nothing about
     // RigController changed to make this work, which is the property
@@ -695,6 +753,8 @@ int main() {
 #ifndef _WIN32
         STEP(test_a_native_backend_works_over_a_socket);
         STEP(test_dtr_keying_never_reaches_hamlib);
+        STEP(test_the_data_input_can_be_keyed_instead_of_the_mic);
+        STEP(test_mic_keying_is_the_command_it_always_was);
         STEP(test_the_controller_drives_a_bridged_rig);
 #endif
         check::current_step = "reporting";

--- a/native/tests/test_settings_dialog.cpp
+++ b/native/tests/test_settings_dialog.cpp
@@ -49,6 +49,7 @@ settings::Config populated() {
     c.rig.rts = "low";
     c.rig.ptt_method = "rts";
     c.rig.ptt_device = "/dev/ttyUSB9";
+    c.rig.ptt_audio = "data";
     c.rig.mode = "pkt_usb";
 
     c.folders.receive_dir = "/srv/sstv/in";

--- a/tests/test_native_settings.py
+++ b/tests/test_native_settings.py
@@ -78,6 +78,7 @@ NON_DEFAULT = {
         "rts": "low",
         "ptt_method": "rts",
         "ptt_device": "COM7",
+        "ptt_audio": "data",
         "mode": "pkt_usb",
         "ptt_lead_s": 0.45,
         "ptt_tail_s": 0.25,


### PR DESCRIPTION
Closes #49.

On radios with Hamlib's `RIG_PTT_RIG_MICDATA` ptt type (TS-480 and friends) the mic and the rear data input key with *different* CAT commands — `TX0` and `TX1`. This app sent a plain `TX`, so a station wired to the rear panel keyed the front one, as the issue reports.

**The setting was only half of it.** `apply_ptt_settings` forced `ptt_type` to `"RIG"` for CAT keying, and that token overwrites the rig's own caps — so even a well-formed data request would have been folded back into a mic key, silently. Both halves are in here, and both are pinned by the test.

- `core/rig/hamlib.*` — `PttAudio{Mic,Data}` on `HamlibConfig`; `"RIGMICDATA"` when the operator asks for the data input, `"RIG"` otherwise; `RIG_PTT_ON_DATA` only for CAT keying. Mic stays `RIG_PTT_ON` rather than `RIG_PTT_ON_MIC` — they differ on a MICDATA rig, and only the first is the command every previous version sent, so the default changes nothing.
- `supports_ptt_audio_source(model)` reads `caps->ptt_type` through `rig_get_caps_int`, so the choice is only offered where it means something: disabled on the desktop, hidden on the phone.
- Desktop: a `rig.ptt_audio` setting (`mic` | `data`) and a "Transmit audio" combo on the rig page.
- Android: `pttAudio` / `pttAudioSupported` on `RigControl` and a combo in `RigPane.qml`, shown only for a MICDATA model on CAT.

Test: `test_rig_hamlib` drives a TS-480 over the existing bridged Kenwood fake — `TX1` for data, a bare `TX` for the default. Mutation-tested in both directions (revert the token or the keying call and it fails).

ctest 31/31, `pytest tests/test_native_settings.py` 19/19, `check_includes` / `check_layering` clean, x86_64 APK builds.

**Not verified on hardware** — no MICDATA radio here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aan2xGiPjn1t6UydAkAPu9