### PR TITLE
Fix polling resumption after PTT release (issue #40)

### DIFF
--- a/native/core/rig/controller.cpp
+++ b/native/core/rig/controller.cpp
@@ -126,10 +126,21 @@ void run(std::shared_ptr<RigSession> s) {
             std::unique_lock<std::mutex> lock(s->m);
             // Wake for: a stop, a keying request, or the poll deadline.
             // Paused means transmit is in progress, so there is no poll
-            // deadline at all -- only a job or a stop can wake us.
+            // deadline at all -- only a job, a stop, or resume_polling()
+            // clearing `paused` should wake us there. That last one is
+            // its own predicate rather than folded into the general
+            // `wake` below: sharing one predicate between both branches
+            // would make `!s->paused` true from the first instant of the
+            // *unpaused* wait too, firing wait_until immediately on every
+            // poll instead of at next_poll. As written, only the paused
+            // wait watches `paused` -- and it has to, because resume_polling()
+            // only clears the flag and notifies; a predicate that did not
+            // check it would sleep straight through that notify and leave
+            // polling dead until the next over keys the rig, which is what
+            // issue #40 saw as "the frequency stops updating".
             const auto wake = [&] { return s->stopping || s->ptt != nullptr; };
             if (s->paused) {
-                s->cv.wait(lock, wake);
+                s->cv.wait(lock, [&] { return wake() || !s->paused; });
             } else {
                 s->cv.wait_until(lock, next_poll, wake);
             }

--- a/native/tests/test_rig.cpp
+++ b/native/tests/test_rig.cpp
@@ -187,6 +187,11 @@ struct Published {
             return false;
         });
     }
+    bool wait_for_frequency_count(std::size_t n, double timeout_s = 5.0) {
+        std::unique_lock<std::mutex> lock(m);
+        return cv.wait_for(lock, std::chrono::duration<double>(timeout_s),
+                           [&] { return frequencies.size() >= n; });
+    }
 };
 
 // --- backoff ----------------------------------------------------------------
@@ -444,7 +449,18 @@ void test_polling_pauses_while_transmitting() {
     controller.pause_polling();
     controller.set_ptt(true);
     controller.set_ptt(false);
+    const std::size_t polls_before_resume = pub.frequency_count();
     controller.resume_polling();
+
+    // Resuming must actually resume: the worker parks on the session's
+    // condition variable while paused, and a wake predicate that only
+    // looked for a stop or a keying request slept straight through
+    // resume_polling()'s notify -- polling was then dead until the next
+    // over keyed the rig, which on the air read as "the frequency stops
+    // updating after a transmission" (issue #40). The unkey above pushed
+    // the poll deadline one interval out, so this waits across it.
+    check::is_true(pub.wait_for_frequency_count(polls_before_resume + 1),
+                   "rig/pause: polling resumes after the over");
 
     const std::vector<std::string> calls = probe->call_log();
     std::size_t on_idx = calls.size();


### PR DESCRIPTION
## Summary

Fixes a race condition where polling would not resume immediately after `resume_polling()` was called, causing the frequency to stop updating after a transmission until the next over keyed the rig.

## Root Cause

The worker thread's condition variable wait predicate while paused only checked for stop or keying requests, not for the `paused` flag being cleared. When `resume_polling()` cleared the flag and notified the condition variable, the predicate would still evaluate to false, causing the thread to sleep through the notification and remain blocked until external activity (another keying event) woke it.

## Changes

**native/core/rig/controller.cpp:**
- Modified the paused-state wait predicate to also check `!s->paused`, ensuring the thread wakes when polling is resumed
- Added detailed comments explaining why the paused and unpaused waits must use different predicates (to avoid spurious wakeups in the unpaused case)

**native/tests/test_rig.cpp:**
- Added `wait_for_frequency_count()` helper method to `Published` struct for synchronizing on frequency updates
- Enhanced `test_polling_pauses_while_transmitting()` to verify that polling actually resumes after `resume_polling()` is called, catching the regression described in issue #40

## Implementation Details

The fix uses a separate predicate for the paused wait (`[&] { return wake() || !s->paused; }`) rather than folding `!s->paused` into the general `wake` predicate. This is necessary because the unpaused wait uses `wait_until()` with a deadline, and a predicate that checked `!s->paused` would fire immediately on every poll cycle instead of waiting for the deadline, breaking the polling interval.

https://claude.ai/code/session_013Mgm8HcmRgxSTfv6xkdR16