### PR TITLE
rx: keep a reception open until its scheduled end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      # Cap torch's CPU dispatch below AVX-512, both ATen's own kernels
+      # and oneDNN's JIT (the bf16 matmul path). The hosted runner pools
+      # are heterogeneous fleets, and on 2026-09-01 a windows-latest
+      # machine died with 0xc000001d (STATUS_ILLEGAL_INSTRUCTION) inside
+      # the bfloat16 matmuls of muon.newton_schulz -- oneDNN picked an
+      # AVX-512/AMX kernel by CPUID and the machine faulted on it; the
+      # re-run passed only because it landed on a different SKU. torch
+      # in this job is the *reference* implementation, so the cap costs
+      # speed nobody measures and makes the kernel choice deterministic.
+      # Set for all three platforms: the die roll is a property of any
+      # mixed fleet, not of Windows.
+      ATEN_CPU_CAPABILITY: avx2
+      DNNL_MAX_CPU_ISA: AVX2
     steps:
       - uses: actions/checkout@v7
       # Exact tag, because setup-uv publishes no moving major alias at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1565,6 +1565,18 @@ need when `--native` fails and you want to know *where*.
   enough to matter smears past the 32-sample CP and causes ISI. The
   160-sample demod correlation already nulls the heterodyne image
   exactly. Only sync filters (its own copy).
+- **A CI python job dying with `0xc000001d` in a torch test is the
+  runner, not the test** (`STATUS_ILLEGAL_INSTRUCTION`, seen 2026-09-01
+  on windows-latest inside `muon.newton_schulz`'s bfloat16 matmuls, and
+  at least once before that). The hosted pools are heterogeneous
+  fleets; torch/oneDNN pick AVX-512/AMX kernels by CPUID and some SKUs
+  fault on them, so the same commit passes on re-run by landing on a
+  different machine. `ci.yml`'s python job now pins
+  `ATEN_CPU_CAPABILITY=avx2` and `DNNL_MAX_CPU_ISA=AVX2` to make the
+  choice deterministic — torch there is the reference implementation,
+  so only unmeasured speed is spent. If that signature ever appears
+  *with* the caps in place, it is a different bug: read the faulting
+  frame before blaming the fleet.
 - The timing tracker must be heavily smoothed: raw per-frame pilot
   phase slope sees multipath group delay (± many samples), while real
   clock drift is <0.1 sample/frame. Chasing it raw wrecked MPP fading

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,17 +250,10 @@ rule is enforced by `tools/check_layering.py`.
   to the sink. **The reported hang and "autosave never fires" are one
   bug seen from two ends**, since the sink is the only thing that
   saves. A poll that decodes nothing must therefore *count against* a
-  reception, not be skipped over. Three things ended up load-bearing.
+  reception, not be skipped over. Two things ended up load-bearing.
   The header path needs a **deadline of its own** (its known mode's
   duration past its start, where blind uses mode C's) — it had none at
-  all, `frames_received >= n_frames_expected` and nothing else. The
-  stall test **must not be extended to the header path** while it is
-  still decoding: a spurious preamble lock in noise goes on decoding
-  the same handful of frames for as long as it is looked at, and
-  ending *that* on a stall turns a false lock into a saved picture of
-  noise (`test_noise_produces_nothing` is what catches it) — so the
-  stall clock runs on polls where the reception did not decode, plus,
-  blind only, where it decoded and did not advance. And
+  all, `frames_received >= n_frames_expected` and nothing else. And
   `decode_loop_low_cpu`'s "wait until the transmission should have
   arrived" is a wait on **something outside the loop's control**, so it
   is bounded by the audio still missing plus `end_grace`; unbounded, a
@@ -270,33 +263,100 @@ rule is enforced by `tools/check_layering.py`.
   way to ask the real modem to stop decoding on cue, which is why the
   slow suite cannot cover it.
 
-  **The progress bar is position, not fill**: the last frame
-  successfully received over the frames expected, never latents
-  received over latents expected. Only the blind path can tell the two
-  apart — the preamble path decodes a contiguous prefix, so its
-  `frames_received` count *is* its reach — and there a fill fraction is
-  a completion percentage that is not one: the erasures that path lives
-  with (a fade, or simply not having heard the start) hold it down
-  permanently, so a reception already at the transmission's last frame
-  reported 70% and the bar never filled. `_blind_progress` returns the
-  numbers separately because they answer different questions — the
-  confident
-  *count* is still what the `--end-grace` stall detector watches, since
-  retrospective decoding filling in frames behind the furthest one is
-  real progress that the reach deliberately does not move. **The reach
-  is also what the blind path reports as `frames_received`** (since the
-  beacon's mode field supplied `n_frames_expected`, every status line
-  formats the frames pair and the percentage together — leaving it
-  unset froze one indicator next to the other), and that is why
-  `complete` is gated on `not pending.blind`: a reach at the last frame
-  is a position with erasures behind it, exactly when backfill is still
-  improving the picture, not a finished count.
-  `framing.frame_of_latent()` is what makes the reach computable at all
-  (the inverse of `slot_range_for_frame`, as one cached table): the
-  interleaver scatters each frame across the whole picture, so a latent
-  count answers "how much" and only the frame index answers "how far".
-  Mirrored in `native/core/`, where `rx::blind_progress` is public for
-  the same reason `poll_wait` is.
+  **Delivering a reception and retiring it are separate events**
+  (2026-08-26), and that split is what `end_grace` means now. Once the
+  beacon's mode field made `deadline_abs` exact on the blind path too
+  (`PROTOCOL_VERSION` 4), the stall detector's original job — stopping
+  a blind mode-A/B reception from running to mode C's length and
+  diluting the picture with noise — was gone, and what was left was a
+  misfire: **a fade longer than `end_grace` is indistinguishable from a
+  transmitter that stopped**, and ending the reception recorded its
+  start in `finished_starts`, so the blind path's re-acquisition
+  seconds later was dropped by `_already_finished` and the rest of a
+  picture still being heard was *refused* for the rest of the
+  transmission. So a stall now **delivers** (autosave must not wait on
+  a signal that may never come back) and leaves the reception
+  **dormant** — still tracked, status `waiting`/`Status::Waiting` —
+  until `complete`, its deadline, or a different reception taking the
+  slot. What makes that nearly free is that **the record is not an
+  accumulator**: every decode is retrospective over the whole ring, and
+  the ring (130 s) outlives the longest mode (95 s), so one re-decode
+  after a fade recovers everything and the engine only has to stop
+  refusing to try. Four consequences.
+  `Reception.saved_path` says "this one was already delivered here,
+  **replace** it" — one transmission is one file, one gallery entry,
+  one notification, which is why Android's `save_reception` overwrites
+  in place and deliberately does *not* re-arm the consuming
+  `take_saved_picture()`.
+  A dormant reception is in `finished_starts` (so the preamble search
+  steps over it and a transmission cut off early cannot go on hiding a
+  later one) but is checked **before** that list on the blind path,
+  which is the whole resume mechanism.
+  Taking over the tracked slot now **delivers what it replaces**
+  instead of discarding it, which was survivable only while stalls
+  retired receptions quickly.
+  And only an at-least-as-good decode replaces the held picture:
+  receptions live long enough now to see fade-time decodes, and
+  everything but `metric` was last-write-wins.
+
+  **The stall is no longer blind-only, and the old reasoning for that
+  was about the wrong number.** It said a spurious preamble lock in
+  noise decodes the same handful of frames forever, so stalling the
+  header path would autosave a picture of noise. But the header path's
+  `frames_received` is `received.sum()`, and `received[f]` is true for
+  every frame whose *samples are in the buffer* — signal or noise,
+  faded or clean. It is buffer coverage, not signal: it climbs through
+  a fade, it climbs through the noise after a transmitter cuts off
+  (which is why *that* case ends on `complete` at the scheduled end and
+  never needed a stall), and a false lock climbs with it. The one thing
+  that stops it is **the buffer not growing** — capture unplugged, the
+  stream dead — and there the header path had no test that could ever
+  fire (it keeps decoding, it never reaches its count, and `total` has
+  stopped so the deadline is unreachable by construction): the same
+  indefinite "receiving" this record exists to close, left open on one
+  path. `test_noise_produces_nothing` still holds and still matters.
+
+  **Three numbers, and the bar is the one that climbs with the clock**
+  (2026-08-26). `frames_received` is now `_frames_in_buffer` on both
+  paths — the frames of the transmission whose *audio has arrived*,
+  arithmetic on buffer positions with no weights in it — and that is
+  what the bar shows. Beside it, less prominently, `frames_decoded`:
+  how many of those frames carried confident data. And unchanged
+  underneath, the confident-latent *count*, which is the only thing the
+  `--end-grace` stall clock may ever be fed.
+
+  The bar was previously the blind path's *reach* (the furthest frame
+  decoded), which was itself a fix for a fill fraction that could never
+  reach 100% — the erasures that path lives with (a fade, or simply not
+  having heard the start) hold a fill down permanently. But a reach
+  stalls too: it freezes for the whole of a fade, on the display that
+  is supposed to say whether anything is still happening. Buffer
+  position has neither problem, and the header path had been reporting
+  exactly it all along without anyone noticing — `DemodResult.frames_received`
+  is `received.sum()`, and `received[f]` is set for every frame whose
+  samples are in the buffer. So this is the header path's number
+  generalized rather than a new invention, and the reach is retired.
+  A late join starts the bar part-way up (its early frames are gone for
+  good) rather than at zero, which is why `buf_start` is an argument.
+
+  **The stall metric is load-bearing and none of the display numbers
+  can stand in for it.** Anything positional does not move when
+  retrospective decoding fills in frames *behind* the furthest one,
+  which is real progress and must not read as a stall; and any count
+  over the whole legal frame range climbs on buffer growth alone, so a
+  reception fed that would never stall at all. `_decode_progress`
+  returns the count and `frames_decoded` from one pass over the same
+  mask, and `tests/test_rx_progress.py` pins all three apart.
+  `framing.frame_of_latent()` is what makes the decoded count
+  computable (the inverse of `slot_range_for_frame`, as one cached
+  table): the interleaver scatters each frame across the whole picture,
+  so a latent count answers "how much" and only a frame index answers
+  "how far". `complete` stays gated on `not pending.blind` — on the
+  blind path frames_received reaching the total says the audio arrived,
+  not that it decoded, and retiring on that is the deadline's job (the
+  same instant, by construction). Mirrored in `native/core/`, where
+  `rx::decode_progress` and `rx::frames_in_buffer` are public for the
+  same reason `poll_wait` is.
 - `sstvae/tx/engine.py` — encode → modulate → PTT → play → unkey.
   **The invariant is that PTT always comes back down**: try/finally
   around the keyed region *plus* an independent `_PttWatchdog` thread

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,62 +282,80 @@ rule is enforced by `tools/check_layering.py`.
   accumulator**: every decode is retrospective over the whole ring, and
   the ring (130 s) outlives the longest mode (95 s), so one re-decode
   after a fade recovers everything and the engine only has to stop
-  refusing to try. Four consequences.
+  refusing to try. Five consequences.
   `Reception.saved_path` says "this one was already delivered here,
   **replace** it" — one transmission is one file, one gallery entry,
   one notification, which is why Android's `save_reception` overwrites
   in place and deliberately does *not* re-arm the consuming
-  `take_saved_picture()`.
+  `take_saved_picture()`. `Reception.redelivery` carries the "same
+  reception again" fact separately, because a sink that declines to
+  save (the desktop with autosave off) returns no path — keyed on the
+  path alone, a redelivery there logged a second "reception complete"
+  for one transmission.
   A dormant reception is in `finished_starts` (so the preamble search
   steps over it and a transmission cut off early cannot go on hiding a
-  later one) but is checked **before** that list on the blind path,
-  which is the whole resume mechanism.
+  later one) but stays resumable on **both** paths: the blind path
+  checks the tracked reception before that list, and the header path
+  aims one targeted demodulate at its own preamble when the span search
+  finds nothing new — without which a reception whose beacon doesn't
+  decode ("blind-locked with the beacon not decoding" is a real field
+  state) was unreachable after one stall.
   Taking over the tracked slot now **delivers what it replaces**
   instead of discarding it, which was survivable only while stalls
   retired receptions quickly.
-  And only an at-least-as-good decode replaces the held picture:
+  Only an at-least-as-good decode replaces the held picture:
   receptions live long enough now to see fade-time decodes, and
   everything but `metric` was last-write-wins.
+  And `deadline_abs` has a **wall-clock shadow** (`deadline_wall`,
+  anchored when the deadline is computed, never per poll): the buffer
+  deadline is measured against `total`, so a capture that dies
+  mid-reception freezes `total` below it and makes it unreachable by
+  construction — the record (and `--once`) then sat in "waiting"
+  forever. While capture is alive the shadow trails the buffer deadline
+  by `end_grace` and never fires.
 
-  **The stall is no longer blind-only, and the old reasoning for that
-  was about the wrong number.** It said a spurious preamble lock in
-  noise decodes the same handful of frames forever, so stalling the
-  header path would autosave a picture of noise. But the header path's
-  `frames_received` is `received.sum()`, and `received[f]` is true for
-  every frame whose *samples are in the buffer* — signal or noise,
-  faded or clean. It is buffer coverage, not signal: it climbs through
-  a fade, it climbs through the noise after a transmitter cuts off
-  (which is why *that* case ends on `complete` at the scheduled end and
-  never needed a stall), and a false lock climbs with it. The one thing
-  that stops it is **the buffer not growing** — capture unplugged, the
-  stream dead — and there the header path had no test that could ever
-  fire (it keeps decoding, it never reaches its count, and `total` has
-  stopped so the deadline is unreachable by construction): the same
-  indefinite "receiving" this record exists to close, left open on one
-  path. `test_noise_produces_nothing` still holds and still matters.
+  **The stall is no longer blind-only, and the stall clock watches one
+  number on both paths: the confident-latent count.** The old
+  blind-only rule said a spurious preamble lock in noise decodes the
+  same handful of frames forever, so stalling the header path would
+  autosave a picture of noise — but what protects against that is the
+  delivery gate, not the stall's reach: nothing is delivered, at a
+  stall or a deadline, without confident latents, and noise has
+  essentially none. The header path briefly fed `received.sum()` in as
+  its metric instead, and that was wrong twice over: it is buffer
+  coverage, true for every frame whose *samples* are in the buffer, so
+  it climbs for noise exactly as for signal (a false lock would have
+  been *delivered* at its deadline), and it made `metric` a frame count
+  on one path and a latent count on the other — `pending.metric` and
+  `delivered_metric` compare across polls, a reception can stall on the
+  header path and resume blind, and a ~2-frame blind decode (hundreds
+  of latents) then outranked a delivered half-transmission (a frame
+  count) and overwrote the better picture.
+  `test_noise_produces_nothing` still holds and still matters.
 
   **Three numbers, and the bar is the one that climbs with the clock**
-  (2026-08-26). `frames_received` is now `_frames_in_buffer` on both
-  paths — the frames of the transmission whose *audio has arrived*,
-  arithmetic on buffer positions with no weights in it — and that is
-  what the bar shows. Beside it, less prominently, `frames_decoded`:
-  how many of those frames carried confident data. And unchanged
-  underneath, the confident-latent *count*, which is the only thing the
-  `--end-grace` stall clock may ever be fed.
+  (2026-08-26). `frames_received` is the bar: on the blind path
+  `_frames_elapsed` — whole frames since the transmission's own first
+  frame, clamped to the mode's count, arithmetic on buffer positions
+  with no weights in it — and on the header path `received.sum()`,
+  which agrees while capture is alive since that path heard the start.
+  Beside it, less prominently, `frames_decoded`: how many frames
+  carried confident data. And underneath, the confident-latent *count*,
+  the only thing the `--end-grace` stall clock may ever be fed.
 
   The bar was previously the blind path's *reach* (the furthest frame
   decoded), which was itself a fix for a fill fraction that could never
   reach 100% — the erasures that path lives with (a fade, or simply not
   having heard the start) hold a fill down permanently. But a reach
   stalls too: it freezes for the whole of a fade, on the display that
-  is supposed to say whether anything is still happening. Buffer
-  position has neither problem, and the header path had been reporting
-  exactly it all along without anyone noticing — `DemodResult.frames_received`
-  is `received.sum()`, and `received[f]` is set for every frame whose
-  samples are in the buffer. So this is the header path's number
-  generalized rather than a new invention, and the reach is retired.
-  A late join starts the bar part-way up (its early frames are gone for
-  good) rather than at zero, which is why `buf_start` is an argument.
+  is supposed to say whether anything is still happening. Elapsed
+  position has neither problem. It deliberately counts from the
+  transmission's first frame, not from the audio we captured: a late
+  join starts the bar part-way up — the transmission *is* 400 frames
+  into its schedule when we join — and still reaches 100%, where a
+  captured-audio count starts at zero and caps below the top forever.
+  The frames a join missed show up as the gap against `frames_decoded`,
+  exactly like a fade's.
 
   **The stall metric is load-bearing and none of the display numbers
   can stand in for it.** Anything positional does not move when
@@ -346,7 +364,9 @@ rule is enforced by `tools/check_layering.py`.
   over the whole legal frame range climbs on buffer growth alone, so a
   reception fed that would never stall at all. `_decode_progress`
   returns the count and `frames_decoded` from one pass over the same
-  mask, and `tests/test_rx_progress.py` pins all three apart.
+  mask (guarding the `frame_of_latent()` -1 slots, which numpy would
+  otherwise wrap to the last frame), and `tests/test_rx_progress.py`
+  pins all three apart.
   `framing.frame_of_latent()` is what makes the decoded count
   computable (the inverse of `slot_range_for_frame`, as one cached
   table): the interleaver scatters each frame across the whole picture,
@@ -355,7 +375,7 @@ rule is enforced by `tools/check_layering.py`.
   blind path frames_received reaching the total says the audio arrived,
   not that it decoded, and retiring on that is the deadline's job (the
   same instant, by construction). Mirrored in `native/core/`, where
-  `rx::decode_progress` and `rx::frames_in_buffer` are public for the
+  `rx::decode_progress` and `rx::frames_elapsed` are public for the
   same reason `poll_wait` is.
 - `sstvae/tx/engine.py` — encode → modulate → PTT → play → unkey.
   **The invariant is that PTT always comes back down**: try/finally

