### PR TITLE
Model v5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2202,11 +2202,25 @@ not implemented, but the document format is built for them (see
 
 ONNX runtime path complete: the codec is onnxruntime, torch is
 training-only, and `cli`/`listen` install ~263 MB instead of
-~555 MB. The published codec is **v4** (2026-08-14), and `DEFAULT_FILE`
+~555 MB. The published codec is **v5** (2026-09-01), and `DEFAULT_FILE`
 / `DEFAULT_REVISION` point at it in both implementations: six codec
-artifacts plus `v4-decoder-grad-fp32.onnx` for the optimizer. The app
+artifacts plus `v5-decoder-grad-fp32.onnx` for the optimizer. The app
 fetches what it needs on first run, per part — and a station that never
 optimizes never fetches the gradient graph.
+
+**v5 is v4's lineage fine-tuned through the three-pass overshoot
+clipper** (`dists-0-lf` epoch 568 → epoch 598), i.e. the encoder
+adapting to the transmitter that landed with `CLIP_OVERSHOOT`. Measured
+against its own parent, paired seeds, 16 COCO val images, 30 cells of
+(mode × condition): **+0.096 dB PSNR mean, 30/30 cells positive**, 94%
+of paired images, +0.081 / +0.091 / +0.115 for modes A / B / C. It is
+worth *more the longer the transmission*, and least under `mpd` fading
+(+0.04–0.07), which is the one cell to re-measure before quoting.
+Acquisition is untouched — sync counts identical in all 30 cells.
+**The comparison is confounded and says so**: parent and child differ
+by 30 epochs as well as by the clipper, and no control fine-tuned the
+same 30 epochs through the *old* clipper exists, so this establishes
+"v5 is the better checkpoint to ship" and not the cause.
 
 **v4 is the cc12 lineage fine-tuned through the `PROTOCOL_VERSION` 3
 modem** (epoch 536), and the codec revision and the protocol version are
@@ -2215,13 +2229,22 @@ Measured against v3 through the same channel, mode B: **+0.43 dB AWGN
 and +0.42 dB mpp on photographs, +1.14 / +1.27 on non-photo**, and
 +0.64 / +0.65 on a real certificate. Roughly a quarter of that is the
 pilot and headroom change and three quarters the fine-tune. Bumping the
-revision is a **three-place change** — `sstvae/checkpoint.py`'s
+revision is a **four-place change** — `sstvae/checkpoint.py`'s
 `DEFAULT_FILE`, `native/core/checkpoint/checkpoint.hpp`'s
-`DEFAULT_REVISION`, and **`GRAD_REVISIONS` in both**, which is the one
-that gets missed: omitting the new revision there refuses the
-optimizer's gradient fetch on the current codec and reads as an
-unpublished artifact rather than a stale list. Both suites now assert
-`DEFAULT_REVISION` is in `GRAD_REVISIONS`.
+`DEFAULT_REVISION`, **`GRAD_REVISIONS` in both**, and
+**`native/android-app/CMakeLists.txt`**, which pins the two fp16
+artifacts the APK bundles *by sha256 as well as by name*. This note
+said "three-place" until the v5 bump (2026-09-01) and was wrong: the
+Android bundle post-dates it, and nothing cross-checks the list, so the
+count is only as good as whoever last edited it — grep for the old
+revision string rather than trusting it. `GRAD_REVISIONS` is still the
+one most likely to be *silently* wrong: omitting the new revision there
+refuses the optimizer's gradient fetch on the current codec and reads
+as an unpublished artifact rather than a stale list, and both suites
+assert `DEFAULT_REVISION` is in `GRAD_REVISIONS`. The C++
+`GRAD_REVISIONS` is a fixed-size `std::array`, so *its* size is a
+compile error rather than a silent miss — which is the failure mode the
+others should aspire to.
 
 Remaining: run stage-2 fine-tune (start from a good stage-1
 checkpoint, `--lr 1e-4`) — note pre-beacon checkpoints remain

--- a/native/android-app/CMakeLists.txt
+++ b/native/android-app/CMakeLists.txt
@@ -205,8 +205,8 @@ if(SSTVAE_ANDROID_BUNDLE_MODELS)
     # splits on semicolons, so a list of "a;b" pairs arrives flattened
     # into single items and the hash silently goes missing.
     foreach(_m IN ITEMS
-        "v4-decoder-fp16.onnx|e82404514c822d394c3315c0a4d4ce3df05654e7c90d7e18296f34c52f44a006"
-        "v4-encoder-fp16.onnx|15b0e072f9fe52282f2721209c2846f4d0f0b14474b7a399934bb3448b2a933d")
+        "v5-decoder-fp16.onnx|7ada1b0bac7ad4ff567bee12f0dc9677e91af380d0f47b6263005c40fe2b1808"
+        "v5-encoder-fp16.onnx|8195bb80791b17116204f0c47c510302fafb4697c46529e53371846a80658bcc")
         string(REPLACE "|" ";" _pair "${_m}")
         list(GET _pair 0 _name)
         list(GET _pair 1 _sha)