--- a/native/android-app/listener.cpp
+++ b/native/android-app/listener.cpp
@@ -331,6 +331,11 @@ void Listener::stop() {
 QString Listener::plain_status() const {
     const rx::Progress p = Session::instance().progress();
     if (p.status == rx::Status::Done) return QStringLiteral("Picture complete");
+    if (p.status == rx::Status::Waiting) {
+        // The picture is already saved; the reception stays open until
+        // the transmission's scheduled end in case the signal returns.
+        return QStringLiteral("Lost sync — waiting for the rest");
+    }
     if (p.status != rx::Status::Receiving) return {};
 
     QString out = QStringLiteral("Receiving a picture");
@@ -362,6 +367,12 @@ QString Listener::status() const {
         out += QStringLiteral("\nframes %1").arg(*p.frames_received);
         if (p.n_frames_expected.value_or(0) > 0) {
             out += QStringLiteral("/%1").arg(*p.n_frames_expected);
+            // Arrived against decoded: the gap is what a fade cost.
+            if (p.frames_decoded) {
+                out += QStringLiteral("   decoded %1%")
+                           .arg(100.0 * *p.frames_decoded / *p.n_frames_expected,
+                                0, 'f', 0);
+            }
         }
     }
     if (p.mode_name) {

--- a/native/android-app/pictures.cpp
+++ b/native/android-app/pictures.cpp
@@ -89,8 +89,15 @@ QVariant PictureList::data(const QModelIndex& index, int role) const {
             return e.mode;
         case SnrRole:
             return e.snr_db;
-        case FramesRole:
-            return QStringLiteral("%1/%2").arg(e.frames_received).arg(e.frames_expected);
+        case FramesRole: {
+            QString s = QStringLiteral("%1/%2").arg(e.frames_received)
+                            .arg(e.frames_expected);
+            if (e.frames_decoded > 0 && e.frames_expected > 0) {
+                s += QStringLiteral("  (%1% decoded)")
+                         .arg(100.0 * e.frames_decoded / e.frames_expected, 0, 'f', 0);
+            }
+            return s;
+        }
         case SummaryRole: {
             // One line, because a gallery row has room for one. The
             // callsign leads: on a phone the first question about a
@@ -131,6 +138,7 @@ void PictureList::refresh() {
             e.mode = o.value("mode").toString();
             e.snr_db = o.value("snr_db").toDouble();
             e.frames_received = o.value("frames_received").toInt();
+            e.frames_decoded = o.value("frames_decoded").toInt();
             e.frames_expected = o.value("frames_expected").toInt();
         }
         entries_.push_back(e);

--- a/native/android-app/pictures.hpp
+++ b/native/android-app/pictures.hpp
@@ -40,6 +40,11 @@ struct PictureEntry {
     QString mode;
     double snr_db = 0.0;
     int frames_received = 0;
+    // Frames that carried confident data, against frames_received's
+    // "frames whose audio arrived". Absent in sidecars written before
+    // the field existed, which read back as 0 and are shown as unknown
+    // rather than as nothing decoded.
+    int frames_decoded = 0;
     int frames_expected = 0;
 };
 

--- a/native/android-app/service_jni.cpp
+++ b/native/android-app/service_jni.cpp
@@ -89,6 +89,12 @@ Java_org_cleverdomain_sstvae_ListenerService_nativeStatusLine(JNIEnv* env, jclas
         case sstvae::rx::Status::Done:
             s = "Reception complete";
             break;
+        case sstvae::rx::Status::Waiting:
+            // Saved already, and still open: if the signal comes back
+            // before the transmission's scheduled end, the rest of it
+            // goes into that same picture.
+            s = "Lost sync - waiting for the rest";
+            break;
         case sstvae::rx::Status::Listening:
         default:
             // The poll count is the difference between "alive and

--- a/native/android-app/session.cpp
+++ b/native/android-app/session.cpp
@@ -98,8 +98,18 @@ std::optional<std::string> Session::save_reception(const rx::Reception& r) {
     char stamp[32];
     std::strftime(stamp, sizeof(stamp), "%Y-%m-%d_%H%M%SZ", &tm);
 
-    const std::string base = dir + "/" + stamp;
-    const std::string png = base + ".png";
+    // A reception that recovered after a fade comes back with the path
+    // its first delivery went to (rx::Reception::saved_path): the PNG
+    // and the sidecar beside it are rewritten in place, so one
+    // transmission stays one picture. The sidecar's timestamp then has
+    // to come from the *existing* name rather than from the clock, or a
+    // replacement would date the reception to when the fade ended while
+    // the filename beside it still said when it started.
+    const bool replaced = r.saved_path.has_value();
+    const std::string png = replaced ? *r.saved_path : dir + "/" + stamp + ".png";
+    const std::string base = png.size() > 4 ? png.substr(0, png.size() - 4) : png;
+    const std::string received =
+        replaced ? std::filesystem::path(base).filename().string() : stamp;
     try {
         std::error_code ec;
         std::filesystem::create_directories(dir, ec);
@@ -107,7 +117,7 @@ std::optional<std::string> Session::save_reception(const rx::Reception& r) {
 
         std::ostringstream meta;
         meta << "{\n";
-        meta << "  \"received\": \"" << stamp << "\",\n";
+        meta << "  \"received\": \"" << received << "\",\n";
         meta << "  \"callsign\": \"" << json_escape(r.callsign) << "\",\n";
         meta << "  \"mode\": " << (r.mode_name ? "\"" + json_escape(*r.mode_name) + "\""
                                                : "null")
@@ -115,6 +125,11 @@ std::optional<std::string> Session::save_reception(const rx::Reception& r) {
         meta << "  \"snr_db\": " << r.snr_db << ",\n";
         meta << "  \"frames_received\": "
              << (r.frames_received ? std::to_string(*r.frames_received) : "null") << ",\n";
+        // How much of the transmission arrived against how much of it
+        // decoded: without the second the sidecar cannot say whether a
+        // picture came through or merely went by.
+        meta << "  \"frames_decoded\": "
+             << (r.frames_decoded ? std::to_string(*r.frames_decoded) : "null") << ",\n";
         meta << "  \"frames_expected\": "
              << (r.n_frames_expected ? std::to_string(*r.n_frames_expected) : "null")
              << "\n";
@@ -129,7 +144,15 @@ std::optional<std::string> Session::save_reception(const rx::Reception& r) {
     }
     {
         std::lock_guard<std::mutex> lk(mu_);
-        saved_picture_ = png;
+        // Only a *new* picture is offered to the service.
+        // take_saved_picture() is consuming so that each reception is
+        // posted and exported exactly once; re-arming it for a
+        // replacement would post a second notification and insert a
+        // second MediaStore row for the same transmission, the file
+        // having been overwritten in place. The summary is refreshed
+        // either way -- it is a display of the best decode so far, not
+        // an event.
+        if (!replaced) saved_picture_ = png;
         std::ostringstream sum;
         sum << (r.callsign.empty() ? "unknown" : r.callsign.c_str());
         if (r.mode_name) sum << "  mode " << *r.mode_name;
@@ -137,6 +160,10 @@ std::optional<std::string> Session::save_reception(const rx::Reception& r) {
         if (r.n_frames_expected.value_or(0) > 0) {
             sum << "  " << r.frames_received.value_or(0) << "/"
                 << *r.n_frames_expected;
+            if (r.frames_decoded) {
+                sum << "  " << (100 * *r.frames_decoded / *r.n_frames_expected)
+                    << "% decoded";
+            }
         }
         saved_summary_ = sum.str();
     }

--- a/native/core/rx/engine.cpp
+++ b/native/core/rx/engine.cpp
@@ -190,6 +190,19 @@ void remember_finished(std::deque<std::int64_t>& finished, std::int64_t pos) {
 // reception can still be delivered after its decodes have stopped.
 // `deadline_abs` is a buffer position, not a time: past it, no real
 // frame of this transmission can still be arriving (see decode_loop).
+//
+// The record also outlives its own delivery. Delivering and retiring are
+// separate events: a stall hands the picture to the sink straight away
+// (so autosave is never delayed) but leaves the reception *dormant* --
+// still tracked, still able to take contributions -- until its scheduled
+// end. That is what makes a fade survivable. A fade longer than
+// end_grace is indistinguishable from a transmitter that stopped, and
+// the old behaviour retired the reception on the spot and recorded its
+// start as finished, so the blind path's re-acquisition a few seconds
+// later was dropped as already-handled and the rest of a picture still
+// being heard was refused. Since PROTOCOL_VERSION 4 the beacon names the
+// mode, so `deadline_abs` is exact on the blind path too, and the
+// scheduled end -- not the stall -- is what ends a reception.
 struct Pending {
     std::int64_t start = 0;         // absolute preamble-start position
     std::int64_t deadline_abs = 0;  // absolute buffer position
@@ -204,10 +217,60 @@ struct Pending {
     std::optional<Clock::time_point> stable_since;
     std::shared_ptr<const images::Picture> image;
     std::optional<std::string> mode_name;
-    std::optional<int> frames_received, n_frames_expected;
+    std::optional<int> frames_received, frames_decoded, n_frames_expected;
     std::string callsign;
     double snr_db = kNaN;
+    // `metric` as of the last delivery, and where that delivery went.
+    // Together they are the whole dormancy bookkeeping: a delivery only
+    // happens when the reception has improved on what the sink already
+    // has, and a second one replaces the first in place rather than
+    // producing a second picture of one transmission.
+    int delivered_metric = 0;
+    std::optional<std::string> saved_path;
 };
+
+// Hand `pending` to the sink if it has improved on what the sink
+// already has. Returns whether anything was delivered.
+//
+// Called both when a reception stalls and when it retires, which is the
+// whole point: the stall delivers so autosave is prompt, retirement
+// delivers whatever arrived afterwards. `delivered_metric` is what keeps
+// that from turning into a delivery per poll, and `saved_path` is what
+// makes the second delivery a replacement rather than a second picture
+// of the same transmission.
+//
+// The first delivery is also what records the start in `finished`: from
+// then on the preamble search steps over it, so a transmission that was
+// cut off early cannot go on hiding a later one for the rest of its own
+// scheduled duration. The reception stays resumable anyway -- the blind
+// path checks the tracked reception before that list (see decode_loop).
+bool deliver(Pending& pending, const Sink& sink, SharedState& state,
+             std::deque<std::int64_t>& finished) {
+    if (pending.metric <= pending.delivered_metric || !pending.image) return false;
+    const bool first = pending.delivered_metric == 0;
+
+    Reception rec;
+    rec.image = *pending.image;
+    rec.mode_name = pending.mode_name;
+    rec.callsign = pending.callsign;
+    rec.snr_db = pending.snr_db;
+    rec.frames_received = pending.frames_received;
+    rec.frames_decoded = pending.frames_decoded;
+    rec.n_frames_expected = pending.n_frames_expected;
+    rec.saved_path = pending.saved_path;
+    const std::optional<std::string> saved_path = sink(rec);
+
+    pending.delivered_metric = pending.metric;
+    if (saved_path) pending.saved_path = saved_path;
+    if (first) {
+        // Bookkeeping, not disk: this reception has been *handled*, so
+        // it must never be rediscovered as a new one while its audio is
+        // still in the buffer -- whether or not the sink chose to save.
+        remember_finished(finished, pending.start);
+    }
+    state.update([&](Progress& s) { s.saved_path = saved_path; });
+    return true;
+}
 
 // Back to "listening", with the per-reception fields cleared.
 void reset_to_listening(SharedState& state) {
@@ -215,6 +278,7 @@ void reset_to_listening(SharedState& state) {
         s.status = Status::Listening;
         s.mode_name.reset();
         s.frames_received.reset();
+        s.frames_decoded.reset();
         s.n_frames_expected.reset();
         s.progress_frac = 0.0;
         s.callsign.clear();
@@ -224,8 +288,7 @@ void reset_to_listening(SharedState& state) {
 
 }  // namespace
 
-BlindProgress blind_progress(std::span<const double> weights_full,
-                             int n_frames_expected) {
+DecodeProgress decode_progress(std::span<const double> weights_full) {
     // The metric counts confidently-received latents only, not bare
     // nonzero ones: demodulate_blind assigns *some* nonzero weight to
     // essentially every legal abs_frame slot its ever-growing search
@@ -235,24 +298,43 @@ BlindProgress blind_progress(std::span<const double> weights_full,
     // whether any new real data has arrived -- until buffer growth has
     // mapped the *entire* legal abs_frame range. That read as "stuck
     // receiving forever": the stall detector never saw a stable metric
-    // to end_grace against.
+    // to end_grace against. **This is what the stall clock watches, and
+    // nothing else may be substituted for it** -- see the header.
     //
-    // One past the highest absolute frame index any confidently-received
-    // latent belongs to, or 0 if none does. See the header for why that,
-    // and not the count, is the bar.
+    // frames_decoded is the same mask counted the other way: how many
+    // of the transmission's frames carried confident data at all.
     const std::span<const std::int32_t> frame_of = framing::frame_of_latent();
     const std::size_t n = std::min(weights_full.size(), frame_of.size());
-    BlindProgress out;
-    int last = -1;
+    std::vector<bool> seen(static_cast<std::size_t>(kMaxModeFrames), false);
+    DecodeProgress out;
     for (std::size_t i = 0; i < n; ++i) {
         if (weights_full[i] > kProgressWeightThreshold) {
             ++out.metric;
-            last = std::max(last, frame_of[i]);
+            const std::int32_t f = frame_of[i];
+            if (f >= 0 && f < kMaxModeFrames) seen[static_cast<std::size_t>(f)] = true;
         }
     }
-    out.reach = last + 1;
-    out.frac = static_cast<double>(out.reach) / n_frames_expected;
+    out.frames_decoded = static_cast<int>(std::count(seen.begin(), seen.end(), true));
     return out;
+}
+
+int frames_in_buffer(std::int64_t start, std::int64_t buf_start, std::int64_t total,
+                     int n_frames) {
+    const std::int64_t frames_start = start + PREAMBLE_SAMPLES + HEADER_SAMPLES;
+    // The first frame still in the buffer (ceil: a frame counts once
+    // its whole span is there) and the last one that has arrived. Both
+    // clamp into [0, n_frames], which is also what makes the negative
+    // cases -- audio older than the transmission, or none of it yet --
+    // come out as the 0 they should be.
+    const std::int64_t before = buf_start - frames_start;
+    const std::int64_t elapsed = total - frames_start;
+    const std::int64_t first =
+        before <= 0 ? 0 : (before + FRAME_SAMPLES - 1) / FRAME_SAMPLES;
+    const std::int64_t last = elapsed <= 0 ? 0 : elapsed / FRAME_SAMPLES;
+    const std::int64_t n = n_frames;
+    const std::int64_t lo = std::min(first, n);
+    const std::int64_t hi = std::min(last, n);
+    return static_cast<int>(std::max(std::int64_t{0}, hi - lo));
 }
 
 double poll_wait(const RxConfig& config, double last_cost_s) {
@@ -294,6 +376,7 @@ const char* status_name(Status s) {
     switch (s) {
         case Status::Listening: return "listening";
         case Status::Receiving: return "receiving";
+        case Status::Waiting: return "waiting";
         case Status::Done: return "done";
     }
     return "listening";
@@ -335,13 +418,18 @@ Sink save_to_dir_sink(std::string out_dir, std::optional<std::pair<int, int>> si
                       bool verbose) {
     return [out_dir = std::move(out_dir), size,
             verbose](const Reception& rec) -> std::optional<std::string> {
-        const std::string path = timestamped_path(out_dir);
+        // A reception that recovered after a fade comes back with the
+        // path its first delivery went to: overwrite that, so one
+        // transmission stays one file.
+        const std::string path =
+            rec.saved_path ? *rec.saved_path : timestamped_path(out_dir);
         std::filesystem::create_directories(std::filesystem::path(path).parent_path());
         const images::Picture& img =
             size ? images::resize(rec.image, size->first, size->second) : rec.image;
         images::save_png(img, path);
         if (verbose) {
-            std::printf("saved %s (mode=%s, callsign=%s%s)\n", path.c_str(),
+            std::printf("%s %s (mode=%s, callsign=%s%s)\n",
+                        rec.saved_path ? "updated" : "saved", path.c_str(),
                         rec.mode_name ? rec.mode_name->c_str() : "unknown, blind sync",
                         rec.callsign.empty() ? "(none)" : rec.callsign.c_str(),
                         fmt_snr(rec.snr_db).c_str());
@@ -421,7 +509,7 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
         std::vector<double> latents_full, weights_full;
         bool have_latents = false;
         std::optional<std::string> mode_name;
-        std::optional<int> n_frames_expected, frames_received;
+        std::optional<int> n_frames_expected, frames_received, frames_decoded;
         std::string callsign;
         double snr_db = kNaN;
         double progress_frac = 0.0;
@@ -451,7 +539,12 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
             have_latents = true;
             mode_name = std::string(r.mode.name);
             n_frames_expected = r.mode.n_frames;
+            // `received.sum()`: the frames whose samples are in the
+            // buffer, which is the bar's numerator (see
+            // frames_in_buffer) and, unchanged, the header path's stall
+            // metric.
             frames_received = r.frames_received;
+            frames_decoded = decode_progress(weights_full).frames_decoded;
             callsign = r.callsign;
             snr_db = r.snr_db;
             progress_frac = static_cast<double>(r.frames_received) / r.mode.n_frames;
@@ -516,11 +609,23 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
                 // free_spans blocks the wrong region.
                 reception_start =
                     buf_start + *rb->frame0_start - PREAMBLE_SAMPLES - HEADER_SAMPLES;
-                // Already handled: treat it as nothing decoded rather
-                // than skipping the rest of the poll, so that whatever
-                // reception is *currently* pending still gets its
-                // completion tests run this time round.
-                if (already_finished(*reception_start, finished_starts, epsilon)) {
+                // The tracked reception is checked *before* the
+                // finished list, and that is the whole resume
+                // mechanism: a reception delivered early on a stall is
+                // in that list (so the preamble search steps over it)
+                // while still being the one we are tracking, and
+                // dropping its re-acquisition here is exactly what used
+                // to refuse the rest of a picture that was still being
+                // heard.
+                //
+                // Anything else already handled: treat it as nothing
+                // decoded rather than skipping the rest of the poll, so
+                // that whatever reception is *currently* pending still
+                // gets its completion tests run this time round.
+                const bool ours =
+                    pending && std::llabs(*reception_start - pending->start) <= epsilon;
+                if (!ours &&
+                    already_finished(*reception_start, finished_starts, epsilon)) {
                     reception_start.reset();
                 } else {
                     latents_full = std::move(rb->latents);
@@ -541,16 +646,21 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
                         mode_name = std::string(spec.name);
                         n_frames_expected = spec.n_frames;
                     }
-                    const BlindProgress bp = blind_progress(
-                        weights_full,
-                        n_frames_expected ? *n_frames_expected : kMaxModeFrames);
-                    progress_metric = bp.metric;
-                    progress_frac = bp.frac;
-                    // The reach doubles as the reported frame counter --
-                    // see BlindProgress for why leaving this unset froze
-                    // half of every status line once the beacon's mode
-                    // field supplied the other half.
-                    frames_received = bp.reach;
+                    // The stall metric stays the confident-latent count
+                    // -- the amount decoded, which is the only thing
+                    // that stops climbing when the signal does. The bar
+                    // is the positional count instead, so a fade holds
+                    // back the *decoded* figure beside it rather than
+                    // freezing the bar.
+                    const DecodeProgress dp = decode_progress(weights_full);
+                    progress_metric = dp.metric;
+                    frames_decoded = dp.frames_decoded;
+                    const int n_display =
+                        n_frames_expected ? *n_frames_expected : kMaxModeFrames;
+                    frames_received = frames_in_buffer(
+                        *reception_start, buf_start,
+                        static_cast<std::int64_t>(total), n_display);
+                    progress_frac = static_cast<double>(*frames_received) / n_display;
                 }
             }
         }
@@ -570,10 +680,25 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
             // inherit the previous one's stall clock, or it can be
             // mistaken for a reception that has already stopped
             // advancing and be ended immediately.
+            //
+            // The outgoing record is delivered first. Taking over used
+            // to discard it -- picture, metric and all -- which was
+            // survivable only because a stall retired receptions
+            // quickly; now that one is kept until its scheduled end,
+            // the overlap is routine and dropping it would lose a
+            // picture that had already decoded. No Done flash here: the
+            // new reception publishes Receiving a few lines below, and
+            // a status the operator cannot see is not worth a
+            // two-second pause in the loop.
             if (!pending || std::llabs(*reception_start - pending->start) > epsilon) {
+                if (pending) deliver(*pending, sink, state, finished_starts);
                 Pending p;
                 p.start = *reception_start;
                 pending = std::move(p);
+                // Nothing has been saved for *this* reception yet, and
+                // a status line that named the previous one's file
+                // would be attributing it to the picture now on screen.
+                state.update([](Progress& s) { s.saved_path.reset(); });
             }
             // The deterministic backstop. The transmission's start is
             // known exactly -- from the header path's own acquisition,
@@ -602,17 +727,27 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
                 pending->metric = progress_metric;
                 advanced = true;
             }
-            pending->image = std::make_shared<const images::Picture>(
-                decode(latents_full, weights_full));
-            pending->mode_name = mode_name;
-            pending->frames_received = frames_received;
-            pending->n_frames_expected = n_frames_expected;
-            pending->callsign = callsign;
-            pending->snr_db = snr_db;
+            // Only an at-least-as-good decode replaces the held
+            // picture. A reception now lives until its scheduled end,
+            // so it sees decodes taken during a fade -- which are real
+            // decodes with fewer frames in them, and used to overwrite
+            // a better picture wholesale while `metric`, the only
+            // monotone field, went on saying progress had been made.
+            if (progress_metric >= pending->metric) {
+                pending->image = std::make_shared<const images::Picture>(
+                    decode(latents_full, weights_full));
+                pending->mode_name = mode_name;
+                pending->frames_received = frames_received;
+                pending->frames_decoded = frames_decoded;
+                pending->n_frames_expected = n_frames_expected;
+                pending->callsign = callsign;
+                pending->snr_db = snr_db;
+            }
             state.update([&](Progress& s) {
                 s.status = Status::Receiving;
                 s.mode_name = mode_name;
                 s.frames_received = frames_received;
+                s.frames_decoded = frames_decoded;
                 s.n_frames_expected = n_frames_expected;
                 s.progress_frac = std::min(progress_frac, 1.0);
                 s.callsign = callsign;
@@ -626,8 +761,16 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
             continue;
         }
 
-        // Two things end a reception short of its own frame count, and
-        // both are timed against end_grace.
+        // Two things interrupt a reception short of its own frame
+        // count, and both are timed against end_grace. Since the
+        // beacon's mode field made the deadline exact on both paths,
+        // neither of them *ends* a reception any more: they deliver it,
+        // and it stays tracked until its scheduled end. A fade longer
+        // than end_grace looks exactly like a transmitter that stopped,
+        // and only the transmitter's own clock can tell the difference
+        // -- so the picture goes to the sink now (autosave must not
+        // wait on a signal that may never come back) and the reception
+        // stays open for the rest of it (nothing is lost if it does).
         //
         // It stopped decoding. That is how a reception actually ends in
         // the field: its audio scrolls out of the ring buffer, or its
@@ -640,21 +783,35 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
         // of the poll entirely, is why a reception in that state could
         // never satisfy any completion test however long it sat.
         //
-        // Or -- blind only, where there is no frames_received count to
-        // finish on -- its decoded progress stopped advancing.
-        // Deliberately *not*
-        // extended to the header path: a spurious preamble-shaped lock
-        // in noise goes on decoding the same handful of frames for as
-        // long as it is looked at, and ending that on a stall would turn
-        // a false lock into a reported, and autosaved, picture of noise
-        // (see test_noise_produces_nothing). The header path does not
-        // need it anyway -- frames_received climbs as the buffer grows,
-        // so a real transmission reaches its count, and the deadline
-        // below is the backstop for one that does not. Keyed on
-        // pending->blind rather than "mode unknown": since the beacon's
-        // mode field, the blind path knows the mode too, so
-        // n_frames_expected no longer distinguishes the paths.
-        const bool no_progress = !decoded || (pending->blind && !advanced);
+        // Or its decoded progress stopped advancing. This used to be
+        // blind-only, on the grounds that a spurious preamble-shaped
+        // lock in noise goes on decoding the same handful of frames for
+        // as long as it is looked at, and that ending *that* on a stall
+        // turns a false lock into an autosaved picture of noise (see
+        // test_noise_produces_nothing). Neither half of that argument
+        // survives what the two numbers actually measure.
+        //
+        // The header path's frames_received is `received.sum()`, and
+        // `received[f]` is true for every frame whose samples are in
+        // the buffer -- signal or noise, faded or clean (see
+        // modem::Modem::demodulate). It is buffer coverage, not signal.
+        // So it climbs right through a fade, it climbs through the
+        // noise that follows a transmitter cutting off early (which is
+        // why *that* case ends on `complete` at the transmission's
+        // scheduled end rather than needing a stall at all), and a
+        // false lock in noise climbs with it. The one thing that stops
+        // it is the buffer not growing -- capture unplugged, the stream
+        // dead, the host no longer delivering callbacks -- and there
+        // the header path had no test that could ever fire: it goes on
+        // decoding, so `!decoded` is false; it never reaches its frame
+        // count; and `total` has stopped, so the deadline below is
+        // unreachable by construction. It sat in Receiving forever,
+        // which is the hang this whole record exists to close, still
+        // open on one path.
+        //
+        // And a stall no longer ends a reception -- it delivers one and
+        // keeps it -- so the distinction has nothing left to protect.
+        const bool no_progress = !decoded || !advanced;
         if (no_progress) {
             if (!pending->stable_since) pending->stable_since = Clock::now();
         } else {
@@ -674,8 +831,25 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
                               *pending->frames_received >= *pending->n_frames_expected;
         const bool stalled = pending->stable_since &&
                              seconds_since(*pending->stable_since) >= config.end_grace;
-        if (!complete && !stalled &&
-            static_cast<std::int64_t>(total) < pending->deadline_abs) {
+        // Retirement is the transmitter's own clock, not ours: its
+        // frame count is in, or the buffer holds audio past the point
+        // where its last frame could still be arriving. Nothing else
+        // drops the record -- see `Pending`.
+        const bool retire =
+            complete || static_cast<std::int64_t>(total) >= pending->deadline_abs;
+
+        if (!retire) {
+            if (stalled) {
+                // Delivered, but still tracked: dormant. `deliver` is a
+                // no-op unless it improved on what the sink already
+                // has, so a reception that stays quiet is handed over
+                // exactly once however many polls it sits through --
+                // while the status says Waiting throughout, including
+                // for a reception that never had a confident latent to
+                // deliver at all.
+                deliver(*pending, sink, state, finished_starts);
+                state.update([](Progress& s) { s.status = Status::Waiting; });
+            }
             continue;
         }
 
@@ -686,21 +860,9 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
         // transmission that was merely weak on its first polls must stay
         // findable rather than be blocked out for as long as its audio
         // is in the buffer.
-        const bool delivered = pending->metric > 0 && pending->image;
+        deliver(*pending, sink, state, finished_starts);
+        const bool delivered = pending->delivered_metric > 0;
         if (delivered) {
-            Reception rec;
-            rec.image = *pending->image;
-            rec.mode_name = pending->mode_name;
-            rec.callsign = pending->callsign;
-            rec.snr_db = pending->snr_db;
-            rec.frames_received = pending->frames_received;
-            rec.n_frames_expected = pending->n_frames_expected;
-            const std::optional<std::string> saved_path = sink(rec);
-
-            // Bookkeeping, not disk: this reception has been *handled*,
-            // so it must never be rediscovered while its audio is still
-            // in the buffer -- whether or not the sink chose to save it.
-            remember_finished(finished_starts, pending->start);
             // Retire the blind evidence with the reception. The
             // delivered transmission's fold otherwise keeps the
             // accumulator's argmax for a long time -- its peak/median
@@ -727,10 +889,7 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
             // CPU-friendly accumulator cannot do.
             make_blind_acc(blind_acc);
             blind_acc_pushed = static_cast<std::int64_t>(total);
-            state.update([&](Progress& s) {
-                s.status = Status::Done;
-                s.saved_path = saved_path;
-            });
+            state.update([](Progress& s) { s.status = Status::Done; });
         }
         pending.reset();
 
@@ -864,8 +1023,10 @@ void decode_loop_low_cpu(RingBuffer& ring, const Decoder& decode, SharedState& s
             continue;
         }
 
+        const std::vector<double> weights_full = latents::pad_to_full(r.weights);
         auto img = std::make_shared<const images::Picture>(
-            decode(latents::pad_to_full(r.latents), latents::pad_to_full(r.weights)));
+            decode(latents::pad_to_full(r.latents), weights_full));
+        const int frames_decoded = decode_progress(weights_full).frames_decoded;
 
         Reception rec;
         rec.image = *img;
@@ -873,6 +1034,7 @@ void decode_loop_low_cpu(RingBuffer& ring, const Decoder& decode, SharedState& s
         rec.callsign = r.callsign;
         rec.snr_db = r.snr_db;
         rec.frames_received = r.frames_received;
+        rec.frames_decoded = frames_decoded;
         rec.n_frames_expected = r.mode.n_frames;
         const std::optional<std::string> saved_path = sink(rec);
 
@@ -880,6 +1042,7 @@ void decode_loop_low_cpu(RingBuffer& ring, const Decoder& decode, SharedState& s
             s.status = Status::Done;
             s.image = img;
             s.frames_received = r.frames_received;
+            s.frames_decoded = frames_decoded;
             s.progress_frac =
                 std::min(static_cast<double>(r.frames_received) / r.mode.n_frames, 1.0);
             s.snr_db = r.snr_db;

--- a/native/core/rx/engine.cpp
+++ b/native/core/rx/engine.cpp
@@ -206,11 +206,27 @@ void remember_finished(std::deque<std::int64_t>& finished, std::int64_t pos) {
 struct Pending {
     std::int64_t start = 0;         // absolute preamble-start position
     std::int64_t deadline_abs = 0;  // absolute buffer position
+    // `deadline_abs` translated to wall time when it was computed, plus
+    // end_grace. The buffer-position deadline is the transmitter's
+    // clock and is right whenever capture is alive -- but it is
+    // measured against `total`, so if capture dies mid-reception
+    // `total` freezes below it and it becomes unreachable by
+    // construction: the loop would sit in Waiting forever with the
+    // picture already delivered. The wall clock keeps running when the
+    // buffer does not. Anchored when `deadline_abs` is set (or
+    // tightened by a later-learned mode), never re-anchored per poll --
+    // recomputing it from now() every decoded poll would push it
+    // forever into the future in exactly the frozen-buffer case it
+    // exists for.
+    std::optional<Clock::time_point> deadline_wall;
     // Whether the *most recent* decode of this reception came from the
     // blind path. Per-poll, not per-reception: a reception first found
-    // blind can later decode over the preamble path (or vice versa),
-    // and the stall-on-no-advance test below must follow the path
-    // currently driving the record.
+    // blind can later decode over the preamble path (or vice versa).
+    // Only `complete` consults it -- the header path's frames_received
+    // is a contiguous decoded count that genuinely finishes at the
+    // total, where the blind path's is positional with erasures behind
+    // it. The stall clock watches the same confident-latent metric on
+    // both paths.
     bool blind = false;
     int metric = 0;                 // best progress metric seen
     // When the metric last stopped advancing; unset while it still is.
@@ -242,8 +258,10 @@ struct Pending {
 // The first delivery is also what records the start in `finished`: from
 // then on the preamble search steps over it, so a transmission that was
 // cut off early cannot go on hiding a later one for the rest of its own
-// scheduled duration. The reception stays resumable anyway -- the blind
-// path checks the tracked reception before that list (see decode_loop).
+// scheduled duration. The reception stays resumable anyway, on both
+// paths: the blind path checks the tracked reception before that list,
+// and the header path aims one demodulate at its own preamble when the
+// search finds nothing new (see decode_loop).
 bool deliver(Pending& pending, const Sink& sink, SharedState& state,
              std::deque<std::int64_t>& finished) {
     if (pending.metric <= pending.delivered_metric || !pending.image) return false;
@@ -258,6 +276,7 @@ bool deliver(Pending& pending, const Sink& sink, SharedState& state,
     rec.frames_decoded = pending.frames_decoded;
     rec.n_frames_expected = pending.n_frames_expected;
     rec.saved_path = pending.saved_path;
+    rec.redelivery = !first;
     const std::optional<std::string> saved_path = sink(rec);
 
     pending.delivered_metric = pending.metric;
@@ -318,23 +337,14 @@ DecodeProgress decode_progress(std::span<const double> weights_full) {
     return out;
 }
 
-int frames_in_buffer(std::int64_t start, std::int64_t buf_start, std::int64_t total,
-                     int n_frames) {
+int frames_elapsed(std::int64_t start, std::int64_t total, int n_frames) {
     const std::int64_t frames_start = start + PREAMBLE_SAMPLES + HEADER_SAMPLES;
-    // The first frame still in the buffer (ceil: a frame counts once
-    // its whole span is there) and the last one that has arrived. Both
-    // clamp into [0, n_frames], which is also what makes the negative
-    // cases -- audio older than the transmission, or none of it yet --
-    // come out as the 0 they should be.
-    const std::int64_t before = buf_start - frames_start;
+    // Whole frames since the transmission's first one, clamped into
+    // [0, n_frames] -- which is also what makes the negative case
+    // (none of it has arrived yet) come out as the 0 it should be.
     const std::int64_t elapsed = total - frames_start;
-    const std::int64_t first =
-        before <= 0 ? 0 : (before + FRAME_SAMPLES - 1) / FRAME_SAMPLES;
-    const std::int64_t last = elapsed <= 0 ? 0 : elapsed / FRAME_SAMPLES;
-    const std::int64_t n = n_frames;
-    const std::int64_t lo = std::min(first, n);
-    const std::int64_t hi = std::min(last, n);
-    return static_cast<int>(std::max(std::int64_t{0}, hi - lo));
+    const std::int64_t got = elapsed <= 0 ? 0 : elapsed / FRAME_SAMPLES;
+    return static_cast<int>(std::min<std::int64_t>(got, n_frames));
 }
 
 double poll_wait(const RxConfig& config, double last_cost_s) {
@@ -527,6 +537,35 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
             const std::vector<std::complex<double>> z = dsp::to_baseband(samples);
             found = find_new_reception(modem, samples, z, buf_start, finished_starts,
                                        epsilon, config.drift_track);
+            // A delivered-but-still-open reception is in finished_starts,
+            // so the search above steps over its preamble -- correctly,
+            // for new receptions (a transmission cut off early must not
+            // hide a later one), and fatally for resuming *this* one
+            // over the header path: the blind branch has its own resume
+            // (the `ours` check below) but needs the beacon to decode,
+            // and "blind-locked with the beacon not decoding" is a real
+            // field condition. So when nothing new was found, aim one
+            // demodulate at the tracked reception's own preamble; if the
+            // signal came back, this decode is retrospective over the
+            // whole ring and picks up everything.
+            if (!found && pending &&
+                already_finished(pending->start, finished_starts, epsilon)) {
+                const std::int64_t lo =
+                    std::max<std::int64_t>(0, pending->start - buf_start - epsilon);
+                const std::int64_t hi = std::min<std::int64_t>(
+                    static_cast<std::int64_t>(samples.size()),
+                    pending->start - buf_start + PREAMBLE_SAMPLES + epsilon);
+                if (hi - lo >= PREAMBLE_SAMPLES) {
+                    try {
+                        modem::DemodResult r =
+                            modem.demodulate(samples, window_s(lo, hi),
+                                             config.drift_track);
+                        const std::int64_t start = buf_start + r.preamble_start;
+                        found = FoundReception{std::move(r), start};
+                    } catch (const sync::SyncError&) {
+                    }
+                }
+            }
         } catch (const std::exception&) {
             // One bad poll must not end the session.
             found = std::nullopt;
@@ -540,15 +579,28 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
             mode_name = std::string(r.mode.name);
             n_frames_expected = r.mode.n_frames;
             // `received.sum()`: the frames whose samples are in the
-            // buffer, which is the bar's numerator (see
-            // frames_in_buffer) and, unchanged, the header path's stall
-            // metric.
+            // buffer, which is the bar's numerator here (see
+            // frames_elapsed -- on this path the two agree while
+            // capture is alive, since the preamble was heard).
             frames_received = r.frames_received;
-            frames_decoded = decode_progress(weights_full).frames_decoded;
             callsign = r.callsign;
             snr_db = r.snr_db;
             progress_frac = static_cast<double>(r.frames_received) / r.mode.n_frames;
-            progress_metric = r.frames_received;
+            // The stall/delivery metric is the confident-latent count
+            // on *both* paths -- one unit, because pending->metric and
+            // delivered_metric compare across polls and a reception can
+            // switch paths between them (a header reception that stalls
+            // and resumes blind, or the reverse). The header path used
+            // to feed frames_received here, and a frame count against a
+            // latent count let a ~14-frame blind resume outrank a
+            // 300-frame delivered picture. It also gates delivery on
+            // decoded content rather than buffer coverage, which is
+            // what keeps a spurious lock in noise from being
+            // *delivered* as a picture of noise at its stall or
+            // deadline.
+            const DecodeProgress dp = decode_progress(weights_full);
+            progress_metric = dp.metric;
+            frames_decoded = dp.frames_decoded;
             reception_start = found->start;
         } else {
             // Fold whatever is new since the last poll into the running
@@ -657,9 +709,9 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
                     frames_decoded = dp.frames_decoded;
                     const int n_display =
                         n_frames_expected ? *n_frames_expected : kMaxModeFrames;
-                    frames_received = frames_in_buffer(
-                        *reception_start, buf_start,
-                        static_cast<std::int64_t>(total), n_display);
+                    frames_received = frames_elapsed(
+                        *reception_start, static_cast<std::int64_t>(total),
+                        n_display);
                     progress_frac = static_cast<double>(*frames_received) / n_display;
                 }
             }
@@ -720,8 +772,23 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
             const auto deadline_frames =
                 static_cast<std::int64_t>(n_frames_expected ? *n_frames_expected
                                                             : kMaxModeFrames);
-            pending->deadline_abs = pending->start + PREAMBLE_SAMPLES + HEADER_SAMPLES +
-                                    deadline_frames * FRAME_SAMPLES;
+            const std::int64_t deadline_abs = pending->start + PREAMBLE_SAMPLES +
+                                              HEADER_SAMPLES +
+                                              deadline_frames * FRAME_SAMPLES;
+            if (deadline_abs != pending->deadline_abs) {
+                pending->deadline_abs = deadline_abs;
+                // Its wall-clock shadow, anchored here and only here --
+                // see Pending::deadline_wall for why re-anchoring it
+                // every poll would defeat it.
+                const double remaining_s =
+                    static_cast<double>(deadline_abs -
+                                        static_cast<std::int64_t>(total)) / FS +
+                    config.end_grace;
+                pending->deadline_wall =
+                    Clock::now() +
+                    std::chrono::duration_cast<Clock::duration>(
+                        std::chrono::duration<double>(remaining_s));
+            }
             pending->blind = !found;
             if (progress_metric > pending->metric) {
                 pending->metric = progress_metric;
@@ -783,34 +850,25 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
         // of the poll entirely, is why a reception in that state could
         // never satisfy any completion test however long it sat.
         //
-        // Or its decoded progress stopped advancing. This used to be
+        // Or its decoded progress stopped advancing. The metric is the
+        // confident-latent count on both paths (see decode_progress),
+        // so on the header path this fires on a fade -- delivering
+        // promptly, exactly as the blind path does -- and on a capture
+        // that died mid-reception, where the same audio decodes to the
+        // same latents forever, the count never reaches anything, and
+        // `total` has stopped so the buffer deadline is unreachable
+        // (the wall-clock shadow is what retires it). This used to be
         // blind-only, on the grounds that a spurious preamble-shaped
         // lock in noise goes on decoding the same handful of frames for
         // as long as it is looked at, and that ending *that* on a stall
         // turns a false lock into an autosaved picture of noise (see
-        // test_noise_produces_nothing). Neither half of that argument
-        // survives what the two numbers actually measure.
-        //
-        // The header path's frames_received is `received.sum()`, and
-        // `received[f]` is true for every frame whose samples are in
-        // the buffer -- signal or noise, faded or clean (see
-        // modem::Modem::demodulate). It is buffer coverage, not signal.
-        // So it climbs right through a fade, it climbs through the
-        // noise that follows a transmitter cutting off early (which is
-        // why *that* case ends on `complete` at the transmission's
-        // scheduled end rather than needing a stall at all), and a
-        // false lock in noise climbs with it. The one thing that stops
-        // it is the buffer not growing -- capture unplugged, the stream
-        // dead, the host no longer delivering callbacks -- and there
-        // the header path had no test that could ever fire: it goes on
-        // decoding, so `!decoded` is false; it never reaches its frame
-        // count; and `total` has stopped, so the deadline below is
-        // unreachable by construction. It sat in Receiving forever,
-        // which is the hang this whole record exists to close, still
-        // open on one path.
-        //
-        // And a stall no longer ends a reception -- it delivers one and
-        // keeps it -- so the distinction has nothing left to protect.
+        // test_noise_produces_nothing). What protects against that is
+        // not the stall's reach but the delivery gate: a stall (or a
+        // deadline) delivers nothing unless confident latents were
+        // decoded, and a false lock in noise has essentially none --
+        // where the buffer-coverage count the header path used to feed
+        // this clock climbed for noise exactly as for signal, and would
+        // have *delivered* the noise at the deadline.
         const bool no_progress = !decoded || !advanced;
         if (no_progress) {
             if (!pending->stable_since) pending->stable_since = Clock::now();
@@ -833,10 +891,16 @@ void decode_loop(RingBuffer& ring, const Decoder& decode, SharedState& state,
                              seconds_since(*pending->stable_since) >= config.end_grace;
         // Retirement is the transmitter's own clock, not ours: its
         // frame count is in, or the buffer holds audio past the point
-        // where its last frame could still be arriving. Nothing else
-        // drops the record -- see `Pending`.
+        // where its last frame could still be arriving. The wall-clock
+        // shadow is for the one case where the buffer's clock has
+        // stopped -- capture died mid-reception, so `total` froze below
+        // the deadline and would hold the record (and `once`) in
+        // Waiting forever. While capture is alive the buffer deadline
+        // fires first by construction (the shadow trails it by
+        // end_grace). Nothing else drops the record -- see `Pending`.
         const bool retire =
-            complete || static_cast<std::int64_t>(total) >= pending->deadline_abs;
+            complete || static_cast<std::int64_t>(total) >= pending->deadline_abs ||
+            (pending->deadline_wall && Clock::now() >= *pending->deadline_wall);
 
         if (!retire) {
             if (stalled) {

--- a/native/core/rx/engine.hpp
+++ b/native/core/rx/engine.hpp
@@ -11,13 +11,15 @@
 // from-here-on.
 //
 // A reception is finished when a fully-synced decode reports all its
-// frames, when decoded progress stops advancing for `end_grace`
-// seconds, or when the buffer holds audio past the point where the last
+// frames, or when the buffer holds audio past the point where the last
 // frame of that transmission could still be arriving -- whichever comes
-// first. All three run against the tracked reception retained *across*
-// polls (`Pending`, in the .cpp), so none of them depends on the current
-// poll having produced a decode at all; see `Pending` for why that is
-// the whole ballgame.
+// first. Progress stopping for `end_grace` seconds does not finish it:
+// it *delivers* it, so autosave never waits on a signal that may not
+// come back, and leaves it tracked until its scheduled end so a fade it
+// recovers from still contributes. All of it runs against the tracked
+// reception retained *across* polls (`Pending`, in the .cpp), so none of
+// it depends on the current poll having produced a decode at all; see
+// `Pending` for why that is the whole ballgame.
 //
 // Headless, and knows nothing about audio devices or any UI: it reads a
 // `RingBuffer` somebody else is filling, publishes live status into a
@@ -129,51 +131,65 @@ struct RxConfig {
 // asserting on latency instead of on the decision.
 double poll_wait(const RxConfig& config, double last_cost_s);
 
-// (stall metric, progress fraction) for one blind decode. Exposed for
+// (stall metric, frames decoded) for one decode's weights. Exposed for
 // the same reason `poll_wait` is: it is arithmetic, and the alternative
 // is inferring it from a whole decode run.
 //
-// Two different questions, deliberately answered by two different
-// numbers. The metric is the count of confidently-received latents (see
-// count_confident in the .cpp for why confidence is what makes it
-// usable as a stall detector). The fraction is how far *into* the
-// transmission we have got -- the last frame that decoded, over the
-// frames expected -- and is not that count over the total. A count
-// reads as a completion percentage and is not one: the erasures this
-// path lives with (a fade, or simply not having heard the start) hold
-// it down permanently, so a reception already at the transmission's
-// last frame reports 70% and the bar never fills. The interleaver is
-// why the two differ at all -- each frame's latents are scattered
-// across the whole picture, so only the frame index says "how far".
+// The **metric** is the count of confidently-received latents (see
+// decode_progress in the .cpp for why confidence is what makes it
+// usable). **This is the number the stall clock watches, and nothing
+// else may be substituted for it**: anything positional does not move
+// when retrospective decoding fills in frames behind the furthest one,
+// and any count over the *whole* legal frame range climbs on buffer
+// growth alone, so a reception fed either would never stall or never
+// stop stalling.
 //
-// `n_frames_expected` is the denominator: the beacon's mode field
-// (PROTOCOL_VERSION 4) names the transmission's real frame count, so
-// the caller passes that when the beacon's mode index is one it knows,
-// and mode C's count -- the longest, the pre-mode-field assumption --
-// when it isn't.
-// `reach` is the fraction's own numerator -- one past the furthest
-// frame confidently decoded -- returned separately because it is what
-// the blind path reports as frames_received: every status line formats
-// the frames pair and the percentage together, so leaving
-// frames_received unset froze one indicator next to the other once the
-// beacon's mode field supplied n_frames_expected. It is a *position*,
-// not a count of frames actually held, which is why a blind reception
-// must never be treated as complete just because its reach hit the
-// last frame (see decode_loop's `complete` test).
-struct BlindProgress {
+// **frames_decoded** is how many of the transmission's frames carried
+// confident data. It is a *fill*, and it is what a UI shows beside the
+// progress bar rather than as it: a fill reads as a completion
+// percentage without being one, since the erasures both paths live with
+// (a fade, or simply not having heard the start) hold it down
+// permanently. The interleaver is why the two differ at all -- each
+// frame's latents are scattered across the whole picture, so a latent
+// count answers "how much" and only a frame index answers "how far".
+struct DecodeProgress {
     int metric = 0;
-    double frac = 0.0;
-    int reach = 0;
+    int frames_decoded = 0;
 };
-BlindProgress blind_progress(std::span<const double> weights_full,
-                             int n_frames_expected);
+DecodeProgress decode_progress(std::span<const double> weights_full);
+
+// How many of a transmission's frames have arrived: the progress bar's
+// numerator, and pure arithmetic on buffer positions.
+//
+// This is what the bar shows, because it is the only one of the
+// available numbers that climbs with the clock rather than with the
+// decoder's luck. The header path already reported exactly this --
+// `DemodResult::frames_received` counts every frame whose samples are
+// in the buffer, signal or noise -- so this is that number generalized
+// to the blind path, which had been showing how far its furthest
+// *decoded* frame reached and so stalled on the erasures that are its
+// normal state.
+//
+// `buf_start` is in it because a blind reception can begin before the
+// audio does: joining a transmission late leaves its early frames
+// permanently unavailable, and a bar that starts at 40% and fills is
+// honest where one that starts at 0 and can never reach 100 is not.
+// Monotone in practice rather than by construction -- it assumes the
+// ring outlives the longest mode (130 s against 95 s), the same
+// assumption the rest of the retrospective decoding rests on.
+int frames_in_buffer(std::int64_t start, std::int64_t buf_start, std::int64_t total,
+                     int n_frames);
 
 // The `threading.Event` the reference stops on. Shared with the
 // transmitter, which needs the same primitive for its cancel flag and
 // its watchdog; the name stays because "stop flag" is what it is here.
 using StopFlag = util::Event;
 
-enum class Status { Listening, Receiving, Done };
+// Waiting is a reception that lost sync and has already been delivered,
+// but whose scheduled end has not arrived: neither receiving a signal
+// (there isn't one) nor idle (a picture is still open for the rest of
+// its frames). See `Pending` in the .cpp.
+enum class Status { Listening, Receiving, Waiting, Done };
 
 const char* status_name(Status s);
 
@@ -185,8 +201,19 @@ struct Reception {
     std::optional<std::string> mode_name;
     std::string callsign;
     double snr_db = 0.0;
+    // How much of the transmission arrived, and how much of it actually
+    // decoded. The first is the progress bar's numerator and climbs
+    // with the clock; the second is a fill, and the gap between them is
+    // what a fade costs. See frames_in_buffer and decode_progress.
     std::optional<int> frames_received;
+    std::optional<int> frames_decoded;
     std::optional<int> n_frames_expected;
+    // Set when this same reception has already been delivered once, to
+    // the path named here: a fade ended it early, it recovered before
+    // its scheduled end, and this is the better decode. **Replace what
+    // is there rather than adding a second picture** -- one
+    // transmission is one file, one gallery entry, one notification.
+    std::optional<std::string> saved_path;
 };
 
 // What the loop publishes for a UI to display.
@@ -198,7 +225,11 @@ struct Reception {
 struct Progress {
     Status status = Status::Listening;
     std::optional<std::string> mode_name;
+    // frames_received is the frames that have arrived (what the bar
+    // shows); frames_decoded is how many of them carried confident data
+    // (shown beside it, never as it). See frames_in_buffer.
     std::optional<int> frames_received;
+    std::optional<int> frames_decoded;
     std::optional<int> n_frames_expected;
     double progress_frac = 0.0;
     std::string callsign;

--- a/native/core/rx/engine.hpp
+++ b/native/core/rx/engine.hpp
@@ -158,27 +158,25 @@ struct DecodeProgress {
 };
 DecodeProgress decode_progress(std::span<const double> weights_full);
 
-// How many of a transmission's frames have arrived: the progress bar's
-// numerator, and pure arithmetic on buffer positions.
+// How far through its schedule a transmission has got: the progress
+// bar's numerator, and pure arithmetic on buffer positions.
 //
 // This is what the bar shows, because it is the only one of the
 // available numbers that climbs with the clock rather than with the
-// decoder's luck. The header path already reported exactly this --
+// decoder's luck. The header path already reported nearly this --
 // `DemodResult::frames_received` counts every frame whose samples are
 // in the buffer, signal or noise -- so this is that number generalized
 // to the blind path, which had been showing how far its furthest
 // *decoded* frame reached and so stalled on the erasures that are its
 // normal state.
 //
-// `buf_start` is in it because a blind reception can begin before the
-// audio does: joining a transmission late leaves its early frames
-// permanently unavailable, and a bar that starts at 40% and fills is
-// honest where one that starts at 0 and can never reach 100 is not.
-// Monotone in practice rather than by construction -- it assumes the
-// ring outlives the longest mode (130 s against 95 s), the same
-// assumption the rest of the retrospective decoding rests on.
-int frames_in_buffer(std::int64_t start, std::int64_t buf_start, std::int64_t total,
-                     int n_frames);
+// It counts from the transmission's own first frame, not from the audio
+// we happened to capture: joining a transmission late leaves its early
+// frames permanently unavailable, and a bar that starts at 60% and
+// fills to 100% is honest where one that starts at 0 and can never
+// reach 100 is not. The frames the join missed show up instead as the
+// gap against frames_decoded, exactly like a fade's.
+int frames_elapsed(std::int64_t start, std::int64_t total, int n_frames);
 
 // The `threading.Event` the reference stops on. Shared with the
 // transmitter, which needs the same primitive for its cancel flag and
@@ -201,10 +199,11 @@ struct Reception {
     std::optional<std::string> mode_name;
     std::string callsign;
     double snr_db = 0.0;
-    // How much of the transmission arrived, and how much of it actually
-    // decoded. The first is the progress bar's numerator and climbs
-    // with the clock; the second is a fill, and the gap between them is
-    // what a fade costs. See frames_in_buffer and decode_progress.
+    // How far through its schedule the transmission got, and how much
+    // of it actually decoded. The first is the progress bar's numerator
+    // and climbs with the clock; the second is a fill, and the gap
+    // between them is what a fade -- or joining late -- costs. See
+    // frames_elapsed and decode_progress.
     std::optional<int> frames_received;
     std::optional<int> frames_decoded;
     std::optional<int> n_frames_expected;
@@ -214,6 +213,14 @@ struct Reception {
     // is there rather than adding a second picture** -- one
     // transmission is one file, one gallery entry, one notification.
     std::optional<std::string> saved_path;
+    // True on every delivery after the first, whether or not the sink
+    // chose to save. saved_path cannot carry this by itself: a sink
+    // that declined to save (a GUI with autosave off) returns no path,
+    // and a redelivery would then read as a brand-new reception -- two
+    // "reception complete" records for one transmission. saved_path
+    // says where to write; this says whether it is the same reception
+    // again.
+    bool redelivery = false;
 };
 
 // What the loop publishes for a UI to display.
@@ -225,9 +232,9 @@ struct Reception {
 struct Progress {
     Status status = Status::Listening;
     std::optional<std::string> mode_name;
-    // frames_received is the frames that have arrived (what the bar
-    // shows); frames_decoded is how many of them carried confident data
-    // (shown beside it, never as it). See frames_in_buffer.
+    // frames_received is how far the transmission has got (what the bar
+    // shows); frames_decoded is how many frames carried confident data
+    // (shown beside it, never as it). See frames_elapsed.
     std::optional<int> frames_received;
     std::optional<int> frames_decoded;
     std::optional<int> n_frames_expected;

--- a/native/gui/rx_panel.cpp
+++ b/native/gui/rx_panel.cpp
@@ -578,7 +578,10 @@ void ReceivePanel::on_reception(const QString& saved_path) {
     // shown only in a 5-second status bar flash before this line existed.
     // A replacement is the same reception delivered again with more of
     // it decoded, so it says so rather than reading as a second picture.
-    const bool replaced = reception->saved_path.has_value();
+    // On `redelivery`, not on saved_path: with autosave off the sink
+    // never returns a path, and a redelivery keyed on the path would
+    // log two "reception complete" lines for one transmission.
+    const bool replaced = reception->redelivery;
     QString line = replaced ? tr("reception updated") : tr("reception complete");
     if (reception->mode_name) {
         line += tr(": mode %1").arg(QString::fromStdString(*reception->mode_name));

--- a/native/gui/rx_panel.cpp
+++ b/native/gui/rx_panel.cpp
@@ -419,7 +419,15 @@ std::optional<std::string> ReceivePanel::save_reception(
     }
     const std::string stem =
         settings::format_filename(config.receive.filename_template, fields);
-    const fs::path path = unique_path(out_dir / (stem + ".png"));
+    // A reception that recovered after a fade comes back with the path
+    // its first delivery went to: overwrite that, so one transmission
+    // stays one file rather than leaving the operator to work out which
+    // of two pictures is the better one. The audio beside it is
+    // rewritten for the same reason -- the ring now holds more of the
+    // transmission than it did.
+    const fs::path path = reception.saved_path
+                              ? fs::path(*reception.saved_path)
+                              : unique_path(out_dir / (stem + ".png"));
 
     images::Picture image = reception.image;
     if (const auto size = rx::parse_size(config.receive.save_size)) {
@@ -506,10 +514,33 @@ void ReceivePanel::refresh_status() {
             text = tr("Receiving (blind sync): %1%")
                        .arg(100.0 * progress.progress_frac, 0, 'f', 0);
         }
+        // The frames pair says how much of the transmission has
+        // arrived; this says how much of it actually decoded. They come
+        // apart in a fade, and the difference is the only visible
+        // warning that a picture is filling in with erasures.
+        if (progress.frames_decoded && progress.n_frames_expected.value_or(0) > 0) {
+            text += SEP + tr("decoded %1%")
+                              .arg(100.0 * *progress.frames_decoded /
+                                       *progress.n_frames_expected,
+                                   0, 'f', 0);
+        }
         text += SEP + style::fmt_snr_db(progress.snr_db);
         if (!progress.callsign.empty()) {
             text += SEP + tr("de %1").arg(QString::fromStdString(progress.callsign));
         }
+    } else if (progress.status == rx::Status::Waiting) {
+        // Saved already, and still open: if the signal comes back
+        // before the transmission's scheduled end, the rest of it goes
+        // into that same picture.
+        text = tr("Lost sync — waiting for the rest");
+        if (progress.mode_name) {
+            text += tr(" of mode %1")
+                        .arg(QString::fromStdString(*progress.mode_name));
+        }
+        // Deliberately no filename: the card and the log already carry
+        // it, and `last_saved_path_` is only updated when something is
+        // delivered -- so a reception with nothing worth delivering yet
+        // would name the *previous* picture here.
     } else {
         text = tr("Complete") + SEP + style::fmt_snr_db(progress.snr_db);
         if (last_saved_path_) {
@@ -545,7 +576,10 @@ void ReceivePanel::on_reception(const QString& saved_path) {
     // The one durable record of a completed reception: mode, callsign,
     // SNR, frame count and the *full* saved path -- which was previously
     // shown only in a 5-second status bar flash before this line existed.
-    QString line = tr("reception complete");
+    // A replacement is the same reception delivered again with more of
+    // it decoded, so it says so rather than reading as a second picture.
+    const bool replaced = reception->saved_path.has_value();
+    QString line = replaced ? tr("reception updated") : tr("reception complete");
     if (reception->mode_name) {
         line += tr(": mode %1").arg(QString::fromStdString(*reception->mode_name));
     }
@@ -556,6 +590,12 @@ void ReceivePanel::on_reception(const QString& saved_path) {
         line += tr(", %1/%2 frames")
                     .arg(reception->frames_received.value_or(0))
                     .arg(*reception->n_frames_expected);
+        if (reception->frames_decoded) {
+            line += tr(", %1% decoded")
+                        .arg(100.0 * *reception->frames_decoded /
+                                 *reception->n_frames_expected,
+                             0, 'f', 0);
+        }
     }
     if (!std::isnan(reception->snr_db)) {
         line += tr(", %1").arg(style::fmt_snr_db(reception->snr_db));
@@ -580,6 +620,12 @@ void ReceivePanel::on_reception(const QString& saved_path) {
         card += SEP + tr("%1/%2 frames")
                           .arg(reception->frames_received.value_or(0))
                           .arg(*reception->n_frames_expected);
+        if (reception->frames_decoded) {
+            card += SEP + tr("%1% decoded")
+                              .arg(100.0 * *reception->frames_decoded /
+                                       *reception->n_frames_expected,
+                                   0, 'f', 0);
+        }
     }
     if (!saved_path.isEmpty()) {
         card += SEP + QString::fromStdString(

--- a/native/tests/test_rx_engine.cpp
+++ b/native/tests/test_rx_engine.cpp
@@ -448,6 +448,47 @@ void test_a_reception_whose_decodes_stop_is_still_delivered() {
                    "rx/watchdog: and the loop goes back to listening");
 }
 
+void test_a_reception_whose_buffer_stopped_growing_still_retires() {
+    // Capture died mid-reception, close to the transmission's end. The
+    // stall delivers the picture (that much already worked), but the
+    // sample-position deadline is measured against `total`, and `total`
+    // has frozen just short of it: unreachable by construction, so the
+    // record -- and `once`, which only exits on retirement -- sat in
+    // Waiting forever with the picture already saved. The wall-clock
+    // shadow of the deadline is what retires it; while capture is alive
+    // it trails the buffer deadline by end_grace and never fires.
+    //
+    // The buffer stops ~0.5 s short of the scheduled end so the test's
+    // own wait is bounded by about that plus end_grace -- this asserts
+    // the wait is finite, not how long it takes.
+    Harness h(60.0);
+    const std::vector<double> full = transmission("W1AW", 63);
+    const double short_by_s = 0.5;
+    write_all(h.ring, truncated("W1AW", 63,
+                                static_cast<double>(full.size()) / config::FS - short_by_s));
+
+    std::thread loop([&] {
+        rx::decode_loop(h.ring, h.decoder(), h.state, h.config, h.stop, h.sink());
+    });
+    std::thread watcher([&] { h.poll_watcher(); });
+
+    h.until([&] { return h.received.size() >= 1; },
+            "rx/frozen-buffer: the stall delivers the partial reception");
+    h.until([&] { return h.state.get().status == rx::Status::Listening; },
+            "rx/frozen-buffer: a frozen buffer holds the deadline out of reach "
+            "forever -- only the wall clock can retire this reception");
+    h.stop.set();
+    loop.join();
+    watcher.join();
+
+    check::equal(h.count(), std::size_t{1},
+                 "rx/frozen-buffer: delivered exactly once");
+    if (h.count() != 1) return;
+    check::is_true(h.received[0].frames_received.has_value() &&
+                       *h.received[0].frames_received < mode_a().n_frames,
+                   "rx/frozen-buffer: delivered as the partial reception it is");
+}
+
 void test_a_faded_reception_resumes_and_replaces_its_picture() {
     // The reason losing sync no longer ends a reception.
     //
@@ -509,6 +550,13 @@ void test_a_faded_reception_resumes_and_replaces_its_picture() {
     check::is_true(second.saved_path.has_value() && *second.saved_path == *h.save_as,
                    "rx/fade: the improved picture was delivered as a new reception "
                    "rather than as a replacement for the one already saved");
+    // The engine-side flag, independent of whether the sink saved: a
+    // GUI with autosave off gets no path back and still must not read
+    // a redelivery as a second reception.
+    check::is_true(!h.received[0].redelivery,
+                   "rx/fade: the first delivery is not marked a redelivery");
+    check::is_true(second.redelivery,
+                   "rx/fade: the second is, whatever the sink returned");
     check::is_true(second.frames_decoded.value_or(0) > first_decoded,
                    "rx/fade: the second delivery carries more of the picture");
 }
@@ -782,15 +830,17 @@ void test_poll_backoff() {
                  "rx/backoff: the duty floor bounds the wait");
 }
 
-// The two reception numbers: what arrived, and what decoded.
+// The two reception numbers: how far the transmission got, and what
+// decoded.
 //
-// The bar is `frames whose audio has arrived / frames expected`
-// (frames_in_buffer), pure arithmetic on buffer positions, so it climbs
-// with the clock whatever the decoder manages. Beside it, and never as
-// it, is frames_decoded -- a *fill*, held down permanently by the
-// erasures the blind path lives with. And the confident-latent count is
-// neither: it is the stall clock's input, and nothing else may be
-// substituted for it.
+// The bar is `frames elapsed since the transmission's first frame /
+// frames expected` (frames_elapsed), pure arithmetic on buffer
+// positions, so it climbs with the clock whatever the decoder manages,
+// starts part-way up on a late join, and can always reach 100%. Beside
+// it, and never as it, is frames_decoded -- a *fill*, held down
+// permanently by the erasures the blind path lives with. And the
+// confident-latent count is neither: it is the stall clock's input on
+// both paths, and nothing else may be substituted for it.
 //
 // Arithmetic, so it is checked as arithmetic (see `decode_progress`'s
 // header comment), rather than inferred from a whole decode run.
@@ -846,34 +896,39 @@ void test_the_two_progress_numbers() {
     const int n = config::MODES[0].n_frames;
     const std::int64_t frames_start = config::PREAMBLE_SAMPLES + config::HEADER_SAMPLES;
     const std::int64_t end = frames_start + std::int64_t{n} * config::FRAME_SAMPLES;
-    check::equal(rx::frames_in_buffer(0, 0, 0, n), 0,
+    check::equal(rx::frames_elapsed(0, 0, n), 0,
                  "rx/bar: nothing has arrived yet");
-    check::equal(rx::frames_in_buffer(0, 0, frames_start + config::FRAME_SAMPLES, n), 1,
+    check::equal(rx::frames_elapsed(0, frames_start + config::FRAME_SAMPLES, n), 1,
                  "rx/bar: one whole frame has arrived");
-    check::equal(rx::frames_in_buffer(0, 0, end, n), n, "rx/bar: all of it");
-    check::equal(rx::frames_in_buffer(0, 0, end + 100 * config::FRAME_SAMPLES, n), n,
+    check::equal(rx::frames_elapsed(0, end, n), n, "rx/bar: all of it");
+    check::equal(rx::frames_elapsed(0, end + 100 * config::FRAME_SAMPLES, n), n,
                  "rx/bar: audio past the end is not more of the transmission");
 
     // Climbing with the clock is the property, so check it as one.
     int prev = -1;
     bool monotone = true;
     for (int k = 0; k <= n; k += 7) {
-        const int got = rx::frames_in_buffer(0, 0, frames_start + std::int64_t{k} * config::FRAME_SAMPLES, n);
+        const int got = rx::frames_elapsed(0, frames_start + std::int64_t{k} * config::FRAME_SAMPLES, n);
         monotone = monotone && got >= prev;
         prev = got;
     }
     check::is_true(monotone, "rx/bar: climbs with the clock and nothing else");
 
     // Tuned in at frame 400 of mode C: those frames' audio is gone for
-    // good, so the bar starts at 400/660 and fills from there. Counting
-    // from zero would promise a picture that cannot arrive.
+    // good, so the bar starts at 400/660 -- the transmission is 400
+    // frames into its schedule the moment we join -- and fills to
+    // 660/660 as the rest arrives. Counting only captured audio would
+    // start it at zero and cap it below 100% forever, on the display
+    // whose job is to say how far along the transmission is; the frames
+    // the join missed show up as the gap against frames_decoded,
+    // exactly like a fade's.
     const std::int64_t joined = frames_start + 400 * config::FRAME_SAMPLES;
-    check::equal(rx::frames_in_buffer(0, joined, joined, total), 0,
-                 "rx/bar: a late join has nothing of it yet");
-    check::equal(rx::frames_in_buffer(0, joined,
-                                      frames_start + std::int64_t{total} * config::FRAME_SAMPLES,
-                                      total),
-                 total - 400, "rx/bar: and fills only with what it can still hear");
+    check::equal(rx::frames_elapsed(0, joined, total), 400,
+                 "rx/bar: a late join starts part-way up");
+    check::equal(rx::frames_elapsed(0,
+                                    frames_start + std::int64_t{total} * config::FRAME_SAMPLES,
+                                    total),
+                 total, "rx/bar: and still reaches the top");
 }
 
 // `frame_of_latent` is the inverse of `slot_range_for_frame`, and the
@@ -910,6 +965,7 @@ int main() {
         test_low_cpu_loop_receives();
         test_a_finished_reception_is_not_rediscovered();
         test_a_reception_whose_decodes_stop_is_still_delivered();
+        test_a_reception_whose_buffer_stopped_growing_still_retires();
         test_a_faded_reception_resumes_and_replaces_its_picture();
         test_a_new_reception_does_not_discard_an_undelivered_one();
         test_low_cpu_does_not_wait_forever_for_audio_that_stops();

--- a/native/tests/test_rx_engine.cpp
+++ b/native/tests/test_rx_engine.cpp
@@ -126,10 +126,16 @@ struct Harness {
         };
     }
 
-    // A sink that deliberately declines to save. A finished reception
-    // must be recorded as *handled* either way -- if that bookkeeping
-    // ever moved into the saving branch, a GUI with autosave off would
-    // re-decode and re-report the same picture on every poll.
+    // Where this harness's sink claims to have saved, or nothing --
+    // the default, a sink that deliberately declines to save. A
+    // finished reception must be recorded as *handled* either way: if
+    // that bookkeeping ever moved into the saving branch, a GUI with
+    // autosave off would re-decode and re-report the same picture on
+    // every poll. Set it when the test needs to see a *replacement*,
+    // which is a reception delivered again carrying the path its first
+    // delivery went to.
+    std::optional<std::string> save_as;
+
     rx::Sink sink() {
         return [this](const rx::Reception& r) -> std::optional<std::string> {
             {
@@ -137,7 +143,7 @@ struct Harness {
                 received.push_back(r);
             }
             cv.notify_all();
-            return std::nullopt;
+            return save_as;
         };
     }
 
@@ -378,6 +384,13 @@ void test_a_reception_whose_decodes_stop_is_still_delivered() {
     // again: the loop sat in Receiving indefinitely and the picture it
     // had already decoded was never handed to the sink. A hang and
     // autosave never firing are that one bug from two ends.
+    //
+    // Losing sync delivers the reception but no longer retires it: it
+    // goes dormant (Waiting), still tracked, until the buffer reaches
+    // the point where its last frame could have arrived. So this also
+    // pins the two halves apart -- delivered promptly when progress
+    // stops, retired on the deadline, exactly one picture out of the
+    // pair.
     Harness h(12.0);
     write_all(h.ring, truncated("KC2G", 61, 3.0));
 
@@ -405,11 +418,23 @@ void test_a_reception_whose_decodes_stop_is_still_delivered() {
             "otherwise it is still sitting in receiving with its picture "
             "undelivered, which is both the hang and the autosave-never-fires "
             "report");
+    h.until([&] { return h.state.get().status == rx::Status::Waiting; },
+            "rx/watchdog: delivered, and still open for the rest of its frames "
+            "until its scheduled end");
+
+    // Past the transmission's own deadline, which is what retires it.
+    write_all(h.ring, std::vector<double>(static_cast<std::size_t>(
+                          mode_a().duration_s * config::FS)));
+    h.until([&] { return h.state.get().status == rx::Status::Listening; },
+            "rx/watchdog: retired once no frame of it could still be arriving");
     h.stop.set();
     loop.join();
     watcher.join();
 
-    check::equal(h.count(), std::size_t{1}, "rx/watchdog: delivered exactly once");
+    check::equal(h.count(), std::size_t{1},
+                 "rx/watchdog: delivered exactly once -- a dormant reception that "
+                 "never improved has nothing new for the sink when its deadline "
+                 "retires it");
     if (h.count() != 1) return;
     const rx::Reception& r = h.received[0];
     check::is_true(r.mode_name.has_value() && *r.mode_name == "A",
@@ -421,6 +446,115 @@ void test_a_reception_whose_decodes_stop_is_still_delivered() {
                    "rx/watchdog: the last good decode's picture, not an empty one");
     check::is_true(h.state.get().status == rx::Status::Listening,
                    "rx/watchdog: and the loop goes back to listening");
+}
+
+void test_a_faded_reception_resumes_and_replaces_its_picture() {
+    // The reason losing sync no longer ends a reception.
+    //
+    // A fade longer than end_grace is indistinguishable from a
+    // transmitter that stopped, so the picture is delivered at once --
+    // but the reception stays tracked until its scheduled end, and a
+    // lock recovered before then must be routed back into it. The old
+    // loop recorded the start as finished at that first delivery and
+    // already_finished then dropped every re-acquisition, so the rest
+    // of a picture still being heard was refused for as long as the
+    // transmission lasted.
+    //
+    // The fade is *muted in place*, not cut out: silence written in the
+    // middle of a transmission would shift everything after it, and the
+    // reception being tested would then be a differently-timed one.
+    Harness h(60.0);
+    h.save_as = "/dev/null/fake.png";
+    const std::vector<double> full = frames_only("KC2G", 41);
+    const auto heard = static_cast<std::size_t>(12.0 * config::FS);
+    const auto faded = static_cast<std::size_t>(4.0 * config::FS);
+
+    write_all(h.ring, std::vector<double>(full.begin(),
+                                          full.begin() + static_cast<std::ptrdiff_t>(heard)));
+
+    std::thread loop([&] {
+        rx::decode_loop(h.ring, h.decoder(), h.state, h.config, h.stop, h.sink());
+    });
+    std::thread watcher([&] { h.poll_watcher(); });
+
+    h.until([&] { return h.state.get().status == rx::Status::Receiving; },
+            "rx/fade: the blind path locks on the fragment");
+
+    // The fade: the same span of the transmission, muted.
+    write_all(h.ring, std::vector<double>(faded, 0.0));
+    h.until([&] { return h.received.size() >= 1 &&
+                         h.state.get().status == rx::Status::Waiting; },
+            "rx/fade: a reception that stopped advancing is delivered and left "
+            "open");
+    // On frames_decoded, deliberately: frames_received is positional
+    // and climbs with the buffer whether or not anything was decoded,
+    // so it cannot tell a resumed reception from an abandoned one.
+    const int first_decoded = h.received[0].frames_decoded.value_or(0);
+
+    // And the signal comes back, before the transmission's scheduled end.
+    write_all(h.ring, std::vector<double>(
+                          full.begin() + static_cast<std::ptrdiff_t>(heard + faded),
+                          full.end()));
+    h.until([&] { return h.received.size() >= 2; },
+            "rx/fade: a reception re-acquired before its scheduled end never took "
+            "the rest of its frames -- it was dropped as already handled");
+    h.stop.set();
+    loop.join();
+    watcher.join();
+
+    if (h.received.size() < 2) return;
+    const rx::Reception& second = h.received[1];
+    check::is_true(!h.received[0].saved_path.has_value(),
+                   "rx/fade: the first delivery of a reception replaces nothing");
+    check::is_true(second.saved_path.has_value() && *second.saved_path == *h.save_as,
+                   "rx/fade: the improved picture was delivered as a new reception "
+                   "rather than as a replacement for the one already saved");
+    check::is_true(second.frames_decoded.value_or(0) > first_decoded,
+                   "rx/fade: the second delivery carries more of the picture");
+}
+
+void test_a_new_reception_does_not_discard_an_undelivered_one() {
+    // Taking over the tracked slot delivers what is being replaced.
+    //
+    // Dropping it was survivable while a stall retired receptions
+    // within end_grace; now that one is kept until its scheduled end, a
+    // second transmission arriving over the top of it is routine, and
+    // the picture already decoded would go out with the record.
+    //
+    // end_grace is put out of reach and the buffer never gets near the
+    // first transmission's own duration, so neither the stall nor the
+    // deadline can deliver it: the takeover is the only thing left.
+    Harness h(12.0);
+    h.config.end_grace = 1e9;
+    write_all(h.ring, truncated("KC2G", 61, 3.0));
+
+    std::thread loop([&] {
+        rx::decode_loop(h.ring, h.decoder(), h.state, h.config, h.stop, h.sink());
+    });
+    std::thread watcher([&] { h.poll_watcher(); });
+
+    h.until([&] { return h.state.get().status == rx::Status::Receiving; },
+            "rx/takeover: the first fragment puts the loop in receiving");
+    check::equal(h.count(), std::size_t{0},
+                 "rx/takeover: nothing has been delivered yet");
+
+    // Age the first one out of the ring, then give the loop a second
+    // transmission at a different position -- so the next poll decodes
+    // something that is not the reception being tracked.
+    write_all(h.ring, std::vector<double>(static_cast<std::size_t>(12.0 * config::FS)));
+    write_all(h.ring, truncated("W1AW", 62, 3.0));
+
+    h.until([&] { return h.received.size() >= 1; },
+            "rx/takeover: the reception being replaced was discarded -- its "
+            "picture had already decoded and nothing else can deliver it");
+    h.stop.set();
+    loop.join();
+    watcher.join();
+
+    if (h.received.empty()) return;
+    check::is_true(h.received[0].frames_received.has_value() &&
+                       *h.received[0].frames_received < mode_a().n_frames,
+                   "rx/takeover: delivered as the partial reception it is");
 }
 
 void test_low_cpu_does_not_wait_forever_for_audio_that_stops() {
@@ -648,16 +782,19 @@ void test_poll_backoff() {
                  "rx/backoff: the duty floor bounds the wait");
 }
 
-// The progress bar is position, not fill: the last frame successfully
-// received over the frames expected, never latents-received over
-// latents-expected. Only the blind path can tell the two apart -- it
-// decodes whatever frames it can place, with holes where the signal
-// faded or where the transmission started before the buffer did -- and
-// a fill fraction there is a completion percentage that is not one.
+// The two reception numbers: what arrived, and what decoded.
 //
-// Arithmetic, so it is checked as arithmetic (see `blind_progress`'s
+// The bar is `frames whose audio has arrived / frames expected`
+// (frames_in_buffer), pure arithmetic on buffer positions, so it climbs
+// with the clock whatever the decoder manages. Beside it, and never as
+// it, is frames_decoded -- a *fill*, held down permanently by the
+// erasures the blind path lives with. And the confident-latent count is
+// neither: it is the stall clock's input, and nothing else may be
+// substituted for it.
+//
+// Arithmetic, so it is checked as arithmetic (see `decode_progress`'s
 // header comment), rather than inferred from a whole decode run.
-void test_blind_progress_is_the_last_frame_reached() {
+void test_the_two_progress_numbers() {
     const int total = config::MODES[config::N_MODES - 1].n_frames;
     const auto n_latents =
         static_cast<std::size_t>(config::MODES[config::N_MODES - 1].n_latents);
@@ -670,60 +807,73 @@ void test_blind_progress_is_the_last_frame_reached() {
         return out;
     };
 
-    const rx::BlindProgress none =
-        rx::blind_progress(std::vector<double>(n_latents, 0.0), total);
-    check::is_true(none.metric == 0 && none.frac == 0.0 && none.reach == 0,
-                   "rx/progress: nothing received is zero progress");
+    const rx::DecodeProgress none =
+        rx::decode_progress(std::vector<double>(n_latents, 0.0));
+    check::is_true(none.metric == 0 && none.frames_decoded == 0,
+                   "rx/progress: nothing received is nothing decoded");
 
     // At the threshold, not over it: a latent that only ties does not
     // count, the same cutoff the stall metric has always used.
-    const rx::BlindProgress tied = rx::blind_progress(weights_for({0}, 0.5), total);
-    check::is_true(tied.metric == 0 && tied.frac == 0.0,
+    const rx::DecodeProgress tied = rx::decode_progress(weights_for({0}, 0.5));
+    check::is_true(tied.metric == 0 && tied.frames_decoded == 0,
                    "rx/progress: a weight at the threshold does not count");
 
-    // Every other frame of mode B's range plus its last: half the
-    // latents, but the transmission has been followed all the way to its
-    // end. The old count-based fraction reported ~50% here.
-    const int reach = config::MODES[1].n_frames;
+    // Every other frame of mode B's range: a frame counts once whatever
+    // it carries, while the metric counts latents. The interleaver is
+    // why the two answers differ at all.
     std::vector<int> sparse;
-    for (int f = 0; f < reach; f += 2) sparse.push_back(f);
-    sparse.push_back(reach - 1);
-    const rx::BlindProgress half = rx::blind_progress(weights_for(sparse, 1.0), total);
-    check::is_true(std::abs(half.frac - static_cast<double>(reach) / total) < 1e-12,
-                   "rx/progress: half the latents, all the way to mode B's last frame");
+    for (int f = 0; f < config::MODES[1].n_frames; f += 2) sparse.push_back(f);
+    const rx::DecodeProgress half = rx::decode_progress(weights_for(sparse, 1.0));
+    check::equal(half.frames_decoded, static_cast<int>(sparse.size()),
+                 "rx/progress: frames decoded counts frames, not latents");
     check::is_true(half.metric == static_cast<int>(sparse.size()) * config::LATENTS_PER_FRAME,
                    "rx/progress: the stall metric is still the confident count");
-    // The reach is the fraction's numerator, reported as the blind
-    // path's frames_received so the status line's frame counter and its
-    // percentage advance together instead of one freezing.
-    check::equal(half.reach, reach,
-                 "rx/progress: the reach is the fraction's own numerator");
-
-    // The beacon's mode field (PROTOCOL_VERSION 4) gives the blind path
-    // the real frame count: a complete mode B reception reads 100%, not
-    // the 2/3 that dividing by mode C's count reported before.
-    const rx::BlindProgress known =
-        rx::blind_progress(weights_for(sparse, 1.0), reach);
-    check::is_true(std::abs(known.frac - 1.0) < 1e-12,
-                   "rx/progress: a known mode makes the bar fill at that mode's end");
-
-    // Tuned in at frame 400 of mode C and heard the rest: two thirds of
-    // the latents are gone for good and the bar must still read full.
-    std::vector<int> late;
-    for (int f = 400; f < total; ++f) late.push_back(f);
-    check::is_true(std::abs(rx::blind_progress(weights_for(late, 1.0), total).frac - 1.0) < 1e-12,
-                   "rx/progress: a late join reports where it is, not how much it has");
 
     // Retrospective decoding filling in frames *behind* the furthest one
-    // is progress in quality but not in position; the bar must not move.
-    const double reached = rx::blind_progress(weights_for({0, 300}, 1.0), total).frac;
-    check::is_true(std::abs(reached - 301.0 / total) < 1e-12,
-                   "rx/progress: the furthest frame sets the bar");
+    // is real progress, and the stall clock has to see it as progress or
+    // it ends a reception that is still improving. That is the property
+    // no positional number has, and the reason this is the metric.
+    const rx::DecodeProgress reached = rx::decode_progress(weights_for({0, 300}, 1.0));
     std::vector<int> filled;
     for (int f = 0; f <= 300; ++f) filled.push_back(f);
-    check::is_true(
-        std::abs(rx::blind_progress(weights_for(filled, 1.0), total).frac - reached) < 1e-12,
-        "rx/progress: backfill behind the furthest frame does not move it");
+    const rx::DecodeProgress backfilled = rx::decode_progress(weights_for(filled, 1.0));
+    check::is_true(backfilled.metric > reached.metric,
+                   "rx/progress: backfill moves the stall metric");
+    check::is_true(backfilled.frames_decoded > reached.frames_decoded,
+                   "rx/progress: and moves the decoded count with it");
+
+    // The bar. No weights anywhere in it -- that is the whole point.
+    const int n = config::MODES[0].n_frames;
+    const std::int64_t frames_start = config::PREAMBLE_SAMPLES + config::HEADER_SAMPLES;
+    const std::int64_t end = frames_start + std::int64_t{n} * config::FRAME_SAMPLES;
+    check::equal(rx::frames_in_buffer(0, 0, 0, n), 0,
+                 "rx/bar: nothing has arrived yet");
+    check::equal(rx::frames_in_buffer(0, 0, frames_start + config::FRAME_SAMPLES, n), 1,
+                 "rx/bar: one whole frame has arrived");
+    check::equal(rx::frames_in_buffer(0, 0, end, n), n, "rx/bar: all of it");
+    check::equal(rx::frames_in_buffer(0, 0, end + 100 * config::FRAME_SAMPLES, n), n,
+                 "rx/bar: audio past the end is not more of the transmission");
+
+    // Climbing with the clock is the property, so check it as one.
+    int prev = -1;
+    bool monotone = true;
+    for (int k = 0; k <= n; k += 7) {
+        const int got = rx::frames_in_buffer(0, 0, frames_start + std::int64_t{k} * config::FRAME_SAMPLES, n);
+        monotone = monotone && got >= prev;
+        prev = got;
+    }
+    check::is_true(monotone, "rx/bar: climbs with the clock and nothing else");
+
+    // Tuned in at frame 400 of mode C: those frames' audio is gone for
+    // good, so the bar starts at 400/660 and fills from there. Counting
+    // from zero would promise a picture that cannot arrive.
+    const std::int64_t joined = frames_start + 400 * config::FRAME_SAMPLES;
+    check::equal(rx::frames_in_buffer(0, joined, joined, total), 0,
+                 "rx/bar: a late join has nothing of it yet");
+    check::equal(rx::frames_in_buffer(0, joined,
+                                      frames_start + std::int64_t{total} * config::FRAME_SAMPLES,
+                                      total),
+                 total - 400, "rx/bar: and fills only with what it can still hear");
 }
 
 // `frame_of_latent` is the inverse of `slot_range_for_frame`, and the
@@ -753,13 +903,15 @@ int main() {
     try {
         test_poll_backoff();
         test_frame_of_latent_inverts_slot_range_for_frame();
-        test_blind_progress_is_the_last_frame_reached();
+        test_the_two_progress_numbers();
         test_stop_interrupts_a_wait_in_progress();
         test_a_clean_transmission_is_received_once();
         test_noise_produces_nothing();
         test_low_cpu_loop_receives();
         test_a_finished_reception_is_not_rediscovered();
         test_a_reception_whose_decodes_stop_is_still_delivered();
+        test_a_faded_reception_resumes_and_replaces_its_picture();
+        test_a_new_reception_does_not_discard_an_undelivered_one();
         test_low_cpu_does_not_wait_forever_for_audio_that_stops();
         test_two_transmissions_are_both_received();
         test_fresh_session_does_not_inherit_blind_evidence_from_a_prior_one();

--- a/sstvae/rx/engine.py
+++ b/sstvae/rx/engine.py
@@ -10,15 +10,18 @@ history from before sync was acquired, a mid-stream lock still decodes
 the frames that arrived before it -- retrospective decoding, not just
 from-here-on.
 
-Reception is considered finished when a fully-synced decode reports all
-its frames received, when decoded progress stops advancing for
---end-grace seconds, or when the buffer holds audio past the point where
-the last frame of that transmission could possibly still be arriving --
-whichever comes first. All three tests run against `_Pending`, the
-tracked reception retained *across* polls, so that none of them depends
-on the current poll having produced a decode at all; see `_Pending` for
-why that is the whole ballgame, and PROGRESS_WEIGHT_THRESHOLD for what
-"progress" counts as on the blind path.
+A reception is finished when a fully-synced decode reports all its
+frames received, or when the buffer holds audio past the point where the
+last frame of that transmission could possibly still be arriving --
+whichever comes first. Losing sync for --end-grace seconds does not
+finish it: it *delivers* it, so autosave never waits on a signal that
+may not come back, and leaves it tracked until its scheduled end so a
+fade it recovers from still contributes. Every one of those tests runs
+against `_Pending`, the tracked reception retained *across* polls, so
+that none of them depends on the current poll having produced a decode
+at all; see `_Pending` for why that is the whole ballgame, and
+`_decode_progress` for what "progress" counts as -- which is not what
+the progress bar shows, deliberately (`_frames_in_buffer`).
 
 `decode_loop_low_cpu` is a cheaper variant that drops the blind fallback
 (and with it retrospective mid-stream decoding); see its docstring.
@@ -78,65 +81,73 @@ SAME_RECEPTION_EPSILON_S = 1.0
 PROGRESS_WEIGHT_THRESHOLD = 0.5
 
 
-def _blind_progress(
-    weights_full: np.ndarray, n_frames_expected: int
-) -> tuple[int, float, int]:
-    """(stall metric, progress fraction, frame reach) for one blind decode.
-
-    Two different questions, deliberately answered by two different
-    numbers.
+def _decode_progress(weights_full: np.ndarray) -> tuple[int, int]:
+    """(stall metric, frames decoded) for one decode's weights.
 
     The **metric** is the count of confidently-received latents, and
-    confidence is what makes it usable: demodulate_blind assigns *some*
-    nonzero weight to essentially every legal abs_frame slot its
-    ever-growing search range touches, real signal or not (just small
-    for noise, after the med_h fix in modem.py), so a nonzero count
-    keeps climbing every poll purely from the buffer growing --
-    independent of whether any new real data has arrived -- until buffer
-    growth has mapped the *entire* legal abs_frame range, which can take
-    a whole mode's duration after the real transmission already ended.
-    That read as "stuck receiving forever": the stall detector never saw
-    a stable value to end_grace against. PROGRESS_WEIGHT_THRESHOLD
-    matches the "good" cutoff already used to judge latents elsewhere
-    (see tests/test_blind_acquisition.py); only real frames clear it, so
-    the count stops climbing exactly when the real data does.
+    confidence is what makes it usable as a stall signal:
+    demodulate_blind assigns *some* nonzero weight to essentially every
+    legal abs_frame slot its ever-growing search range touches, real
+    signal or not (just small for noise, after the med_h fix in
+    modem.py), so a nonzero count keeps climbing every poll purely from
+    the buffer growing -- independent of whether any new real data has
+    arrived -- until buffer growth has mapped the *entire* legal
+    abs_frame range, which can take a whole mode's duration after the
+    real transmission already ended. That read as "stuck receiving
+    forever": the stall detector never saw a stable value to end_grace
+    against. PROGRESS_WEIGHT_THRESHOLD matches the "good" cutoff already
+    used to judge latents elsewhere (see
+    tests/test_blind_acquisition.py); only real frames clear it, so the
+    count stops climbing exactly when the real data does. **This is the
+    number the stall clock watches, and nothing else may be substituted
+    for it** -- every alternative here either climbs on buffer growth
+    alone (so a reception never stalls) or is a position rather than an
+    amount (so retrospective backfill reads as no progress).
 
-    The **fraction** is how far *into* the transmission we have got --
-    the last frame that decoded, over the frames expected -- and is not
-    that count over the total. A count reads as a completion percentage
-    and is not one: the erasures this path lives with (a fade, or simply
-    not having heard the start) hold it down permanently, so a reception
-    already at the transmission's last frame still shows 70%, and the
-    bar never fills. The interleaver is why the two differ at all --
-    each frame's latents are scattered across the whole picture, so only
-    the frame index says "how far".
-
-    `n_frames_expected` is the denominator: the beacon's mode field
-    (PROTOCOL_VERSION 4) names the transmission's real frame count, so
-    the caller passes that when the beacon's mode index is one it knows,
-    and mode C's count -- the longest, the pre-mode-field assumption --
-    when it isn't.
-
-    The **reach** is the fraction's own numerator, returned separately
-    because it is what the blind path reports as `frames_received`. The
-    beacon mode gave the blind path an `n_frames_expected`, and every
-    status line formats the pair together -- so leaving
-    `frames_received` unset put a frozen "frame None/440" (or 0/440)
-    next to a moving percentage, one indicator advancing while the
-    other never did. It is a *position*, not a count of frames
-    actually held: erasures behind the reach are the normal state of
-    this path, which is also why a blind reception must never be
-    treated as complete just because its reach hit the last frame (see
-    the `complete` test in decode_loop).
+    **Frames decoded** is the same mask counted the other way: how many
+    of the transmission's frames carried confident data at all. It is a
+    *fill*, and it is what the UI shows beside the progress bar rather
+    than as it -- a fill fraction reads as a completion percentage and
+    is not one, since the erasures both paths live with (a fade, or
+    simply not having heard the start) hold it down permanently. What
+    fills is `_frames_in_buffer`. The interleaver is why the two differ
+    at all: each frame's latents are scattered across the whole picture,
+    so a latent count answers "how much" and only a frame index answers
+    "how far".
     """
     good = weights_full > PROGRESS_WEIGHT_THRESHOLD
-    frames = framing.frame_of_latent()[good]
-    last_frame = int(frames.max()) + 1 if frames.size else 0
-    return (
-        int(np.count_nonzero(good)),
-        last_frame / n_frames_expected,
-        last_frame,
-    )
+    seen = np.zeros(MODES["C"].n_frames, dtype=bool)
+    seen[framing.frame_of_latent()[good]] = True
+    return int(np.count_nonzero(good)), int(np.count_nonzero(seen))
+
+
+def _frames_in_buffer(start: int, buf_start: int, total: int, n_frames: int) -> int:
+    """How many of a transmission's frames have arrived: the progress
+    bar's numerator, and pure arithmetic on buffer positions.
+
+    This is what the bar should show, because it is the only one of the
+    available numbers that climbs with the clock rather than with the
+    decoder's luck. The header path already reported exactly this --
+    `DemodResult.frames_received` is `received.sum()`, and `received[f]`
+    is set for every frame whose samples are in the buffer, signal or
+    noise -- so this is that number generalized to the blind path, which
+    had been showing how far its furthest *decoded* frame reached and so
+    stalled on the erasures that are its normal state.
+
+    `buf_start` is in it because a blind reception can begin before the
+    audio does: joining a transmission late leaves its early frames
+    permanently unavailable, and a bar that starts at 40% and fills is
+    honest where one that starts at 0 and can never reach 100 is not.
+    Monotone in practice rather than by construction -- it assumes the
+    ring outlives the longest mode (130 s against 95 s), which is the
+    same assumption the rest of the retrospective decoding rests on.
+    """
+    frames_start = start + PREAMBLE_SAMPLES + HEADER_SAMPLES
+    first = -(-(buf_start - frames_start) // FRAME_SAMPLES)  # ceil
+    last = (total - frames_start) // FRAME_SAMPLES
+    lo = min(max(first, 0), n_frames)
+    hi = min(max(last, 0), n_frames)
+    return int(max(0, hi - lo))
 
 
 @dataclass
@@ -198,6 +209,20 @@ class _Pending:
     the reception can still be delivered after its decodes have stopped.
     `deadline_abs` is a buffer position, not a time: past it, no real
     frame of this transmission can still be arriving (see decode_loop).
+
+    The record also outlives its own delivery. Delivering and retiring
+    are separate events: a stall hands the picture to the sink straight
+    away (so autosave is never delayed) but leaves the reception
+    *dormant* -- still tracked, still able to take contributions -- until
+    its scheduled end. That is what makes a fade survivable. A fade
+    longer than end_grace is indistinguishable from a transmitter that
+    stopped, and the old behaviour retired the reception on the spot and
+    recorded its start as finished, so the blind path's re-acquisition a
+    few seconds later was dropped as already-handled and the rest of a
+    picture still being heard was refused. Since PROTOCOL_VERSION 4 the
+    beacon names the mode, so `deadline_abs` is exact on the blind path
+    too, and the scheduled end -- not the stall -- is what ends a
+    reception.
     """
 
     start: int  # absolute (ring-buffer-coordinate) preamble-start position
@@ -210,14 +235,22 @@ class _Pending:
     # retrospective-fill progress and must not fire while the header
     # path's frames_received is what's advancing.
     blind: bool = False
-    metric: int = 0  # best progress metric seen; see _blind_progress
+    metric: int = 0  # best progress metric seen; see _decode_progress
     stable_since: float | None = None  # when the metric last stopped advancing
     image: object = None
     mode_name: str | None = None
     frames_received: int | None = None
+    frames_decoded: int | None = None
     n_frames_expected: int | None = None
     callsign: str = ""
     snr_db: float = float("nan")
+    # `metric` as of the last delivery, and where that delivery went.
+    # Together they are the whole dormancy bookkeeping: a delivery only
+    # happens when the reception has improved on what the sink already
+    # has, and a second one replaces the first in place rather than
+    # producing a second picture of one transmission.
+    delivered_metric: int = 0
+    saved_path: str | None = None
 
 
 @dataclass
@@ -232,15 +265,36 @@ class Reception:
     mode_name: str | None
     callsign: str
     snr_db: float
+    # How much of the transmission arrived, and how much of it actually
+    # decoded. The first is the progress bar's numerator and climbs with
+    # the clock; the second is a fill, and the gap between them is what
+    # a fade costs. See _frames_in_buffer and _decode_progress.
     frames_received: int | None
+    frames_decoded: int | None
     n_frames_expected: int | None
+    # Set when this same reception has already been delivered once, to
+    # the path named here: a fade ended it early, it recovered before its
+    # scheduled end, and this is the better decode. **Replace what is
+    # there rather than adding a second picture** -- one transmission is
+    # one file, one gallery entry, one notification.
+    saved_path: str | None = None
 
 
 @dataclass
 class SharedState:
-    status: str = "listening"  # listening | receiving | done
+    # listening | receiving | waiting | done.
+    #
+    # "waiting" is a reception that lost sync and has already been
+    # delivered, but whose scheduled end has not arrived: it is neither
+    # receiving a signal (there isn't one) nor idle (a picture is still
+    # open for the rest of its frames). See _Pending.
+    status: str = "listening"
     mode_name: str | None = None
+    # frames_received is the frames that have arrived (what the bar
+    # shows); frames_decoded is how many of them carried confident data
+    # (shown beside it, never as it). See _frames_in_buffer.
     frames_received: int | None = None
+    frames_decoded: int | None = None
     n_frames_expected: int | None = None
     progress_frac: float = 0.0
     callsign: str = ""
@@ -301,18 +355,70 @@ class SaveToDirSink:
         self.verbose = verbose
 
     def on_reception(self, rec: Reception) -> str | None:
-        out_path = timestamped_path(self.out_dir)
+        # A reception that recovered after a fade comes back with the
+        # path its first delivery went to: overwrite that, so one
+        # transmission stays one file.
+        out_path = (
+            Path(rec.saved_path) if rec.saved_path else timestamped_path(self.out_dir)
+        )
         out_path.parent.mkdir(parents=True, exist_ok=True)
         img = rec.image
         if self.size is not None:
             img = img.resize(self.size)
         img.save(out_path)
         if self.verbose:
+            verb = "updated" if rec.saved_path else "saved"
             print(
-                f"saved {out_path} (mode={rec.mode_name or 'unknown, blind sync'}, "
+                f"{verb} {out_path} (mode={rec.mode_name or 'unknown, blind sync'}, "
                 f"callsign={rec.callsign or '(none)'}{fmt_snr(rec.snr_db)})"
             )
         return str(out_path)
+
+
+def _deliver(pending: "_Pending", sink, state: "SharedState", finished_starts) -> bool:
+    """Hand `pending` to the sink if it has improved on what the sink
+    already has. Returns whether anything was delivered.
+
+    Called both when a reception stalls and when it retires, which is the
+    whole point: the stall delivers so autosave is prompt, retirement
+    delivers whatever arrived afterwards. `delivered_metric` is what
+    keeps that from turning into a delivery per poll, and `saved_path`
+    is what makes the second delivery a replacement rather than a second
+    picture of the same transmission.
+
+    The first delivery is also what records the start in
+    `finished_starts` -- from then on the preamble search steps over it,
+    so a transmission that was cut off early cannot go on hiding a later
+    one for the rest of its own scheduled duration. The reception stays
+    resumable anyway: the blind path checks the tracked reception before
+    that list (see decode_loop).
+    """
+    if pending.metric <= pending.delivered_metric or pending.image is None:
+        return False
+    first = pending.delivered_metric == 0
+    saved_path = sink.on_reception(
+        Reception(
+            image=pending.image,
+            mode_name=pending.mode_name,
+            callsign=pending.callsign,
+            snr_db=pending.snr_db,
+            frames_received=pending.frames_received,
+            frames_decoded=pending.frames_decoded,
+            n_frames_expected=pending.n_frames_expected,
+            saved_path=pending.saved_path,
+        )
+    )
+    pending.delivered_metric = pending.metric
+    if saved_path is not None:
+        pending.saved_path = saved_path
+    if first:
+        # Bookkeeping, not disk: this reception has been *handled*, so it
+        # must never be rediscovered as a new one while its audio is
+        # still in the buffer -- whether or not the sink chose to save.
+        finished_starts.append(pending.start)
+    with state.lock:
+        state.saved_path = saved_path
+    return True
 
 
 def _already_finished(pos: float, finished_starts, epsilon_samples: float) -> bool:
@@ -447,6 +553,7 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
         t0 = time.time()
         latents_full = weights_full = None
         mode_name = n_frames_expected = frames_received = None
+        frames_decoded = None
         callsign = ""
         snr_db = float("nan")
         progress_frac = 0.0
@@ -470,11 +577,16 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
             weights_full = pad_to_full(r.weights)
             mode_name = r.mode.name
             n_frames_expected = r.mode.n_frames
+            # `received.sum()`: the frames whose samples are in the
+            # buffer, which is the bar's numerator (see
+            # _frames_in_buffer) and, unchanged, the header path's stall
+            # metric.
             frames_received = r.frames_received
             callsign = r.callsign
             snr_db = r.snr_db
             progress_frac = frames_received / n_frames_expected
             progress_metric = frames_received
+            _, frames_decoded = _decode_progress(weights_full)
         else:
             # Fold whatever's new since the last poll into the running
             # accumulator -- O(new samples), not O(window) -- which is
@@ -525,11 +637,25 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
                 reception_start = (
                     buf_start + rb.frame0_start - PREAMBLE_SAMPLES - HEADER_SAMPLES
                 )
-                # Already handled: treat it as nothing decoded rather
-                # than skipping the rest of the poll, so that whatever
-                # reception is *currently* pending still gets its
-                # completion tests run this time round.
-                if _already_finished(reception_start, finished_starts, epsilon_samples):
+                # The tracked reception is checked *before* the
+                # finished list, and that is the whole resume mechanism:
+                # a reception delivered early on a stall is in that list
+                # (so the preamble search steps over it) while still
+                # being the one we are tracking, and dropping its
+                # re-acquisition here is exactly what used to refuse the
+                # rest of a picture that was still being heard.
+                #
+                # Anything else already handled: treat it as nothing
+                # decoded rather than skipping the rest of the poll, so
+                # that whatever reception is *currently* pending still
+                # gets its completion tests run this time round.
+                ours = (
+                    pending is not None
+                    and abs(reception_start - pending.start) <= epsilon_samples
+                )
+                if not ours and _already_finished(
+                    reception_start, finished_starts, epsilon_samples
+                ):
                     reception_start = None
                 else:
                     latents_full = rb.latents
@@ -546,16 +672,21 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
                     if blind_spec is not None:
                         mode_name = blind_spec.name
                         n_frames_expected = blind_spec.n_frames
-                    progress_metric, progress_frac, reach = _blind_progress(
-                        weights_full,
+                    # The stall metric stays the confident-latent count
+                    # -- the amount decoded, which is the only thing
+                    # that stops climbing when the signal does. The bar
+                    # is the positional count instead, so a fade holds
+                    # back the *decoded* figure beside it rather than
+                    # freezing the bar.
+                    progress_metric, frames_decoded = _decode_progress(weights_full)
+                    n_display = (
                         n_frames_expected if n_frames_expected is not None
-                        else MODES["C"].n_frames,
+                        else MODES["C"].n_frames
                     )
-                    # The reach doubles as the reported frame counter --
-                    # see _blind_progress for why leaving this None froze
-                    # half of every status line once the beacon's mode
-                    # field supplied the other half.
-                    frames_received = reach
+                    frames_received = _frames_in_buffer(
+                        reception_start, buf_start, total, n_display
+                    )
+                    progress_frac = frames_received / n_display
             else:
                 reception_start = None
 
@@ -574,8 +705,24 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
             # inherit the previous one's stall clock, or it can be
             # mistaken for a reception that has already stopped
             # advancing and be ended immediately.
+            #
+            # The outgoing record is delivered first. Taking over used to
+            # discard it -- picture, metric and all -- which was survivable
+            # only because a stall retired receptions quickly; now that one
+            # is kept until its scheduled end, the overlap is routine and
+            # dropping it would lose a picture that had already decoded.
+            # No "done" flash here: the new reception publishes "receiving"
+            # a few lines below, and a status the operator cannot see is
+            # not worth a two-second pause in the loop.
             if pending is None or abs(reception_start - pending.start) > epsilon_samples:
+                if pending is not None:
+                    _deliver(pending, sink, state, finished_starts)
                 pending = _Pending(start=reception_start, deadline_abs=0)
+                # Nothing has been saved for *this* reception yet, and a
+                # status line that named the previous one's file would
+                # be attributing it to the picture now on screen.
+                with state.lock:
+                    state.saved_path = None
             # The deterministic backstop. The transmission's start is
             # known exactly -- from the header path's own acquisition,
             # or from the beacon on the blind path, both in the same
@@ -605,16 +752,25 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
             if progress_metric > pending.metric:
                 pending.metric = progress_metric
                 advanced = True
-            pending.image = reconstruct(model, latents_full, weights_full)
-            pending.mode_name = mode_name
-            pending.frames_received = frames_received
-            pending.n_frames_expected = n_frames_expected
-            pending.callsign = callsign
-            pending.snr_db = snr_db
+            # Only an at-least-as-good decode replaces the held picture.
+            # A reception now lives until its scheduled end, so it sees
+            # decodes taken during a fade -- which are real decodes with
+            # fewer frames in them, and used to overwrite a better
+            # picture wholesale while `metric`, the only monotone field,
+            # went on saying progress had been made.
+            if progress_metric >= pending.metric:
+                pending.image = reconstruct(model, latents_full, weights_full)
+                pending.mode_name = mode_name
+                pending.frames_received = frames_received
+                pending.frames_decoded = frames_decoded
+                pending.n_frames_expected = n_frames_expected
+                pending.callsign = callsign
+                pending.snr_db = snr_db
             with state.lock:
                 state.status = "receiving"
                 state.mode_name = mode_name
                 state.frames_received = frames_received
+                state.frames_decoded = frames_decoded
                 state.n_frames_expected = n_frames_expected
                 state.progress_frac = min(progress_frac, 1.0)
                 state.callsign = callsign
@@ -626,8 +782,16 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
                 state.status = "listening"
             continue
 
-        # Two things end a reception short of its own frame count, and
-        # both are timed against end_grace.
+        # Two things interrupt a reception short of its own frame count,
+        # and both are timed against end_grace. Since the beacon's mode
+        # field made the deadline exact on both paths, neither of them
+        # *ends* a reception any more: they deliver it, and it stays
+        # tracked until its scheduled end. A fade longer than end_grace
+        # looks exactly like a transmitter that stopped, and only the
+        # transmitter's own clock can tell the difference -- so the
+        # picture goes to the sink now (autosave must not wait on a
+        # signal that may never come back) and the reception stays open
+        # for the rest of it (nothing is lost if it does).
         #
         # It stopped decoding. That is how a reception actually ends in
         # the field: its audio scrolls out of the ring buffer, or its
@@ -640,19 +804,34 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
         # of the poll entirely, is why a reception in that state could
         # never satisfy any completion test however long it sat.
         #
-        # Or -- blind only, where there is no frame count to finish on
-        # -- its decoded progress stopped advancing. Deliberately *not*
-        # extended to the header path: a spurious preamble-shaped lock
-        # in noise goes on decoding the same handful of frames for as
-        # long as it is looked at, and ending that on a stall would turn
-        # a false lock into a reported, and autosaved, picture of noise.
-        # The header path does not need it anyway -- frames_received
-        # climbs as the buffer grows, so a real transmission reaches its
-        # count, and the deadline below is the backstop for one that
-        # does not. Keyed on pending.blind rather than "mode unknown":
-        # since the beacon's mode field, the blind path knows the mode
-        # too, so n_frames_expected no longer distinguishes the paths.
-        no_progress = not decoded or (pending.blind and not advanced)
+        # Or its decoded progress stopped advancing. This used to be
+        # blind-only, on the grounds that a spurious preamble-shaped
+        # lock in noise goes on decoding the same handful of frames for
+        # as long as it is looked at, and that ending *that* on a stall
+        # turns a false lock into an autosaved picture of noise. Neither
+        # half of that argument survives what the two numbers actually
+        # measure.
+        #
+        # The header path's frames_received is `received.sum()`, and
+        # `received[f]` is true for every frame whose samples are in the
+        # buffer -- signal or noise, faded or clean (modem.demodulate).
+        # It is buffer coverage, not signal. So it climbs right through
+        # a fade, it climbs through the noise that follows a transmitter
+        # cutting off early (which is why *that* case ends on `complete`
+        # at the transmission's scheduled end rather than needing a
+        # stall at all), and a false lock in noise climbs with it. The
+        # one thing that stops it is the buffer not growing -- capture
+        # unplugged, the stream dead, the host no longer delivering
+        # callbacks -- and there the header path had no test that could
+        # ever fire: it goes on decoding, so `not decoded` is false; it
+        # never reaches its frame count; and `total` has stopped, so the
+        # deadline below is unreachable by construction. It sat in
+        # "receiving" forever, which is the hang this whole record
+        # exists to close, still open on one path.
+        #
+        # And a stall no longer ends a reception -- it delivers one and
+        # keeps it -- so the distinction has nothing left to protect.
+        no_progress = not decoded or not advanced
         if no_progress:
             if pending.stable_since is None:
                 pending.stable_since = time.time()
@@ -677,7 +856,24 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
             pending.stable_since is not None
             and (time.time() - pending.stable_since) >= config.end_grace
         )
-        if not (complete or stalled or total >= pending.deadline_abs):
+        # Retirement is the transmitter's own clock, not ours: its frame
+        # count is in, or the buffer holds audio past the point where
+        # its last frame could still be arriving. Nothing else drops the
+        # record -- see _Pending.
+        retire = complete or total >= pending.deadline_abs
+
+        if not retire:
+            if stalled:
+                # Delivered, but still tracked: dormant. _deliver is a
+                # no-op unless it improved on what the sink already has,
+                # so a reception that stays quiet is handed over exactly
+                # once however many polls it sits through -- while the
+                # status says "waiting" throughout, including for a
+                # reception that never had a confident latent to deliver
+                # at all.
+                _deliver(pending, sink, state, finished_starts)
+                with state.lock:
+                    state.status = "waiting"
             continue
 
         # Deliver only what has something in it. A reception that ended
@@ -687,22 +883,9 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
         # transmission that was merely weak on its first polls must stay
         # findable rather than be blocked out for as long as its audio
         # is in the buffer.
-        delivered = pending.metric > 0 and pending.image is not None
+        _deliver(pending, sink, state, finished_starts)
+        delivered = pending.delivered_metric > 0
         if delivered:
-            saved_path = sink.on_reception(
-                Reception(
-                    image=pending.image,
-                    mode_name=pending.mode_name,
-                    callsign=pending.callsign,
-                    snr_db=pending.snr_db,
-                    frames_received=pending.frames_received,
-                    n_frames_expected=pending.n_frames_expected,
-                )
-            )
-            # Bookkeeping, not disk: this reception has been *handled*,
-            # so it must never be rediscovered while its audio is still
-            # in the buffer -- whether or not the sink chose to save it.
-            finished_starts.append(pending.start)
             # Retire the blind evidence with the reception. The delivered
             # transmission's fold otherwise keeps the accumulator's
             # argmax for a long time -- its peak/median score does not
@@ -730,7 +913,6 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
             blind_acc_pushed = total
             with state.lock:
                 state.status = "done"
-                state.saved_path = saved_path
 
         pending = None
 
@@ -744,6 +926,7 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
             state.status = "listening"
             state.mode_name = None
             state.frames_received = None
+            state.frames_decoded = None
             state.n_frames_expected = None
             state.progress_frac = 0.0
             state.callsign = ""
@@ -858,7 +1041,9 @@ def decode_loop_low_cpu(ring: RingBuffer, model, state: SharedState, config: RxC
                 state.status = "listening"
             continue
 
-        img = reconstruct(model, pad_to_full(r.latents), pad_to_full(r.weights))
+        weights_full = pad_to_full(r.weights)
+        img = reconstruct(model, pad_to_full(r.latents), weights_full)
+        _, frames_decoded = _decode_progress(weights_full)
         saved_path = sink.on_reception(
             Reception(
                 image=img,
@@ -866,6 +1051,7 @@ def decode_loop_low_cpu(ring: RingBuffer, model, state: SharedState, config: RxC
                 callsign=r.callsign,
                 snr_db=r.snr_db,
                 frames_received=r.frames_received,
+                frames_decoded=frames_decoded,
                 n_frames_expected=r.mode.n_frames,
             )
         )
@@ -873,6 +1059,7 @@ def decode_loop_low_cpu(ring: RingBuffer, model, state: SharedState, config: RxC
             state.status = "done"
             state.image = img
             state.frames_received = r.frames_received
+            state.frames_decoded = frames_decoded
             state.progress_frac = min(r.frames_received / r.mode.n_frames, 1.0)
             state.snr_db = r.snr_db
             state.saved_path = saved_path

--- a/sstvae/rx/engine.py
+++ b/sstvae/rx/engine.py
@@ -21,7 +21,7 @@ against `_Pending`, the tracked reception retained *across* polls, so
 that none of them depends on the current poll having produced a decode
 at all; see `_Pending` for why that is the whole ballgame, and
 `_decode_progress` for what "progress" counts as -- which is not what
-the progress bar shows, deliberately (`_frames_in_buffer`).
+the progress bar shows, deliberately (`_frames_elapsed`).
 
 `decode_loop_low_cpu` is a cheaper variant that drops the blind fallback
 (and with it retrospective mid-stream decoding); see its docstring.
@@ -110,44 +110,45 @@ def _decode_progress(weights_full: np.ndarray) -> tuple[int, int]:
     than as it -- a fill fraction reads as a completion percentage and
     is not one, since the erasures both paths live with (a fade, or
     simply not having heard the start) hold it down permanently. What
-    fills is `_frames_in_buffer`. The interleaver is why the two differ
+    fills is `_frames_elapsed`. The interleaver is why the two differ
     at all: each frame's latents are scattered across the whole picture,
     so a latent count answers "how much" and only a frame index answers
     "how far".
     """
     good = weights_full > PROGRESS_WEIGHT_THRESHOLD
+    frame_of = framing.frame_of_latent()
     seen = np.zeros(MODES["C"].n_frames, dtype=bool)
-    seen[framing.frame_of_latent()[good]] = True
+    # frame_of is -1 for the never-transmitted dropped latents, and numpy
+    # would happily wrap that to the *last* frame. The C++ mirror guards
+    # `f >= 0`; the metric still counts every confident latent, dropped
+    # slot or not, exactly as the C++ does.
+    seen[frame_of[good & (frame_of >= 0)]] = True
     return int(np.count_nonzero(good)), int(np.count_nonzero(seen))
 
 
-def _frames_in_buffer(start: int, buf_start: int, total: int, n_frames: int) -> int:
-    """How many of a transmission's frames have arrived: the progress
+def _frames_elapsed(start: int, total: int, n_frames: int) -> int:
+    """How far through its schedule a transmission has got: the progress
     bar's numerator, and pure arithmetic on buffer positions.
 
     This is what the bar should show, because it is the only one of the
     available numbers that climbs with the clock rather than with the
-    decoder's luck. The header path already reported exactly this --
+    decoder's luck. The header path already reported nearly this --
     `DemodResult.frames_received` is `received.sum()`, and `received[f]`
     is set for every frame whose samples are in the buffer, signal or
     noise -- so this is that number generalized to the blind path, which
     had been showing how far its furthest *decoded* frame reached and so
     stalled on the erasures that are its normal state.
 
-    `buf_start` is in it because a blind reception can begin before the
-    audio does: joining a transmission late leaves its early frames
-    permanently unavailable, and a bar that starts at 40% and fills is
-    honest where one that starts at 0 and can never reach 100 is not.
-    Monotone in practice rather than by construction -- it assumes the
-    ring outlives the longest mode (130 s against 95 s), which is the
-    same assumption the rest of the retrospective decoding rests on.
+    It counts from the transmission's own first frame, not from the
+    audio we happened to capture: joining a transmission late leaves its
+    early frames permanently unavailable, and a bar that starts at 60%
+    and fills to 100% is honest where one that starts at 0 and can never
+    reach 100 is not. The frames the join missed show up instead as the
+    gap against `frames_decoded`, exactly like a fade's.
     """
     frames_start = start + PREAMBLE_SAMPLES + HEADER_SAMPLES
-    first = -(-(buf_start - frames_start) // FRAME_SAMPLES)  # ceil
-    last = (total - frames_start) // FRAME_SAMPLES
-    lo = min(max(first, 0), n_frames)
-    hi = min(max(last, 0), n_frames)
-    return int(max(0, hi - lo))
+    elapsed = (total - frames_start) // FRAME_SAMPLES
+    return int(min(max(elapsed, 0), n_frames))
 
 
 @dataclass
@@ -227,13 +228,27 @@ class _Pending:
 
     start: int  # absolute (ring-buffer-coordinate) preamble-start position
     deadline_abs: int
+    # `deadline_abs` translated to wall time when it was computed, plus
+    # end_grace. The buffer-position deadline is the transmitter's clock
+    # and is right whenever capture is alive -- but it is measured
+    # against `total`, so if capture dies mid-reception `total` freezes
+    # below it and it becomes unreachable by construction: the loop
+    # would sit in "waiting" forever with the picture already delivered,
+    # the same indefinite-hang shape all of this exists to close. The
+    # wall clock keeps running when the buffer does not. Anchored when
+    # `deadline_abs` is set (or tightened by a later-learned mode),
+    # never re-anchored per poll -- recomputing it from `now` every
+    # decoded poll would push it forever into the future in exactly the
+    # frozen-buffer case it exists for.
+    deadline_wall: float | None = None
     # Whether the *most recent* decode of this reception came from the
     # blind path. Per-poll, not per-reception: a reception first found
-    # blind can later decode over the preamble path (or vice versa), and
-    # the stall-on-no-advance test below must follow the path currently
-    # driving the record -- it exists for the blind path's
-    # retrospective-fill progress and must not fire while the header
-    # path's frames_received is what's advancing.
+    # blind can later decode over the preamble path (or vice versa).
+    # Only `complete` consults it -- the header path's frames_received
+    # is a contiguous decoded count that genuinely finishes at the
+    # total, where the blind path's is positional with erasures behind
+    # it. The stall clock watches the same confident-latent metric on
+    # both paths.
     blind: bool = False
     metric: int = 0  # best progress metric seen; see _decode_progress
     stable_since: float | None = None  # when the metric last stopped advancing
@@ -265,10 +280,11 @@ class Reception:
     mode_name: str | None
     callsign: str
     snr_db: float
-    # How much of the transmission arrived, and how much of it actually
-    # decoded. The first is the progress bar's numerator and climbs with
-    # the clock; the second is a fill, and the gap between them is what
-    # a fade costs. See _frames_in_buffer and _decode_progress.
+    # How far through its schedule the transmission got, and how much of
+    # it actually decoded. The first is the progress bar's numerator and
+    # climbs with the clock; the second is a fill, and the gap between
+    # them is what a fade -- or joining late -- costs. See
+    # _frames_elapsed and _decode_progress.
     frames_received: int | None
     frames_decoded: int | None
     n_frames_expected: int | None
@@ -278,6 +294,14 @@ class Reception:
     # there rather than adding a second picture** -- one transmission is
     # one file, one gallery entry, one notification.
     saved_path: str | None = None
+    # True on every delivery after the first, whether or not the sink
+    # chose to save. `saved_path` cannot carry this by itself: a sink
+    # that declined to save (a GUI with autosave off) returns no path,
+    # and a redelivery would then read as a brand-new reception -- two
+    # "reception complete" records for one transmission. `saved_path`
+    # says where to write; this says whether it is the same reception
+    # again.
+    redelivery: bool = False
 
 
 @dataclass
@@ -290,9 +314,9 @@ class SharedState:
     # open for the rest of its frames). See _Pending.
     status: str = "listening"
     mode_name: str | None = None
-    # frames_received is the frames that have arrived (what the bar
-    # shows); frames_decoded is how many of them carried confident data
-    # (shown beside it, never as it). See _frames_in_buffer.
+    # frames_received is how far the transmission has got (what the bar
+    # shows); frames_decoded is how many frames carried confident data
+    # (shown beside it, never as it). See _frames_elapsed.
     frames_received: int | None = None
     frames_decoded: int | None = None
     n_frames_expected: int | None = None
@@ -390,8 +414,10 @@ def _deliver(pending: "_Pending", sink, state: "SharedState", finished_starts) -
     `finished_starts` -- from then on the preamble search steps over it,
     so a transmission that was cut off early cannot go on hiding a later
     one for the rest of its own scheduled duration. The reception stays
-    resumable anyway: the blind path checks the tracked reception before
-    that list (see decode_loop).
+    resumable anyway, on both paths: the blind path checks the tracked
+    reception before that list, and the header path aims one demodulate
+    at its own preamble when the search finds nothing new (see
+    decode_loop).
     """
     if pending.metric <= pending.delivered_metric or pending.image is None:
         return False
@@ -406,6 +432,7 @@ def _deliver(pending: "_Pending", sink, state: "SharedState", finished_starts) -
             frames_decoded=pending.frames_decoded,
             n_frames_expected=pending.n_frames_expected,
             saved_path=pending.saved_path,
+            redelivery=not first,
         )
     )
     pending.delivered_metric = pending.metric
@@ -570,6 +597,33 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
             modem, samples, to_baseband(samples), buf_start,
             finished_starts, epsilon_samples, drift_track=config.drift_track,
         )
+        # A delivered-but-still-open reception is in finished_starts, so
+        # the search above steps over its preamble -- correctly, for new
+        # receptions (a transmission cut off early must not hide a later
+        # one), and fatally for resuming *this* one over the header path:
+        # the blind branch has its own resume (the `ours` check below)
+        # but needs the beacon to decode, and "blind-locked with the
+        # beacon not decoding" is a real field condition. So when nothing
+        # new was found, aim one demodulate at the tracked reception's
+        # own preamble; if the signal came back, this decode is
+        # retrospective over the whole ring and picks up everything.
+        if r is None and pending is not None and _already_finished(
+            pending.start, finished_starts, epsilon_samples
+        ):
+            lo = max(0, int(pending.start - buf_start - epsilon_samples))
+            hi = min(
+                len(samples),
+                int(pending.start - buf_start + PREAMBLE_SAMPLES + epsilon_samples),
+            )
+            if hi - lo >= PREAMBLE_SAMPLES:
+                try:
+                    r = modem.demodulate(
+                        samples, search_s=(lo / FS, hi / FS),
+                        drift_track=config.drift_track,
+                    )
+                    reception_start = buf_start + r.preamble_start
+                except SyncError:
+                    pass
         full_ok = r is not None
 
         if full_ok:
@@ -578,15 +632,25 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
             mode_name = r.mode.name
             n_frames_expected = r.mode.n_frames
             # `received.sum()`: the frames whose samples are in the
-            # buffer, which is the bar's numerator (see
-            # _frames_in_buffer) and, unchanged, the header path's stall
-            # metric.
+            # buffer, which is the bar's numerator here (see
+            # _frames_elapsed -- on this path the two agree while
+            # capture is alive, since the preamble was heard).
             frames_received = r.frames_received
             callsign = r.callsign
             snr_db = r.snr_db
             progress_frac = frames_received / n_frames_expected
-            progress_metric = frames_received
-            _, frames_decoded = _decode_progress(weights_full)
+            # The stall/delivery metric is the confident-latent count on
+            # *both* paths -- one unit, because `pending.metric` and
+            # `delivered_metric` compare across polls and a reception can
+            # switch paths between them (a header reception that stalls
+            # and resumes blind, or the reverse). The header path used to
+            # feed frames_received here, and a frame count against a
+            # latent count let a ~14-frame blind resume outrank a
+            # 300-frame delivered picture. It also gates delivery on
+            # decoded content rather than buffer coverage, which is what
+            # keeps a spurious lock in noise from being *delivered* as a
+            # picture of noise at its stall or deadline.
+            progress_metric, frames_decoded = _decode_progress(weights_full)
         else:
             # Fold whatever's new since the last poll into the running
             # accumulator -- O(new samples), not O(window) -- which is
@@ -683,8 +747,8 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
                         n_frames_expected if n_frames_expected is not None
                         else MODES["C"].n_frames
                     )
-                    frames_received = _frames_in_buffer(
-                        reception_start, buf_start, total, n_display
+                    frames_received = _frames_elapsed(
+                        reception_start, total, n_display
                     )
                     progress_frac = frames_received / n_display
             else:
@@ -744,10 +808,18 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
                 n_frames_expected if n_frames_expected is not None
                 else MODES["C"].n_frames
             )
-            pending.deadline_abs = (
+            deadline_abs = (
                 pending.start + PREAMBLE_SAMPLES + HEADER_SAMPLES
                 + n_deadline_frames * FRAME_SAMPLES
             )
+            if deadline_abs != pending.deadline_abs:
+                pending.deadline_abs = deadline_abs
+                # Its wall-clock shadow, anchored here and only here --
+                # see _Pending.deadline_wall for why re-anchoring it
+                # every poll would defeat it.
+                pending.deadline_wall = (
+                    time.time() + (deadline_abs - total) / FS + config.end_grace
+                )
             pending.blind = not full_ok
             if progress_metric > pending.metric:
                 pending.metric = progress_metric
@@ -804,33 +876,24 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
         # of the poll entirely, is why a reception in that state could
         # never satisfy any completion test however long it sat.
         #
-        # Or its decoded progress stopped advancing. This used to be
+        # Or its decoded progress stopped advancing. The metric is the
+        # confident-latent count on both paths (see _decode_progress),
+        # so on the header path this fires on a fade -- delivering
+        # promptly, exactly as the blind path does -- and on a capture
+        # that died mid-reception, where the same audio decodes to the
+        # same latents forever, the count never reaches anything, and
+        # `total` has stopped so the buffer deadline is unreachable (the
+        # wall-clock shadow is what retires it). This used to be
         # blind-only, on the grounds that a spurious preamble-shaped
         # lock in noise goes on decoding the same handful of frames for
         # as long as it is looked at, and that ending *that* on a stall
-        # turns a false lock into an autosaved picture of noise. Neither
-        # half of that argument survives what the two numbers actually
-        # measure.
-        #
-        # The header path's frames_received is `received.sum()`, and
-        # `received[f]` is true for every frame whose samples are in the
-        # buffer -- signal or noise, faded or clean (modem.demodulate).
-        # It is buffer coverage, not signal. So it climbs right through
-        # a fade, it climbs through the noise that follows a transmitter
-        # cutting off early (which is why *that* case ends on `complete`
-        # at the transmission's scheduled end rather than needing a
-        # stall at all), and a false lock in noise climbs with it. The
-        # one thing that stops it is the buffer not growing -- capture
-        # unplugged, the stream dead, the host no longer delivering
-        # callbacks -- and there the header path had no test that could
-        # ever fire: it goes on decoding, so `not decoded` is false; it
-        # never reaches its frame count; and `total` has stopped, so the
-        # deadline below is unreachable by construction. It sat in
-        # "receiving" forever, which is the hang this whole record
-        # exists to close, still open on one path.
-        #
-        # And a stall no longer ends a reception -- it delivers one and
-        # keeps it -- so the distinction has nothing left to protect.
+        # turns a false lock into an autosaved picture of noise. What
+        # protects against that is not the stall's reach but the
+        # delivery gate: a stall (or a deadline) delivers nothing unless
+        # confident latents were decoded, and a false lock in noise has
+        # essentially none -- where the buffer-coverage count the header
+        # path used to feed this clock climbed for noise exactly as for
+        # signal, and would have *delivered* the noise at the deadline.
         no_progress = not decoded or not advanced
         if no_progress:
             if pending.stable_since is None:
@@ -858,9 +921,19 @@ def decode_loop(ring: RingBuffer, model, state: SharedState, config: RxConfig,
         )
         # Retirement is the transmitter's own clock, not ours: its frame
         # count is in, or the buffer holds audio past the point where
-        # its last frame could still be arriving. Nothing else drops the
-        # record -- see _Pending.
-        retire = complete or total >= pending.deadline_abs
+        # its last frame could still be arriving. The wall-clock shadow
+        # is for the one case where the buffer's clock has stopped --
+        # capture died mid-reception, so `total` froze below the
+        # deadline and would hold the record (and `--once`) in "waiting"
+        # forever. While capture is alive the buffer deadline fires
+        # first by construction (the shadow trails it by end_grace).
+        # Nothing else drops the record -- see _Pending.
+        retire = (
+            complete
+            or total >= pending.deadline_abs
+            or (pending.deadline_wall is not None
+                and time.time() >= pending.deadline_wall)
+        )
 
         if not retire:
             if stalled:
@@ -1073,6 +1146,7 @@ def decode_loop_low_cpu(ring: RingBuffer, model, state: SharedState, config: RxC
             state.status = "listening"
             state.mode_name = None
             state.frames_received = None
+            state.frames_decoded = None
             state.n_frames_expected = None
             state.progress_frac = 0.0
             state.callsign = ""

--- a/sstvae_listen.py
+++ b/sstvae_listen.py
@@ -58,6 +58,7 @@ def _status_line(state: SharedState) -> str:
         status = state.status
         mode_name = state.mode_name
         frames_received = state.frames_received
+        frames_decoded = state.frames_decoded
         n_frames_expected = state.n_frames_expected
         progress_frac = state.progress_frac
         callsign = state.callsign
@@ -87,10 +88,30 @@ def _status_line(state: SharedState) -> str:
             )
         else:
             line = f"receiving (blind sync): {100 * progress_frac:.0f}%"
+        # The frames pair says how much of the transmission has arrived;
+        # this says how much of it actually decoded. They come apart in
+        # a fade, and the difference is the only visible warning that a
+        # picture is filling in with erasures.
+        if frames_decoded is not None and n_frames_expected:
+            line += f"  decoded {100 * frames_decoded / n_frames_expected:.0f}%"
         line += fmt_snr(snr_db)
         if callsign:
             line += f"  de {callsign}"
         return line
+    if status == "waiting":
+        # Saved already, and still open: the picture is on disk, and if
+        # the signal comes back before the transmission's scheduled end
+        # the rest of it goes into that same file. Nothing may have been
+        # saved at all -- a reception with no confidently-received latent
+        # is not a picture, and is still shown as waiting rather than as
+        # listening, because the slot is still held.
+        line = "lost sync"
+        if saved_path:
+            line += f" -- saved {saved_path}"
+        line += ", waiting for the rest"
+        if mode_name is not None:
+            line += f" of mode {mode_name}"
+        return line + fmt_snr(snr_db)
     return f"done -- saved {saved_path}" + fmt_snr(snr_db)
 
 

--- a/tests/test_rx_progress.py
+++ b/tests/test_rx_progress.py
@@ -1,12 +1,15 @@
-"""The two reception numbers: what arrived, and what decoded.
+"""The two reception numbers: how far the transmission got, and what
+decoded.
 
-The progress bar is `frames whose audio has arrived / frames expected`
-(`_frames_in_buffer`) -- pure arithmetic on buffer positions, so it
-climbs with the clock whatever the decoder manages. Beside it, and never
-as it, is `frames_decoded`: how many of those frames carried confident
-data. That one is a *fill*, and a fill reads as a completion percentage
-without being one, because the erasures the blind path lives with (a
-fade, or simply not having heard the start) hold it down permanently.
+The progress bar is `frames elapsed since the transmission's first
+frame / frames expected` (`_frames_elapsed`) -- pure arithmetic on
+buffer positions, so it climbs with the clock whatever the decoder
+manages, starts part-way up on a late join, and can always reach 100%.
+Beside it, and never as it, is `frames_decoded`: how many frames
+carried confident data. That one is a *fill*, and a fill reads as a
+completion percentage without being one, because the erasures the blind
+path lives with (a fade, or simply not having heard the start) hold it
+down permanently.
 
 The third number is the one nothing may be substituted for: the
 confident-latent *count* is what the --end-grace stall clock watches.
@@ -30,7 +33,7 @@ from sstvae.modem import framing
 from sstvae.rx.engine import (
     PROGRESS_WEIGHT_THRESHOLD,
     _decode_progress,
-    _frames_in_buffer,
+    _frames_elapsed,
 )
 
 TOTAL_FRAMES = MODES["C"].n_frames
@@ -103,16 +106,16 @@ def test_the_stall_metric_is_the_latent_count_and_moves_on_backfill():
     assert decoded_backfilled > decoded_reached
 
 
-def test_the_bar_counts_frames_that_have_arrived():
+def test_the_bar_counts_frames_that_have_gone_by():
     n = MODES["A"].n_frames
     end = FRAMES_START + n * FRAME_SAMPLES
 
-    assert _frames_in_buffer(0, 0, 0, n) == 0
-    assert _frames_in_buffer(0, 0, FRAMES_START, n) == 0
-    assert _frames_in_buffer(0, 0, FRAMES_START + FRAME_SAMPLES, n) == 1
-    assert _frames_in_buffer(0, 0, end, n) == n
+    assert _frames_elapsed(0, 0, n) == 0
+    assert _frames_elapsed(0, FRAMES_START, n) == 0
+    assert _frames_elapsed(0, FRAMES_START + FRAME_SAMPLES, n) == 1
+    assert _frames_elapsed(0, end, n) == n
     # Audio past the transmission's end is not more of it.
-    assert _frames_in_buffer(0, 0, end + 100 * FRAME_SAMPLES, n) == n
+    assert _frames_elapsed(0, end + 100 * FRAME_SAMPLES, n) == n
 
 
 def test_the_bar_climbs_with_the_clock_and_nothing_else():
@@ -120,22 +123,27 @@ def test_the_bar_climbs_with_the_clock_and_nothing_else():
     # a fade cannot hold it back the way it holds back frames_decoded.
     n = MODES["A"].n_frames
     got = [
-        _frames_in_buffer(0, 0, FRAMES_START + k * FRAME_SAMPLES, n)
+        _frames_elapsed(0, FRAMES_START + k * FRAME_SAMPLES, n)
         for k in [*range(0, n, 7), n]
     ]
     assert got == sorted(got)
     assert got[0] == 0 and got[-1] == n
 
 
-def test_a_late_join_starts_part_way_up_rather_than_at_zero():
+def test_a_late_join_starts_part_way_up_and_still_reaches_the_top():
     # Tuned in at frame 400 of mode C: those frames' audio is gone for
-    # good, so the bar starts at 400/660 and fills from there. Counting
-    # from zero would promise a picture that cannot arrive.
+    # good, so the bar starts at 400/660 -- the transmission is 400
+    # frames into its schedule the moment we join -- and fills to
+    # 660/660 as the rest arrives. The frames the join missed appear as
+    # the gap against frames_decoded, exactly like a fade's. Counting
+    # only captured audio instead starts the bar at zero and caps it at
+    # 260/660 forever, on the display whose job is to say how far along
+    # the transmission is.
     n = TOTAL_FRAMES
-    buf_start = FRAMES_START + 400 * FRAME_SAMPLES
-    assert _frames_in_buffer(0, buf_start, buf_start, n) == 0
+    joined = FRAMES_START + 400 * FRAME_SAMPLES
+    assert _frames_elapsed(0, joined, n) == 400
     end = FRAMES_START + n * FRAME_SAMPLES
-    assert _frames_in_buffer(0, buf_start, end, n) == n - 400
+    assert _frames_elapsed(0, end, n) == n
 
 
 def test_a_transmission_that_starts_after_the_buffer_does():
@@ -144,4 +152,20 @@ def test_a_transmission_that_starts_after_the_buffer_does():
     n = MODES["A"].n_frames
     start = 5 * FRAME_SAMPLES
     total = start + FRAMES_START + n * FRAME_SAMPLES
-    assert _frames_in_buffer(start, 0, total, n) == n
+    assert _frames_elapsed(start, total, n) == n
+    # And before that transmission's first frame, nothing of it yet.
+    assert _frames_elapsed(start, start + FRAMES_START, n) == 0
+
+
+def test_dropped_latent_slots_never_count_as_a_decoded_frame():
+    # frame_of_latent() is -1 for the never-transmitted dropped slots,
+    # and numpy indexing would wrap -1 to the *last* frame -- a phantom
+    # "frame 659 decoded" from a latent that never went on the air. The
+    # C++ guards f >= 0; this pins the Python mirror to it. The metric
+    # still counts every confident latent, matching the C++ exactly.
+    table = framing.frame_of_latent()
+    w = np.zeros(MODES["C"].n_latents)
+    w[table < 0] = 0.9
+    metric, decoded = _decode_progress(w)
+    assert decoded == 0
+    assert metric == np.count_nonzero(table < 0)

--- a/tests/test_rx_progress.py
+++ b/tests/test_rx_progress.py
@@ -1,25 +1,41 @@
-"""The reception progress bar: position, not fill.
+"""The two reception numbers: what arrived, and what decoded.
 
-The bar is `last frame successfully received / frames expected`, never
-`latents received / latents expected`. The blind path is the one where
-the two differ -- it decodes whatever frames it can place, with holes
-where the signal faded or where the transmission started before the
-buffer did -- and a fill fraction there is a completion percentage that
-is not one: a reception already at the transmission's last frame reports
-70% and never fills.
+The progress bar is `frames whose audio has arrived / frames expected`
+(`_frames_in_buffer`) -- pure arithmetic on buffer positions, so it
+climbs with the clock whatever the decoder manages. Beside it, and never
+as it, is `frames_decoded`: how many of those frames carried confident
+data. That one is a *fill*, and a fill reads as a completion percentage
+without being one, because the erasures the blind path lives with (a
+fade, or simply not having heard the start) hold it down permanently.
+
+The third number is the one nothing may be substituted for: the
+confident-latent *count* is what the --end-grace stall clock watches.
+It is neither of the two above on purpose -- a position does not move
+when retrospective decoding fills in frames behind it, and anything
+positional climbs on buffer growth alone, so a reception fed either one
+would either never stall or never stop stalling.
 """
 
 import numpy as np
 
 from sstvae.config import (
     DROPPED_LATENTS_PER_GROUP,
+    FRAME_SAMPLES,
+    HEADER_SAMPLES,
     LATENT_GROUPS,
     MODES,
+    PREAMBLE_SAMPLES,
 )
 from sstvae.modem import framing
-from sstvae.rx.engine import PROGRESS_WEIGHT_THRESHOLD, _blind_progress
+from sstvae.rx.engine import (
+    PROGRESS_WEIGHT_THRESHOLD,
+    _decode_progress,
+    _frames_in_buffer,
+)
 
 TOTAL_FRAMES = MODES["C"].n_frames
+# Where a transmission starting at absolute 0 puts its first frame.
+FRAMES_START = PREAMBLE_SAMPLES + HEADER_SAMPLES
 
 
 def _weights_for_frames(frames, weight=1.0):
@@ -48,61 +64,84 @@ def test_frame_of_latent_marks_exactly_the_dropped_latents():
     assert np.count_nonzero(table < 0) == LATENT_GROUPS * DROPPED_LATENTS_PER_GROUP
 
 
-def test_no_confident_latents_is_zero_progress():
-    assert _blind_progress(np.zeros(MODES["C"].n_latents), TOTAL_FRAMES) == (0, 0.0, 0)
+def test_no_confident_latents_is_nothing_decoded():
+    assert _decode_progress(np.zeros(MODES["C"].n_latents)) == (0, 0)
 
 
 def test_weights_at_the_threshold_do_not_count():
     w = _weights_for_frames([0], weight=PROGRESS_WEIGHT_THRESHOLD)
-    assert _blind_progress(w, TOTAL_FRAMES) == (0, 0.0, 0)
+    assert _decode_progress(w) == (0, 0)
 
 
-def test_progress_is_the_last_frame_reached_not_the_count():
-    # Every other frame of mode B's range: half the latents, but the
-    # transmission has been followed all the way to its end. The old
-    # count-based fraction reported ~50% here.
-    reach = MODES["B"].n_frames
-    w = _weights_for_frames([*range(0, reach, 2), reach - 1])
-    metric, frac, got_reach = _blind_progress(w, TOTAL_FRAMES)
-    assert frac == reach / TOTAL_FRAMES
-    # The reach is the fraction's numerator, reported as the blind
-    # path's frames_received so the status line's frame counter and its
-    # percentage advance together instead of one freezing.
-    assert got_reach == reach
-    # The stall metric is still the count -- a different question, and
-    # the one --end-grace watches.
+def test_frames_decoded_counts_frames_not_latents():
+    # Every other frame of mode B's range: half the frames, and a frame
+    # counts once whatever it carries. The interleaver is why the two
+    # answers differ at all -- each frame's latents are scattered across
+    # the whole picture.
+    frames = list(range(0, MODES["B"].n_frames, 2))
+    w = _weights_for_frames(frames)
+    metric, decoded = _decode_progress(w)
+    assert decoded == len(frames)
     assert metric == np.count_nonzero(w > PROGRESS_WEIGHT_THRESHOLD)
+    assert metric > decoded  # latents per frame, not the same question
 
 
-def test_a_known_mode_makes_the_bar_fill_at_that_modes_end():
-    # The beacon's mode field (PROTOCOL_VERSION 4) gives the blind path
-    # the real frame count: a complete mode B reception reads 100%, not
-    # the 2/3 that dividing by mode C's count reported before the field
-    # existed.
-    reach = MODES["B"].n_frames
-    w = _weights_for_frames([*range(0, reach, 2), reach - 1])
-    _, frac, _ = _blind_progress(w, reach)
-    assert frac == 1.0
-
-
-def test_a_late_join_reports_where_it_is_not_how_much_it_has():
-    # Tuned in at frame 400 of mode C and heard the rest: two thirds of
-    # the latents are gone for good, and the bar must still read 100%.
-    w = _weights_for_frames(range(400, TOTAL_FRAMES))
-    _, frac, _ = _blind_progress(w, TOTAL_FRAMES)
-    assert frac == 1.0
-
-
-def test_progress_advances_with_reach_and_ignores_backfill():
+def test_the_stall_metric_is_the_latent_count_and_moves_on_backfill():
+    # The two properties that make the count the only usable stall
+    # signal, and that the display numbers do not have.
     reached = _weights_for_frames([0, 300])
-    _, frac_reached, reach_reached = _blind_progress(reached, TOTAL_FRAMES)
-    assert frac_reached == 301 / TOTAL_FRAMES
-    assert reach_reached == 301
-
-    # Retrospective decoding filling in frames *behind* the furthest one
-    # is real progress in quality but not in position, and the bar must
-    # not jump backwards or forwards for it.
     backfilled = _weights_for_frames(range(0, 301))
-    _, frac_backfilled, reach_backfilled = _blind_progress(backfilled, TOTAL_FRAMES)
-    assert frac_backfilled == frac_reached
-    assert reach_backfilled == reach_reached
+
+    metric_reached, decoded_reached = _decode_progress(reached)
+    metric_backfilled, decoded_backfilled = _decode_progress(backfilled)
+
+    assert metric_reached == np.count_nonzero(reached > PROGRESS_WEIGHT_THRESHOLD)
+    # Retrospective decoding filling in frames *behind* the furthest one
+    # is real progress, and the stall clock has to see it as progress or
+    # it ends a reception that is still improving.
+    assert metric_backfilled > metric_reached
+    assert decoded_backfilled > decoded_reached
+
+
+def test_the_bar_counts_frames_that_have_arrived():
+    n = MODES["A"].n_frames
+    end = FRAMES_START + n * FRAME_SAMPLES
+
+    assert _frames_in_buffer(0, 0, 0, n) == 0
+    assert _frames_in_buffer(0, 0, FRAMES_START, n) == 0
+    assert _frames_in_buffer(0, 0, FRAMES_START + FRAME_SAMPLES, n) == 1
+    assert _frames_in_buffer(0, 0, end, n) == n
+    # Audio past the transmission's end is not more of it.
+    assert _frames_in_buffer(0, 0, end + 100 * FRAME_SAMPLES, n) == n
+
+
+def test_the_bar_climbs_with_the_clock_and_nothing_else():
+    # The property the whole change is for: no weights are involved, so
+    # a fade cannot hold it back the way it holds back frames_decoded.
+    n = MODES["A"].n_frames
+    got = [
+        _frames_in_buffer(0, 0, FRAMES_START + k * FRAME_SAMPLES, n)
+        for k in [*range(0, n, 7), n]
+    ]
+    assert got == sorted(got)
+    assert got[0] == 0 and got[-1] == n
+
+
+def test_a_late_join_starts_part_way_up_rather_than_at_zero():
+    # Tuned in at frame 400 of mode C: those frames' audio is gone for
+    # good, so the bar starts at 400/660 and fills from there. Counting
+    # from zero would promise a picture that cannot arrive.
+    n = TOTAL_FRAMES
+    buf_start = FRAMES_START + 400 * FRAME_SAMPLES
+    assert _frames_in_buffer(0, buf_start, buf_start, n) == 0
+    end = FRAMES_START + n * FRAME_SAMPLES
+    assert _frames_in_buffer(0, buf_start, end, n) == n - 400
+
+
+def test_a_transmission_that_starts_after_the_buffer_does():
+    # The ordinary case: the preamble arrived while we were listening,
+    # so `start` sits inside the buffer and nothing is missing.
+    n = MODES["A"].n_frames
+    start = 5 * FRAME_SAMPLES
+    total = start + FRAMES_START + n * FRAME_SAMPLES
+    assert _frames_in_buffer(start, 0, total, n) == n

--- a/tests/test_rx_watchdog.py
+++ b/tests/test_rx_watchdog.py
@@ -256,10 +256,9 @@ def test_a_header_reception_whose_buffer_stopped_growing_is_delivered(stub_modem
     left open on one path because the no-advance test used to be
     blind-only.
 
-    frames_received is `received.sum()`, which counts frames whose
-    samples are in the buffer rather than frames that carried signal, so
-    on the header path it stops advancing when and only when the buffer
-    does -- which is exactly this."""
+    The stall metric is the confident-latent count on both paths: a
+    frozen buffer decodes the same audio to the same latents forever, so
+    the metric never advances and the stall clock is what fires."""
     modem = stub_modem(_StubModem(good_polls=10**9, frames_received=3))
     sink = _CollectingSink()
     config = RxConfig(poll_interval=0.05, end_grace=0.5)
@@ -497,6 +496,14 @@ def test_a_faded_reception_resumes_and_replaces_its_picture(blind_only):
         "the improved picture was delivered as a new reception rather than as a "
         "replacement for the one already saved"
     )
+    # The engine-side flag, independent of whether the sink saved: a GUI
+    # with autosave off gets no path back and still must not read a
+    # redelivery as a second reception.
+    assert not first.redelivery
+    assert second.redelivery, (
+        "a second delivery of the same reception must say so itself -- "
+        "saved_path cannot, when the sink declined to save"
+    )
     # On frames_decoded, deliberately: frames_received is positional and
     # climbs with the buffer whether or not anything was decoded, so it
     # cannot tell a resumed reception from an abandoned one.
@@ -541,6 +548,178 @@ def test_a_new_reception_does_not_discard_an_undelivered_one(stub_modem):
         "deliver it"
     )
     assert sink.receptions[0].frames_received == 3
+
+
+def test_a_frozen_buffer_still_retires_on_the_wall_clock(stub_modem):
+    """Capture died mid-reception, close to the transmission's end. The
+    stall delivers the picture, but retirement's sample-position
+    deadline is measured against `total`, and `total` has frozen just
+    short of it: unreachable by construction, so the record -- and
+    --once, which only exits on retirement -- sat in "waiting" forever
+    with the picture already delivered. The wall-clock shadow of the
+    deadline is what retires it; while capture is alive it trails the
+    buffer deadline by end_grace and never fires.
+
+    The buffer stops half a second short of the scheduled end so this
+    test's own wait is bounded by about that plus end_grace -- what is
+    asserted is that the wait is finite, not how long it takes."""
+    stub_modem(_StubModem(good_polls=10**9, frames_received=3))
+    sink = _CollectingSink()
+    config = RxConfig(poll_interval=0.05, end_grace=0.4, once=True)
+
+    need_s = (
+        PREAMBLE_SAMPLES + HEADER_SAMPLES + MODE_A.n_frames * rx_engine.FRAME_SAMPLES
+    ) / FS
+    state = _run(
+        config, sink, seconds_of_audio=need_s - 0.5, timeout_s=20.0,
+        until=lambda state, sink: state.status == "done",
+    )
+
+    assert len(sink.receptions) == 1, (
+        "a reception whose buffer froze short of its deadline was never "
+        "retired: the sample-position deadline is unreachable by construction "
+        "there, and only the wall clock can end it"
+    )
+    assert state.status == "done", (
+        f"status {state.status!r}: still waiting on a buffer deadline that a "
+        "frozen buffer can never reach"
+    )
+
+
+def _mode_a_weights_for_frames(frames):
+    """Mode-A-sized weights with exactly `frames` confidently carried."""
+    from sstvae.modem import framing
+
+    w = np.zeros(MODES["C"].n_latents)
+    for f in frames:
+        _, idx = framing.slot_range_for_frame(f)
+        w[idx] = 0.9
+    # Mode A's frames live entirely in the first group, so slicing to the
+    # mode's latent count loses nothing -- assert it, since a silent
+    # truncation here would weaken every test built on this helper.
+    assert not w[MODE_A.n_latents:].any()
+    return w[:MODE_A.n_latents]
+
+
+def _demod_result_for_frames(frames):
+    n = MODE_A.n_latents
+    return DemodResult(
+        latents=np.zeros(n),
+        weights=_mode_a_weights_for_frames(frames),
+        mode=MODE_A,
+        freq_offset=0.0,
+        sync_metric=0.9,
+        frames_received=len(frames),
+        beacon=None,
+        callsign="TEST",
+        preamble_start=0,
+        snr_db=12.0,
+    )
+
+
+def test_a_header_reception_resumes_over_its_own_preamble(stub_modem):
+    """After a stall-delivery the reception's start is in
+    finished_starts, so the preamble search steps over it -- correctly
+    for *new* receptions, but the only other way back in used to be the
+    blind path, which needs the beacon to decode. With the beacon
+    unreadable (narrowband interference on its carrier, a
+    pre-PROTOCOL_VERSION-4 sender), a header reception that faded once
+    was refused for the rest of the transmission with its preamble
+    sitting decodable in the buffer. The engine now aims one demodulate
+    at the tracked reception's own preamble when the search finds
+    nothing new.
+
+    The stub refuses any search window that excludes its preamble at
+    position 0, which is what makes the carve-out visible to it: after
+    the delivery only the targeted resume ever offers a window the stub
+    accepts."""
+    half = _demod_result_for_frames(range(MODE_A.n_frames // 2))
+    full = _demod_result_for_frames(range(MODE_A.n_frames))
+
+    class _ResumingHeaderModem:
+        def __init__(self):
+            self.calls = 0
+
+        def demodulate(self, samples, search_s=None, drift_track="off"):
+            if search_s is not None and search_s[0] > 0:
+                raise SyncError("the preamble is not in this window")
+            self.calls += 1
+            if self.calls <= 2:
+                return half
+            if self.calls <= 12:
+                raise SyncError("faded out")
+            return full
+
+        def demodulate_blind(self, x, search_s=None, acquisition=None,
+                             drift_track="off"):
+            raise SyncError("the beacon never decodes")
+
+    modem = stub_modem(_ResumingHeaderModem())
+    sink = _CollectingSink()
+    config = RxConfig(poll_interval=0.05, end_grace=0.3)
+
+    _run(config, sink, timeout_s=20.0,
+         until=lambda state, sink: len(sink.receptions) >= 2)
+
+    assert modem.calls > 12, (
+        "the modem never got a decodable window again after the stall "
+        "delivery: the header path cannot resume its own reception"
+    )
+    assert len(sink.receptions) == 2, (
+        "a header reception that recovered from a fade, with the beacon "
+        "unreadable, never redelivered: only the blind path could resume it"
+    )
+    first, second = sink.receptions
+    assert first.frames_decoded == MODE_A.n_frames // 2
+    assert second.frames_decoded == MODE_A.n_frames
+    assert second.redelivery and second.saved_path == "/dev/null/fake.png"
+
+
+def test_an_inferior_blind_resume_does_not_replace_a_better_picture(
+        stub_modem, monkeypatch):
+    """The stall/delivery metric is one unit -- the confident-latent
+    count -- on both paths, because a reception can stall on the header
+    path and resume on the blind one. When the header path fed its
+    frame count in instead, a blind resume carrying ~two frames of
+    content outranked a delivered half-transmission (a frame count
+    against a latent count) and overwrote the saved file with the worse
+    decode."""
+    blind_scrap = _blind_result([0, 1])
+
+    class _HeaderThenScrapModem:
+        def __init__(self):
+            self.calls = 0
+            self.blind_calls = 0
+
+        def demodulate(self, samples, search_s=None, drift_track="off"):
+            self.calls += 1
+            if self.calls <= 2:
+                return _demod_result_for_frames(range(MODE_A.n_frames // 2))
+            raise SyncError("gone")
+
+        def demodulate_blind(self, x, search_s=None, acquisition=None,
+                             drift_track="off"):
+            self.blind_calls += 1
+            return blind_scrap
+
+    modem = stub_modem(_HeaderThenScrapModem())
+    monkeypatch.setattr(rx_engine, "BlindAccumulator", _FakeAccumulator)
+    sink = _CollectingSink()
+    config = RxConfig(poll_interval=0.05, end_grace=0.3)
+
+    _run(config, sink, timeout_s=2.5,
+         until=lambda state, sink: len(sink.receptions) >= 2)
+
+    assert modem.blind_calls > 5, (
+        "the blind path never resumed the reception -- not the case under test"
+    )
+    assert len(sink.receptions) == 1, (
+        "a two-frame blind decode was redelivered over a half-transmission "
+        "picture: the paths' metrics are being compared in different units"
+    )
+    assert sink.receptions[0].frames_decoded == MODE_A.n_frames // 2, (
+        "the delivered picture no longer carries the header path's decode"
+    )
 
 
 def test_nothing_is_delivered_when_nothing_ever_decoded(stub_modem):

--- a/tests/test_rx_watchdog.py
+++ b/tests/test_rx_watchdog.py
@@ -45,7 +45,7 @@ class _CollectingSink:
         return "/dev/null/fake.png"
 
 
-def _demod_result(frames_received: int) -> DemodResult:
+def _demod_result(frames_received: int, preamble_start: int = 0) -> DemodResult:
     """A partial mode-A decode: the preamble and header were heard, and
     `frames_received` of the mode's frames landed."""
     n = MODE_A.n_latents
@@ -58,7 +58,7 @@ def _demod_result(frames_received: int) -> DemodResult:
         frames_received=frames_received,
         beacon=None,
         callsign="TEST",
-        preamble_start=0,
+        preamble_start=preamble_start,
         snr_db=12.0,
     )
 
@@ -110,9 +110,16 @@ def stub_modem(monkeypatch):
     return install
 
 
-def _run(config, sink, seconds_of_audio=6.0, timeout_s=20.0, feed_more=None):
+def _run(config, sink, seconds_of_audio=6.0, timeout_s=20.0, feed_more=None,
+         until=None):
     """Run decode_loop against a ring buffer holding `seconds_of_audio`
-    of noise, until the sink sees a reception or `timeout_s` elapses.
+    of noise, until `until(state, sink)` holds -- by default, until the
+    sink sees a reception -- or `timeout_s` elapses.
+
+    `until` is a parameter because delivering and retiring are separate
+    events now: a stalled reception is handed to the sink and stays
+    tracked, so "the sink saw something" no longer means the loop is
+    finished with it.
 
     The audio's *content* is irrelevant here — the stub modem ignores it
     — but its length is not: the loop refuses to attempt a decode below
@@ -120,6 +127,10 @@ def _run(config, sink, seconds_of_audio=6.0, timeout_s=20.0, feed_more=None):
     sample-position deadline is measured against."""
     ring = rx_engine.RingBuffer(200.0)
     ring.write(np.zeros(int(seconds_of_audio * FS)))
+
+    if until is None:
+        def until(state, sink):
+            return bool(sink.receptions)
 
     state = SharedState()
     stop = threading.Event()
@@ -129,9 +140,9 @@ def _run(config, sink, seconds_of_audio=6.0, timeout_s=20.0, feed_more=None):
     th.start()
     try:
         if feed_more is not None:
-            feed_more(ring)
+            feed_more(ring, state)
         deadline = time.time() + timeout_s
-        while time.time() < deadline and not sink.receptions and th.is_alive():
+        while time.time() < deadline and not until(state, sink) and th.is_alive():
             time.sleep(0.02)
     finally:
         stop.set()
@@ -144,26 +155,52 @@ def test_a_reception_whose_decodes_stop_is_still_delivered(stub_modem):
     decodes stop. Nothing else can finish it: it never reports all its
     frames, and the buffer never reaches its sample-position deadline.
     Only the stall test can, and only if it is still evaluated on polls
-    that decoded nothing."""
+    that decoded nothing.
+
+    Losing sync delivers the reception but no longer retires it: it goes
+    dormant ("waiting"), still tracked, until the buffer reaches the
+    point where its last frame could have arrived. So this also pins the
+    two halves apart -- delivered promptly on the stall, retired on the
+    deadline, exactly one picture out of the pair."""
     modem = stub_modem(_StubModem(good_polls=2, frames_received=MODE_A.n_frames // 2))
     sink = _CollectingSink()
     config = RxConfig(poll_interval=0.05, end_grace=0.5)
 
-    state = _run(config, sink, timeout_s=20.0)
+    need = PREAMBLE_SAMPLES + HEADER_SAMPLES + MODE_A.n_frames * rx_engine.FRAME_SAMPLES
+
+    def feed_more(ring, state):
+        deadline = time.time() + 10.0
+        while time.time() < deadline and not sink.receptions:
+            time.sleep(0.02)
+        assert sink.receptions, (
+            "a reception whose decodes stopped was never handed to the sink: it is "
+            "still sitting in 'receiving' with its picture undelivered, which is "
+            "both the hang and the autosave-never-fires report"
+        )
+        assert state.status == "waiting", (
+            f"status {state.status!r} after losing sync: a delivered reception is "
+            "still open for the rest of its frames until its scheduled end"
+        )
+        ring.write(np.zeros(need))
+
+    state = _run(
+        config, sink, timeout_s=20.0, feed_more=feed_more,
+        until=lambda state, sink: state.status == "listening",
+    )
 
     assert modem.calls_after_stop > 0, (
         "the stub never got past its good polls — the test isn't exercising "
         "the failure at all"
     )
     assert len(sink.receptions) == 1, (
-        "a reception whose decodes stopped was never handed to the sink: it is "
-        "still sitting in 'receiving' with its picture undelivered, which is "
-        "both the hang and the autosave-never-fires report"
+        "delivered twice: a dormant reception that never improved has nothing "
+        "new for the sink when its deadline retires it"
     )
     rec = sink.receptions[0]
     assert rec.frames_received == MODE_A.n_frames // 2
     assert rec.mode_name == "A"
     assert rec.callsign == "TEST"
+    assert rec.saved_path is None, "the first delivery of a reception replaces nothing"
     assert state.status == "listening", (
         f"status stuck at {state.status!r} after the reception ended"
     )
@@ -189,7 +226,7 @@ def test_the_preamble_path_has_a_deadline_too(stub_modem):
     # feed past it, so a delivery can only be the deadline firing.
     need = PREAMBLE_SAMPLES + HEADER_SAMPLES + MODE_A.n_frames * rx_engine.FRAME_SAMPLES
 
-    def feed_more(ring):
+    def feed_more(ring, state):
         time.sleep(0.5)
         assert not sink.receptions, (
             "finished before its deadline could be reached — end_grace=1e9 was "
@@ -204,6 +241,46 @@ def test_the_preamble_path_has_a_deadline_too(stub_modem):
         "duration there is provably no more of it left to arrive"
     )
     assert sink.receptions[0].frames_received == 3
+
+
+def test_a_header_reception_whose_buffer_stopped_growing_is_delivered(stub_modem):
+    """Capture died mid-reception, and the header path had no test that
+    could fire.
+
+    It goes on decoding the same partial result from the audio already
+    in the buffer, so "it stopped decoding" is false; it never reaches
+    its frame count; and the sample-position deadline is measured
+    against a `total` that has stopped, so it is unreachable by
+    construction. The reception sat in "receiving" indefinitely with its
+    picture undelivered -- the same hang this record exists to close,
+    left open on one path because the no-advance test used to be
+    blind-only.
+
+    frames_received is `received.sum()`, which counts frames whose
+    samples are in the buffer rather than frames that carried signal, so
+    on the header path it stops advancing when and only when the buffer
+    does -- which is exactly this."""
+    modem = stub_modem(_StubModem(good_polls=10**9, frames_received=3))
+    sink = _CollectingSink()
+    config = RxConfig(poll_interval=0.05, end_grace=0.5)
+
+    # Nothing is ever fed: the buffer holds its 6 s and stops, well
+    # short of mode A's own duration, so the deadline cannot fire.
+    state = _run(config, sink, timeout_s=20.0)
+
+    assert modem.calls > 4, (
+        "the stub never decoded repeatedly -- not the case under test"
+    )
+    assert len(sink.receptions) == 1, (
+        "a header-path reception whose audio stopped arriving was never "
+        "delivered: it decodes the same frames forever, so only progress "
+        "having stopped can end it"
+    )
+    assert sink.receptions[0].frames_received == 3
+    assert state.status == "waiting", (
+        f"status {state.status!r}: the reception is delivered but still open "
+        "until its scheduled end"
+    )
 
 
 def test_a_complete_reception_still_finishes_on_its_frame_count(stub_modem):
@@ -221,16 +298,21 @@ def test_a_complete_reception_still_finishes_on_its_frame_count(stub_modem):
     assert sink.receptions[0].frames_received == MODE_A.n_frames
 
 
-def test_blind_reach_at_the_last_frame_does_not_complete_the_reception(stub_modem, monkeypatch):
-    """The blind path's frames_received is a *reach* (the furthest frame
-    decoded), reported so the status line's frame counter advances in
-    step with its percentage -- not a contiguous count. A reach at the
-    transmission's last frame is exactly when retrospective backfill is
-    still filling erasures behind it, so the header path's
-    "frames_received >= n_frames_expected ends it now" test must not
-    apply: the reception here reaches mode A's last frame on its very
-    first decode and must still be ended by the stall clock (end_grace),
-    not on the spot."""
+def test_the_bar_counts_frames_that_arrived_not_frames_that_decoded(stub_modem, monkeypatch):
+    """The two numbers the UI shows, and why they are two.
+
+    `frames_received` is what the progress bar fills with: the frames of
+    the transmission whose audio has arrived, which climbs with the
+    clock whatever the decoder manages. `frames_decoded` is how many of
+    them carried confident data -- a *fill*, held down permanently by
+    the erasures this path lives with, which is exactly why it is shown
+    beside the bar and never as it.
+
+    Here they are pulled as far apart as a stub can pull them: every one
+    of mode A's frames decoded, against a buffer holding only the first
+    few seconds of it. And neither ends the reception -- the blind path
+    has no contiguous count to finish on, so the stall clock (end_grace)
+    is what delivers it."""
     from sstvae.modem import framing
     from sstvae.modem.beacon import BeaconResult
     from sstvae.modem.modem import BlindDemodResult
@@ -287,12 +369,178 @@ def test_blind_reach_at_the_last_frame_does_not_complete_the_reception(stub_mode
     assert len(sink.receptions) == 1, "the stall clock should still end it"
     rec = sink.receptions[0]
     assert rec.mode_name == "A"
-    assert rec.frames_received == MODE_A.n_frames  # the reach, on display
+    assert rec.frames_decoded == MODE_A.n_frames, "every frame carried data"
     assert rec.n_frames_expected == MODE_A.n_frames
+    assert 0 < rec.frames_received < MODE_A.n_frames, (
+        f"frames_received is {rec.frames_received}: the bar must count the "
+        "frames whose audio has arrived, and only a few seconds of this "
+        "transmission is in the buffer"
+    )
     assert elapsed >= config.end_grace, (
         f"delivered after {elapsed:.2f}s < end_grace={config.end_grace}s: the "
-        "reception was completed on its reach, cutting off retrospective backfill"
+        "reception was completed on a decoded count, cutting off retrospective "
+        "backfill"
     )
+
+
+def _blind_result(frames_present, mode=MODE_A):
+    """A blind decode holding every latent of the frames in
+    `frames_present` and nothing else -- so its progress metric is the
+    number of latents those frames carry."""
+    from sstvae.modem import framing
+    from sstvae.modem.beacon import BeaconResult
+    from sstvae.modem.modem import BlindDemodResult
+
+    weights = np.zeros(MODES["C"].n_latents)
+    for f in frames_present:
+        _, idx = framing.slot_range_for_frame(f)
+        weights[idx] = 0.9
+    return BlindDemodResult(
+        latents=np.zeros(MODES["C"].n_latents), weights=weights, freq_offset=0.0,
+        beacon=BeaconResult(chip_offset=0, frame_index=0, callsign="TEST",
+                            mode_index=mode.index),
+        callsign="TEST", frame_offset=0, n_frames=mode.n_frames,
+        frame0_start=PREAMBLE_SAMPLES + HEADER_SAMPLES, snr_db=10.0,
+    )
+
+
+class _FakeAccumulator:
+    """Stands in for BlindAccumulator: the loop only pushes into it,
+    reports its score, and forwards whatever `result` returns."""
+
+    def __init__(self, *a, **kw):
+        pass
+
+    def push(self, z, start_sample):
+        pass
+
+    def best_score(self):
+        return 12.0
+
+    def result(self, origin=0):
+        return object()
+
+
+@pytest.fixture
+def blind_only(stub_modem, monkeypatch):
+    """Install a modem whose blind decodes come from `results`, one per
+    poll (the last repeating), where None means "no lock this poll".
+    The preamble path is made to fail outright, so the blind path is the
+    only thing driving the loop."""
+
+    def install(results):
+        class _BlindOnlyModem:
+            def __init__(self):
+                self.polls = 0
+
+            def demodulate(self, samples, search_s=None, drift_track="off"):
+                raise SyncError("no preamble")
+
+            def demodulate_blind(self, x, search_s=None, acquisition=None,
+                                 drift_track="off"):
+                r = results[min(self.polls, len(results) - 1)]
+                self.polls += 1
+                if r is None:
+                    raise SyncError("lock decayed")
+                return r
+
+        modem = stub_modem(_BlindOnlyModem())
+        monkeypatch.setattr(
+            rx_engine, "sync_acquire",
+            lambda z, **kw: (_ for _ in ()).throw(SyncError("no preamble")),
+        )
+        monkeypatch.setattr(rx_engine, "BlindAccumulator", _FakeAccumulator)
+        return modem
+
+    return install
+
+
+def test_a_faded_reception_resumes_and_replaces_its_picture(blind_only):
+    """The reason the stall no longer ends a reception.
+
+    A fade longer than end_grace is indistinguishable from a transmitter
+    that stopped, so the picture is delivered at once -- but the
+    reception stays tracked until its scheduled end, and a lock
+    recovered before then must be routed back into it. The old loop
+    recorded the start as finished at that first delivery and
+    `_already_finished` then dropped every re-acquisition, so the rest
+    of a picture still being heard was refused for as long as the
+    transmission lasted.
+
+    The second delivery replaces the first: one transmission, one
+    picture, not two files with the better one arriving second."""
+    half = list(range(MODE_A.n_frames // 2))
+    whole = list(range(MODE_A.n_frames))
+    # Decode half of it, lose the lock for longer than end_grace, come
+    # back with all of it.
+    modem = blind_only([_blind_result(half)] * 2 + [None] * 30 + [_blind_result(whole)])
+    sink = _CollectingSink()
+    config = RxConfig(poll_interval=0.05, end_grace=0.5)
+
+    seen = []
+
+    def watch(state, sink):
+        seen.append(state.status)
+        return len(sink.receptions) >= 2
+
+    state = _run(config, sink, timeout_s=20.0, until=watch)
+
+    assert modem.polls > 32, "the fade never ended -- the test isn't exercising resume"
+    assert len(sink.receptions) == 2, (
+        "a reception delivered when it lost sync never took the rest of its "
+        "frames: re-acquiring it before its scheduled end must contribute to "
+        "the picture, not be dropped as already handled"
+    )
+    first, second = sink.receptions
+    assert first.saved_path is None
+    assert second.saved_path == "/dev/null/fake.png", (
+        "the improved picture was delivered as a new reception rather than as a "
+        "replacement for the one already saved"
+    )
+    # On frames_decoded, deliberately: frames_received is positional and
+    # climbs with the buffer whether or not anything was decoded, so it
+    # cannot tell a resumed reception from an abandoned one.
+    assert second.frames_decoded > first.frames_decoded
+    assert second.frames_decoded == MODE_A.n_frames
+    assert "waiting" in seen, "losing sync must be visible as its own state"
+
+
+def test_a_new_reception_does_not_discard_an_undelivered_one(stub_modem):
+    """Taking over the tracked slot delivers what is being replaced.
+
+    Dropping it was survivable while a stall retired receptions within
+    end_grace; now that one is kept until its scheduled end, a second
+    transmission arriving over the top of it is routine, and the picture
+    already decoded would go out with the record.
+
+    end_grace and the deadline are both out of reach here, so the only
+    thing that can deliver the first reception is the takeover."""
+    class _TwoTransmissions:
+        def __init__(self):
+            self.polls = 0
+
+        def demodulate(self, samples, search_s=None, drift_track="off"):
+            self.polls += 1
+            if self.polls <= 2:
+                return _demod_result(3)
+            return _demod_result(7, preamble_start=int(5 * FS))
+
+        def demodulate_blind(self, x, search_s=None, acquisition=None,
+                             drift_track="off"):
+            raise SyncError("no blind lock")
+
+    stub_modem(_TwoTransmissions())
+    sink = _CollectingSink()
+    config = RxConfig(poll_interval=0.05, end_grace=1e9)
+
+    _run(config, sink, timeout_s=20.0)
+
+    assert sink.receptions, (
+        "the first reception was discarded when the second took over the "
+        "tracked slot: its picture had already decoded and nothing else can "
+        "deliver it"
+    )
+    assert sink.receptions[0].frames_received == 3
 
 
 def test_nothing_is_delivered_when_nothing_ever_decoded(stub_modem):


### PR DESCRIPTION
Beacon v4 made a reception's deadline exact on the blind path too, which
retired the stall detector's original job and left it with a misfire: a
fade longer than `--end-grace` is indistinguishable from a transmitter
that stopped, so the reception was ended *and* recorded as finished, and
the blind path's re-acquisition seconds later was dropped by
`_already_finished`. For the rest of the transmission the receiver
refused to decode a picture it was still hearing.

## What changed

**Delivering and retiring are now separate events.** A stall hands the
picture to the sink at once — autosave is not delayed — and leaves the
reception *dormant*, still tracked, until its frame count is in, its
deadline passes, or another reception takes the slot. The blind path
checks the tracked reception *before* the finished list, which is the
whole resume mechanism; a dormant reception stays carved out of the
preamble search, so a transmission cut off early cannot go on hiding a
later one. This is nearly free because the record is not an accumulator:
every decode is retrospective over the whole ring, and the ring outlives
the longest mode, so one re-decode after a fade recovers everything.

Along with it:

- `Reception.saved_path` means "already delivered here, **replace** it" —
  one transmission stays one file, one gallery row, one notification.
- Taking over the tracked slot now **delivers what it replaces** rather
  than discarding it (a pre-existing picture-loss bug, survivable only
  while stalls retired receptions quickly).
- New `waiting` state: "lost sync — waiting for the rest".
- The stall is **no longer blind-only**. The old reasoning was about the
  wrong number — the header path's `frames_received` is `received.sum()`,
  true for every frame whose *samples* are in the buffer, so it climbs
  through a fade and through post-cutoff noise and stops only when the
  buffer stops. That closes the last indefinite "receiving": capture dies,
  the header path keeps decoding, never completes, and `total` has stopped
  so the deadline is unreachable by construction.

**The progress bar is now what arrived, not what decoded.**
`frames_received` is `_frames_in_buffer` on both paths (arithmetic on
buffer positions, so it climbs with the clock) and `frames_decoded` is the
fill shown beside it. The blind path's *reach* is retired: it froze for
the whole of a fade, on the display whose job is to say whether anything
is still happening. A late join now starts the bar part-way up instead of
at zero.

The stall clock's input is untouched and documented as untouchable:
anything positional does not move when retrospective decoding fills in
frames *behind* the furthest one, and any count over the whole legal frame
range climbs on buffer growth alone.

## Commits

Split by layer rather than by feature — the two behaviours are interleaved
line-by-line in the same files, and each commit here builds and passes on
its own:

1. `rx:` the engines and their tests (Python + C++ mirror)
2. `rx UI:` the CLI, desktop and Android surfaces
3. `CLAUDE.md:` the two paragraphs that were wrong rather than stale

## Verification

`pytest` 408 passed · `pytest -m slow` 18 passed · ctest 31/31 ·
`pytest --native` 407 passed · `check_layering.py` / `check_includes.py` ok.

Five mutation checks each fail the test they should: blind resume (Python
and C++), preemption flush (Python and C++), and the extended stall. Two
existing tests would have silently rotted — the fade tests asserted
`frames_received`, which now climbs from buffer growth alone — and were
re-aimed at `frames_decoded` and re-verified against the mutant.

Not compiled here: `native/android-app/listener.cpp` needs Android-only Qt
headers (`QJniEnvironment`). The other Android files pass `-fsyntax-only`
against the desktop Qt/JDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoAMfCQ69nYpwdbuAsU3mg