--- a/native/core/checkpoint/checkpoint.hpp
+++ b/native/core/checkpoint/checkpoint.hpp
@@ -50,7 +50,7 @@ inline constexpr std::string_view DEFAULT_REPO = "arodland/sstvae";
 // The stem of the checkpoint the artifacts were exported from. Bumping
 // it is how a new published codec is adopted, and that must happen in
 // the same change as the code needing it.
-inline constexpr std::string_view DEFAULT_REVISION = "v4";
+inline constexpr std::string_view DEFAULT_REVISION = "v5";
 
 inline constexpr std::array<std::string_view, 3> PRECISIONS = {"fp32", "fp16",
                                                                "int8"};
@@ -80,7 +80,7 @@ inline constexpr std::string_view GRAD_PRECISION = "fp32";
 // DEFAULT_REVISION** -- omitting it disables the optimizer's gradient
 // fetch on the current codec, which looks like a network fault rather
 // than a stale list.
-inline constexpr std::array<std::string_view, 2> GRAD_REVISIONS = {"v3", "v4"};
+inline constexpr std::array<std::string_view, 3> GRAD_REVISIONS = {"v3", "v4", "v5"};
 
 // Everything an operator has to fix: a bad `--model`, a missing
 // artifact, an unreachable Hub. The message is the deliverable here --

--- a/sstvae/checkpoint.py
+++ b/sstvae/checkpoint.py
@@ -19,7 +19,7 @@ cache hit be trusted outright rather than revalidated — see
 from pathlib import Path
 
 DEFAULT_REPO = "arodland/sstvae"
-DEFAULT_FILE = "v4.pt"
+DEFAULT_FILE = "v5.pt"
 
 # The ONNX artifacts exported from DEFAULT_FILE by scripts/export_onnx.py.
 # `DEFAULT_REVISION` is the stem of the checkpoint they came from, so the
@@ -49,7 +49,7 @@ PARTS = ("encoder", "decoder", GRAD_PART)
 # this is not hypothetical bookkeeping -- it is the difference between a
 # clear message and a 404 for anyone pinning an older revision. Add to
 # it when a revision ships the artifact.
-GRAD_REVISIONS = frozenset({"v3", "v4"})
+GRAD_REVISIONS = frozenset({"v3", "v4", "v5"})
 
 # fp16 is the shipped default: measured identical to fp32 end to end
 # (docs/onnx.md) at half the size. int8 is available but costs ~1 dB of


### PR DESCRIPTION
Updates the model from v4 to v5.

v5 is on the same lineage as v4, with two changes:

1. It's been fine-tuned with LPIPS on the full frame instead of feeding LPIPS a random 256x256 crop. The random crop severely under-sampled the corners of the image, and the model learned to encode less detail in the corners, making them soft. The fine-tune solves that issue.
2. It's been fine-tuned through the new three-stage CESSB clipper (PR #52), which gains around an additional 0.1dB of PSNR on top of the gains the clipper provides.

Both of these changes are primarily encoder-side, so a user on v4 and a user on v5 can communicate, the mismatch penalty isn't too steep. But it's still recommended for everyone to upgrade.